### PR TITLE
ENH: Add Python wrapping for the remaining classes

### DIFF
--- a/include/itkMonogenicPhaseAnalysisEigenValuesImageFilter.hxx
+++ b/include/itkMonogenicPhaseAnalysisEigenValuesImageFilter.hxx
@@ -204,7 +204,7 @@ MonogenicPhaseAnalysisEigenValuesImageFilter< TInputImage, TOutputImage >
 }
 
 template< typename TInputImage, typename TOutputImage >
-itk::FixedArray<
+FixedArray<
   typename MonogenicPhaseAnalysisEigenValuesImageFilter<TInputImage, TOutputImage>::OutputImagePixelType,
   MonogenicPhaseAnalysisEigenValuesImageFilter<TInputImage, TOutputImage>::ImageDimension - 1 >
 MonogenicPhaseAnalysisEigenValuesImageFilter< TInputImage, TOutputImage >
@@ -213,7 +213,8 @@ MonogenicPhaseAnalysisEigenValuesImageFilter< TInputImage, TOutputImage >
 {
   // the angles of the polar coordinates of the normed vector:
   // V = (R1*f, ..., Rn*f) / RieszNorm
-  itk::FixedArray< OutputImagePixelType, ImageDimension - 1> out(0);
+  FixedArray< OutputImagePixelType, ImageDimension - 1> out;
+  out.Fill( NumericTraits< OutputImagePixelType >::ZeroValue() );
   OutputImagePixelType rNorm = sqrt(rieszNormSquare);
   OutputImagePixelType r1Unitary = monoPixel[1] / rNorm;
   for(unsigned int i = 0; i < ImageDimension - 1; i++)

--- a/include/itkMonogenicPhaseAnalysisSoftThresholdImageFilter.hxx
+++ b/include/itkMonogenicPhaseAnalysisSoftThresholdImageFilter.hxx
@@ -165,7 +165,7 @@ MonogenicPhaseAnalysisSoftThresholdImageFilter< TInputImage, TOutputImage >
 }
 
 template< typename TInputImage, typename TOutputImage >
-itk::FixedArray<
+FixedArray<
   typename MonogenicPhaseAnalysisSoftThresholdImageFilter<TInputImage, TOutputImage>::OutputImagePixelType,
   MonogenicPhaseAnalysisSoftThresholdImageFilter<TInputImage, TOutputImage>::ImageDimension - 1 >
 MonogenicPhaseAnalysisSoftThresholdImageFilter< TInputImage, TOutputImage >
@@ -174,7 +174,8 @@ MonogenicPhaseAnalysisSoftThresholdImageFilter< TInputImage, TOutputImage >
 {
   // the angles of the polar coordinates of the normed vector:
   // V = (R1*f, ..., Rn*f) / RieszNorm
-  itk::FixedArray< OutputImagePixelType, ImageDimension - 1> out(0);
+  FixedArray< OutputImagePixelType, ImageDimension - 1> out;
+  out.Fill( NumericTraits< OutputImagePixelType >::ZeroValue() );
   OutputImagePixelType rNorm = sqrt(rieszNormSquare);
   OutputImagePixelType r1Unitary = monoPixel[1] / rNorm;
   for(unsigned int i = 0; i < ImageDimension - 1; i++)

--- a/include/itkWaveletFrequencyForward.h
+++ b/include/itkWaveletFrequencyForward.h
@@ -93,7 +93,7 @@ public:
    * If the size on any dimension is not a power of 2, the max level will be 1.
    * If the sizes are different, but all of them are power of 2, the max level will be the minimum $J_i$.
    */
-  unsigned int ComputeMaxNumberOfLevels(typename InputImageType::SizeType& input_size);
+  static unsigned int ComputeMaxNumberOfLevels(typename InputImageType::SizeType& input_size);
 
   typedef std::pair<unsigned int, unsigned int> IndexPairType;
   /** Get the (Level,Band) from a linear index output */

--- a/include/itkWaveletFrequencyInverse.h
+++ b/include/itkWaveletFrequencyInverse.h
@@ -82,7 +82,7 @@ public:
    * If the size on any dimension is not a power of 2, the max level will be 1.
    * If the sizes are different, but all of them are power of 2, the max level will be the minimum $J_i$.
    */
-  unsigned int ComputeMaxNumberOfLevels(typename InputImageType::SizeType& input_size);
+  static unsigned int ComputeMaxNumberOfLevels(typename InputImageType::SizeType& input_size);
 
   typedef std::pair<unsigned int, unsigned int> IndexPairType;
   /** Get the (Level,Band) from a linear index input */

--- a/include/itkWaveletFrequencyInverse.hxx
+++ b/include/itkWaveletFrequencyInverse.hxx
@@ -386,5 +386,34 @@ void WaveletFrequencyInverse< TInputImage, TOutputImage, TWaveletFilterBank>
     }
 }
 
+template <typename TInputImage, typename TOutputImage, typename TWaveletFilterBank>
+unsigned int WaveletFrequencyInverse<TInputImage, TOutputImage, TWaveletFilterBank>
+::ComputeMaxNumberOfLevels(typename InputImageType::SizeType& input_size)
+{
+  FixedArray<unsigned int, ImageDimension> exponent_per_axis;
+  for (unsigned int axis = 0; axis < ImageDimension; ++axis)
+    {
+    size_t size_axis = input_size[axis];
+    if (size_axis < 2)
+      {
+      exponent_per_axis[axis] = 1;
+      continue;
+      }
+    double exponent = std::log(size_axis) / std::log(2.0);
+    // check that exponent is integer: the fractional part is 0
+    double int_part;
+    if (std::modf(exponent, &int_part ) == 0 )
+      {
+      exponent_per_axis[axis] = static_cast<unsigned int>(exponent);
+      }
+    else
+      {
+      exponent_per_axis[axis] = 1;
+      }
+    }
+  // return the min_element of array (1 if any size is not power of 2)
+  return *std::min_element(exponent_per_axis.Begin(), exponent_per_axis.End());
+}
+
 } // end namespace itk
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -286,3 +286,27 @@ itk_python_expression_add_test(NAME itkIsotropicWaveletFrequencyFunctionPythonTe
   EXPRESSION "instance = itk.IsotropicWaveletFrequencyFunction.New()")
 itk_python_expression_add_test(NAME itkHeldIsotropicWaveletPythonTest
   EXPRESSION "instance = itk.HeldIsotropicWavelet.New()")
+itk_python_expression_add_test(NAME itkMonogenicSignalFrequencyImageFilterPythonTest
+  EXPRESSION "instance = itk.MonogenicSignalFrequencyImageFilter.New()")
+itk_python_expression_add_test(NAME itkVectorInverseFFTImageFilterPythonTest
+  EXPRESSION "instance = itk.VectorInverseFFTImageFilter.New()")
+itk_python_expression_add_test(NAME itkMonogenicPhaseAnalysisEigenValuesImageFilterPythonTest
+  EXPRESSION "instance = itk.MonogenicPhaseAnalysisEigenValuesImageFilter.New()")
+itk_python_expression_add_test(NAME itkMonogenicPhaseAnalysisSoftThresholdImageFilterPythonTest
+  EXPRESSION "instance = itk.MonogenicPhaseAnalysisSoftThresholdImageFilter.New()")
+itk_python_expression_add_test(NAME itkRieszFrequencyFilterBankGeneratorPythonTest
+  EXPRESSION "instance = itk.RieszFrequencyFilterBankGenerator.New()")
+itk_python_expression_add_test(NAME itkShannonIsotropicWaveletPythonTest
+  EXPRESSION "instance = itk.ShannonIsotropicWavelet.New()")
+itk_python_expression_add_test(NAME itkSimoncelliIsotropicWaveletPythonTest
+  EXPRESSION "instance = itk.SimoncelliIsotropicWavelet.New()")
+itk_python_expression_add_test(NAME itkVowIsotropicWaveletPythonTest
+  EXPRESSION "instance = itk.VowIsotropicWavelet.New()")
+itk_python_expression_add_test(NAME itkWaveletFrequencyFilterBankGeneratorPythonTest
+  EXPRESSION "instance = itk.WaveletFrequencyFilterBankGenerator.New()")
+itk_python_expression_add_test(NAME itkWaveletFrequencyForwardPythonTest
+  EXPRESSION "instance = itk.WaveletFrequencyForward.New()")
+itk_python_expression_add_test(NAME itkWaveletFrequencyInversePythonTest
+  EXPRESSION "instance = itk.WaveletFrequencyInverse.New()")
+itk_python_expression_add_test(NAME itkZeroDCImageFilterPythonTest
+  EXPRESSION "instance = itk.ZeroDCImageFilter.New()")

--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,3 +1,7 @@
 itk_wrap_module(IsotropicWavelets)
+set(WRAPPER_SUBMODULE_ORDER
+  itkMonogenicSignalFrequencyImageFilter
+  itkVectorInverseFFTImageFilter
+  )
 itk_auto_load_submodules()
 itk_end_wrap_module()

--- a/wrapping/itkMonogenicPhaseAnalysisEigenValuesImageFilter.wrap
+++ b/wrapping/itkMonogenicPhaseAnalysisEigenValuesImageFilter.wrap
@@ -1,0 +1,9 @@
+itk_wrap_class("itk::MonogenicPhaseAnalysisEigenValuesImageFilter" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_REAL})
+      itk_wrap_template("${ITKM_VI${t}${d}}${ITKM_I${t}${d}}"
+        "${ITKT_VI${t}${d}}, ${ITKT_I${t}${d}}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()
+

--- a/wrapping/itkMonogenicPhaseAnalysisSoftThresholdImageFilter.wrap
+++ b/wrapping/itkMonogenicPhaseAnalysisSoftThresholdImageFilter.wrap
@@ -1,0 +1,9 @@
+itk_wrap_class("itk::MonogenicPhaseAnalysisSoftThresholdImageFilter" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_REAL})
+      itk_wrap_template("${ITKM_VI${t}${d}}${ITKM_I${t}${d}}"
+        "${ITKT_VI${t}${d}}, ${ITKT_I${t}${d}}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()
+

--- a/wrapping/itkMonogenicSignalFrequencyImageFilter.wrap
+++ b/wrapping/itkMonogenicSignalFrequencyImageFilter.wrap
@@ -1,0 +1,25 @@
+itk_wrap_class("itk::ImageSource" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_COMPLEX_REAL})
+      itk_wrap_template("${ITKM_VI${t}${d}}"
+        "${ITKT_VI${t}${d}}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()
+
+itk_wrap_class("itk::ImageToImageFilter" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_COMPLEX_REAL})
+      itk_wrap_template("${ITKM_I${t}${d}}${ITKM_VI${t}${d}}"
+        "${ITKT_I${t}${d}}, ${ITKT_VI${t}${d}}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()
+
+itk_wrap_class("itk::MonogenicSignalFrequencyImageFilter" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_COMPLEX_REAL})
+      itk_wrap_template("${ITKM_I${t}${d}}" "${ITKT_I${t}${d}}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()

--- a/wrapping/itkRieszFrequencyFilterBankGenerator.wrap
+++ b/wrapping/itkRieszFrequencyFilterBankGenerator.wrap
@@ -1,0 +1,8 @@
+itk_wrap_class("itk::RieszFrequencyFilterBankGenerator" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_REAL})
+      itk_wrap_template("${ITKM_I${t}${d}}" "${ITKT_I${t}${d}}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()
+

--- a/wrapping/itkShannonIsotropicWavelet.wrap
+++ b/wrapping/itkShannonIsotropicWavelet.wrap
@@ -1,0 +1,8 @@
+itk_wrap_class("itk::ShannonIsotropicWavelet" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_REAL})
+      itk_wrap_template("${ITKM_${t}}${d}${ITKM_PD${d}}" "${ITKT_${t}}, ${d}, ${ITKT_PD${d}}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()
+

--- a/wrapping/itkSimoncelliIsotropicWavelet.wrap
+++ b/wrapping/itkSimoncelliIsotropicWavelet.wrap
@@ -1,0 +1,8 @@
+itk_wrap_class("itk::SimoncelliIsotropicWavelet" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_REAL})
+      itk_wrap_template("${ITKM_${t}}${d}${ITKM_PD${d}}" "${ITKT_${t}}, ${d}, ${ITKT_PD${d}}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()
+

--- a/wrapping/itkVectorInverseFFTImageFilter.wrap
+++ b/wrapping/itkVectorInverseFFTImageFilter.wrap
@@ -1,0 +1,18 @@
+itk_wrap_class("itk::ImageToImageFilter" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_COMPLEX_REAL})
+      itk_wrap_template("${ITKM_VI${t}${d}}${ITKM_I${t}${d}}"
+        "${ITKT_VI${t}${d}}, ${ITKT_I${t}${d}}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()
+
+itk_wrap_class("itk::VectorInverseFFTImageFilter" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_COMPLEX_REAL})
+      itk_wrap_template("${ITKM_VI${t}${d}}${ITKM_I${t}${d}}"
+        "${ITKT_VI${t}${d}}, ${ITKT_I${t}${d}}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()
+

--- a/wrapping/itkVowIsotropicWavelet.wrap
+++ b/wrapping/itkVowIsotropicWavelet.wrap
@@ -1,0 +1,8 @@
+itk_wrap_class("itk::VowIsotropicWavelet" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_REAL})
+      itk_wrap_template("${ITKM_${t}}${d}${ITKM_PD${d}}" "${ITKT_${t}}, ${d}, ${ITKT_PD${d}}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()
+

--- a/wrapping/itkWaveletFrequencyFilterBankGenerator.wrap
+++ b/wrapping/itkWaveletFrequencyFilterBankGenerator.wrap
@@ -1,0 +1,20 @@
+itk_wrap_include("itkHeldIsotropicWavelet.h")
+itk_wrap_include("itkVowIsotropicWavelet.h")
+itk_wrap_include("itkSimoncelliIsotropicWavelet.h")
+itk_wrap_include("itkShannonIsotropicWavelet.h")
+itk_wrap_class("itk::WaveletFrequencyFilterBankGenerator" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(tc ${WRAP_ITK_COMPLEX_REAL})
+      foreach(tr ${WRAP_ITK_REAL})
+        itk_wrap_template("${ITKM_I${tc}${d}}Vow${ITKM_${tr}}${d}${ITKM_PD${d}}"
+          "${ITKT_I${tc}${d}}, itk::VowIsotropicWavelet< ${ITKT_${tr}}, ${d}, ${ITKT_PD${d}} >")
+        itk_wrap_template("${ITKM_I${tc}${d}}Held${ITKM_${tr}}${d}${ITKM_PD${d}}"
+          "${ITKT_I${tc}${d}}, itk::HeldIsotropicWavelet< ${ITKT_${tr}}, ${d}, ${ITKT_PD${d}} >")
+        itk_wrap_template("${ITKM_I${tc}${d}}Simoncelli${ITKM_${tr}}${d}${ITKM_PD${d}}"
+          "${ITKT_I${tc}${d}}, itk::SimoncelliIsotropicWavelet< ${ITKT_${tr}}, ${d}, ${ITKT_PD${d}} >")
+        itk_wrap_template("${ITKM_I${tc}${d}}Shannon${ITKM_${tr}}${d}${ITKM_PD${d}}"
+          "${ITKT_I${tc}${d}}, itk::ShannonIsotropicWavelet< ${ITKT_${tr}}, ${d}, ${ITKT_PD${d}} >")
+      endforeach()
+    endforeach()
+  endforeach()
+itk_end_wrap_class()

--- a/wrapping/itkWaveletFrequencyForward.wrap
+++ b/wrapping/itkWaveletFrequencyForward.wrap
@@ -1,0 +1,22 @@
+
+itk_wrap_include("itkHeldIsotropicWavelet.h")
+itk_wrap_include("itkVowIsotropicWavelet.h")
+itk_wrap_include("itkSimoncelliIsotropicWavelet.h")
+itk_wrap_include("itkShannonIsotropicWavelet.h")
+itk_wrap_include("itkWaveletFrequencyFilterBankGenerator.h")
+itk_wrap_class("itk::WaveletFrequencyForward" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(tc ${WRAP_ITK_COMPLEX_REAL})
+      foreach(tr ${WRAP_ITK_REAL})
+        itk_wrap_template("${ITKM_I${tc}${d}}${ITKM_I${tc}${d}}Vow${ITKM_${tr}}${d}${ITKM_PD${d}}"
+          "${ITKT_I${tc}${d}}, ${ITKT_I${tc}${d}}, itk::WaveletFrequencyFilterBankGenerator< ${ITKT_I${tc}${d}}, itk::VowIsotropicWavelet< ${ITKT_${tr}}, ${d}, ${ITKT_PD${d}} > >")
+        itk_wrap_template("${ITKM_I${tc}${d}}${ITKM_I${tc}${d}}Held${ITKM_${tr}}${d}${ITKM_PD${d}}"
+          "${ITKT_I${tc}${d}}, ${ITKT_I${tc}${d}}, itk::WaveletFrequencyFilterBankGenerator< ${ITKT_I${tc}${d}}, itk::HeldIsotropicWavelet< ${ITKT_${tr}}, ${d}, ${ITKT_PD${d}} > >")
+        itk_wrap_template("${ITKM_I${tc}${d}}${ITKM_I${tc}${d}}Simoncelli${ITKM_${tr}}${d}${ITKM_PD${d}}"
+          "${ITKT_I${tc}${d}}, ${ITKT_I${tc}${d}}, itk::WaveletFrequencyFilterBankGenerator< ${ITKT_I${tc}${d}}, itk::SimoncelliIsotropicWavelet< ${ITKT_${tr}}, ${d}, ${ITKT_PD${d}} > >")
+        itk_wrap_template("${ITKM_I${tc}${d}}${ITKM_I${tc}${d}}Shannon${ITKM_${tr}}${d}${ITKM_PD${d}}"
+          "${ITKT_I${tc}${d}}, ${ITKT_I${tc}${d}}, itk::WaveletFrequencyFilterBankGenerator< ${ITKT_I${tc}${d}}, itk::ShannonIsotropicWavelet< ${ITKT_${tr}}, ${d}, ${ITKT_PD${d}} > >")
+      endforeach()
+    endforeach()
+  endforeach()
+itk_end_wrap_class()

--- a/wrapping/itkWaveletFrequencyInverse.wrap
+++ b/wrapping/itkWaveletFrequencyInverse.wrap
@@ -1,0 +1,22 @@
+
+itk_wrap_include("itkHeldIsotropicWavelet.h")
+itk_wrap_include("itkVowIsotropicWavelet.h")
+itk_wrap_include("itkSimoncelliIsotropicWavelet.h")
+itk_wrap_include("itkShannonIsotropicWavelet.h")
+itk_wrap_include("itkWaveletFrequencyFilterBankGenerator.h")
+itk_wrap_class("itk::WaveletFrequencyInverse" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(tc ${WRAP_ITK_COMPLEX_REAL})
+      foreach(tr ${WRAP_ITK_REAL})
+        itk_wrap_template("${ITKM_I${tc}${d}}${ITKM_I${tc}${d}}Vow${ITKM_${tr}}${d}${ITKM_PD${d}}"
+          "${ITKT_I${tc}${d}}, ${ITKT_I${tc}${d}}, itk::WaveletFrequencyFilterBankGenerator< ${ITKT_I${tc}${d}}, itk::VowIsotropicWavelet< ${ITKT_${tr}}, ${d}, ${ITKT_PD${d}} > >")
+        itk_wrap_template("${ITKM_I${tc}${d}}${ITKM_I${tc}${d}}Held${ITKM_${tr}}${d}${ITKM_PD${d}}"
+          "${ITKT_I${tc}${d}}, ${ITKT_I${tc}${d}}, itk::WaveletFrequencyFilterBankGenerator< ${ITKT_I${tc}${d}}, itk::HeldIsotropicWavelet< ${ITKT_${tr}}, ${d}, ${ITKT_PD${d}} > >")
+        itk_wrap_template("${ITKM_I${tc}${d}}${ITKM_I${tc}${d}}Simoncelli${ITKM_${tr}}${d}${ITKM_PD${d}}"
+          "${ITKT_I${tc}${d}}, ${ITKT_I${tc}${d}}, itk::WaveletFrequencyFilterBankGenerator< ${ITKT_I${tc}${d}}, itk::SimoncelliIsotropicWavelet< ${ITKT_${tr}}, ${d}, ${ITKT_PD${d}} > >")
+        itk_wrap_template("${ITKM_I${tc}${d}}${ITKM_I${tc}${d}}Shannon${ITKM_${tr}}${d}${ITKM_PD${d}}"
+          "${ITKT_I${tc}${d}}, ${ITKT_I${tc}${d}}, itk::WaveletFrequencyFilterBankGenerator< ${ITKT_I${tc}${d}}, itk::ShannonIsotropicWavelet< ${ITKT_${tr}}, ${d}, ${ITKT_PD${d}} > >")
+      endforeach()
+    endforeach()
+  endforeach()
+itk_end_wrap_class()

--- a/wrapping/itkZeroDCImageFilter.wrap
+++ b/wrapping/itkZeroDCImageFilter.wrap
@@ -1,0 +1,7 @@
+itk_wrap_class("itk::ZeroDCImageFilter" POINTER)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(t ${WRAP_ITK_SCALAR})
+      itk_wrap_template("${ITKM_I${t}${d}}" "${ITKT_I${t}${d}}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
As documented here:

  https://itk.org/ITKSoftwareGuide/html/Book1/ITKSoftwareGuide-Book1ch9.html#x50-1500009.5

Addresses build error:

In file included from /home/matt/src/ITKIsotropicWavelets/include/itkMonogenicPhaseAnalysisEigenValuesImageFilter.h:164:
/home/matt/src/ITKIsotropicWavelets/include/itkMonogenicPhaseAnalysisEigenValuesImageFilter.hxx:216:62: error: call to constructor of 'itk::FixedArray<OutputImagePixelType, ImageDimension - 1>' (aka 'FixedArray<float, ImageDimension - 1>') is ambiguous
  itk::FixedArray< OutputImagePixelType, ImageDimension - 1> out(0);
                                                             ^   ~
/home/matt/bin/ITKIsotropicWavelets-Clang-MinSizeRel/Wrapping/Modules/IsotropicWavelets/itkMonogenicPhaseAnalysisEigenValuesImageFilterPython.cpp:6477:85: note: in instantiation of member function 'itk::MonogenicPhaseAnalysisEigenValuesImageFilter<itk::VectorImage<float, 3>, itk::Image<float, 3> >::ComputePhaseOrientation' requested here
      result = ((itkMonogenicPhaseAnalysisEigenValuesImageFilterVIF3 const *)arg1)->ComputePhaseOrientation((itkVariableLengthVectorF const &)*arg2,(float const &)*arg3);

Add missing implementation of
WaveletFrequencyInverse::ComputeMaxNumberOfLevels (copied from
WaveletFrequencyForward). Method may be removed from WaveletFrequencyInverse
(?).
                                                                                    ^