### PR TITLE
ENH: Improve the coverage for the module.

### DIFF
--- a/test/itkExpandWithZerosImageFilterTest.cxx
+++ b/test/itkExpandWithZerosImageFilterTest.cxx
@@ -16,29 +16,32 @@
  *
  *=========================================================================*/
 
-#include <iostream>
 #include "itkExpandWithZerosImageFilter.h"
 #include "itkCastImageFilter.h"
 #include "itkMath.h"
+#include "itkTestingMacros.h"
+
+#include <iostream>
+
 #ifdef ITK_VISUALIZE_TESTS
 #include "itkViewImage.h"
 #endif
 
-template<unsigned int N>
+
+template< unsigned int VDimension >
 int runExpandWithZerosImageFilterTest()
 {
-  typedef float                    PixelType;
-  typedef itk::Image<PixelType, N> ImageType;
+  typedef float                               PixelType;
+  typedef itk::Image< PixelType, VDimension > ImageType;
   bool testPassed = true;
 
-  // =============================================================
 
-  std::cout << "Create the input image fill with ones." << std::endl;
+  // Create the input image
   typename ImageType::RegionType region;
   typename ImageType::SizeType   size;
-  size.Fill(32);
+  size.Fill( 32 );
   typename ImageType::IndexType inputIndex;
-  inputIndex.Fill(9);
+  inputIndex.Fill( 9 );
   region.SetSize( size );
   region.SetIndex( inputIndex );
   region.SetSize( size );
@@ -47,48 +50,46 @@ int runExpandWithZerosImageFilterTest()
   input->SetLargestPossibleRegion( region );
   input->SetBufferedRegion( region );
   input->Allocate();
-  input->FillBuffer(1);
-
-  // =============================================================
-
-  typedef itk::ExpandWithZerosImageFilter<ImageType, ImageType> ExpanderType;
+  input->FillBuffer( 1 );
+  
+  typedef itk::ExpandWithZerosImageFilter< ImageType, ImageType > ExpanderType;
   typename ExpanderType::Pointer expander = ExpanderType::New();
 
-  unsigned int factors[N];
-  for (unsigned int i = 0; i < N; i++)
-    {
-    factors[i] = 3;
-    }
+  unsigned int expandFactor = 3;
+  ExpanderType::ExpandFactorsType expandFactors;
+  expandFactors.Fill( expandFactor );
+
+  expander->SetExpandFactors( expandFactors );
+  TEST_SET_GET_VALUE( expandFactors, expander->GetExpandFactors() );
 
   expander->SetInput( input );
-  expander->SetExpandFactors( factors );
-  expander->Print( std::cout );
+
   expander->Update();
 
-  // =============================================================
 
-  std::cout << "Checking the output against expected." << std::endl;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType> Iterator;
+  // Check the output against expected value
+  typedef itk::ImageRegionIteratorWithIndex< ImageType > Iterator;
   Iterator outIter( expander->GetOutput(),
                     expander->GetOutput()->GetBufferedRegion() );
-  typename ImageType::IndexType outStartIndex = expander->GetOutput()->GetLargestPossibleRegion().GetIndex();
+  typename ImageType::IndexType outStartIndex =
+    expander->GetOutput()->GetLargestPossibleRegion().GetIndex();
 
   while( !outIter.IsAtEnd() )
     {
     typename ImageType::IndexType index = outIter.GetIndex();
     double value = outIter.Get();
 
-    bool indexIsMultipleOfFactor(true);
-    for (unsigned int i = 0; i < N; ++i)
+    bool indexIsMultipleOfFactor = true;
+    for( unsigned int i = 0; i < VDimension; ++i )
       {
-      if((index[i] - outStartIndex[i]) % expander->GetExpandFactors()[i] != 0)
+      if( (index[i] - outStartIndex[i]) % expander->GetExpandFactors()[i] != 0 )
         {
         indexIsMultipleOfFactor = false;
         break;
         }
       }
     double trueValue = -1;
-    if(indexIsMultipleOfFactor)
+    if( indexIsMultipleOfFactor )
       {
       trueValue = 1;
       }
@@ -97,30 +98,33 @@ int runExpandWithZerosImageFilterTest()
       trueValue = 0;
       }
 
-    if( itk::Math::abs( trueValue - value ) > 1e-4 )
+    double tolerance = 1e-4;
+    if( !itk::Math::FloatAlmostEqual( trueValue, value, 10, tolerance) )
       {
       testPassed = false;
-      std::cout << "Error at Index: " << index << " ";
-      std::cout << "Expected: " << trueValue << " ";
-      std::cout << "Actual: " << value << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Error at Index: " << index << " ";
+      std::cerr << "Expected value: " << trueValue << " ";
+      std::cerr << ", but got: " << value << std::endl;
       }
     ++outIter;
     }
 
-  if ( !testPassed )
+  if( !testPassed )
     {
-    std::cout << "Test failed." << std::endl;
+    std::cerr << "Test failed!" << std::endl;
     return EXIT_FAILURE;
     }
 
 #ifdef ITK_VISUALIZE_TESTS
-  itk::Testing::ViewImage(expander->GetOutput(),  "ExpandWithZeros Output" );
+  itk::Testing::ViewImage( expander->GetOutput(), "ExpandWithZeros Output" );
 #endif
+
   std::cout << "Test passed." << std::endl;
   return EXIT_SUCCESS;
 }
 
-int itkExpandWithZerosImageFilterTest(int argc, char *argv[])
+int itkExpandWithZerosImageFilterTest( int argc, char *argv[] )
 {
   if( argc > 2 )
     {
@@ -128,6 +132,19 @@ int itkExpandWithZerosImageFilterTest(int argc, char *argv[])
               << "[dimension]" << std::endl;
     return EXIT_FAILURE;
     }
+
+  const unsigned int ImageDimension = 2;
+  typedef double                                  PixelType;
+  typedef itk::Image< PixelType, ImageDimension > ImageType;
+
+  // Exercise basic object methods
+  // Done outside the helper function in the test because GCC is limited
+  // when calling overloaded base class functions.
+  typedef itk::ExpandWithZerosImageFilter< ImageType, ImageType > ExpanderType;
+  ExpanderType::Pointer expander = ExpanderType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( expander, ExpandWithZerosImageFilter,
+    ImageToImageFilter );
+
 
   unsigned int dimension = 3;
   if( argc == 2 )
@@ -137,14 +154,15 @@ int itkExpandWithZerosImageFilterTest(int argc, char *argv[])
 
   if( dimension == 2 )
     {
-    return runExpandWithZerosImageFilterTest<2>();
+    return runExpandWithZerosImageFilterTest< 2 >();
     }
   else if( dimension == 3 )
     {
-    return runExpandWithZerosImageFilterTest<3>();
+    return runExpandWithZerosImageFilterTest< 3 >();
     }
   else
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error: only 2 or 3 dimensions allowed, " << dimension << " selected." << std::endl;
     return EXIT_FAILURE;
     }

--- a/test/itkFFTPadPositiveIndexImageFilterTest.cxx
+++ b/test/itkFFTPadPositiveIndexImageFilterTest.cxx
@@ -22,13 +22,14 @@
 #include "itkZeroFluxNeumannBoundaryCondition.h"
 #include "itkPeriodicBoundaryCondition.h"
 #include "itkConstantBoundaryCondition.h"
+#include "itkTestingMacros.h"
 
 int itkFFTPadPositiveIndexImageFilterTest( int argc, char * argv[] )
 {
   if( argc < 3 )
     {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << "  inputImageFile outputImageFile" << std::endl;
+    std::cerr << argv[0] << " inputImageFile outputImageFile" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -36,7 +37,7 @@ int itkFFTPadPositiveIndexImageFilterTest( int argc, char * argv[] )
   typedef unsigned char                       PixelType;
   typedef itk::Image< PixelType,  Dimension > ImageType;
 
-  // readers/writers
+  // Readers, writers and filter typdefs
   typedef itk::ImageFileReader< ImageType  >               ReaderType;
   typedef itk::ImageFileWriter< ImageType >                WriterType;
   typedef itk::FFTPadPositiveIndexImageFilter< ImageType > FFTPadType;
@@ -48,26 +49,46 @@ int itkFFTPadPositiveIndexImageFilterTest( int argc, char * argv[] )
   itk::ConstantBoundaryCondition< ImageType > zeroCond;
   itk::PeriodicBoundaryCondition< ImageType > wrapCond;
 
-  // Create the filters
+  // Create the filter
   FFTPadType::Pointer fftpad = FFTPadType::New();
-  fftpad->SetInput(  reader->GetOutput() );
 
-  fftpad->Update();
+  EXERCISE_BASIC_OBJECT_METHODS( fftpad, FFTPadPositiveIndexImageFilter,
+    ImageToImageFilter );
+
+
+  /*itk::SizeValueType sizeGreatestPrimeFactor;
+  fftpad->SetSizeGreatestPrimeFactor( sizeGreatestPrimeFactor );
+  TEST_SET_GET_VALUE( sizeGreatestPrimeFactor, fftpad->GetSizeGreatestPrimeFactor() );*/
+
+
+  /*FFTPadType::BoundaryConditionPointerType boundaryCondition;
+  fftpad->SetBoundaryCondition( boundaryCondition );
+  TEST_SET_GET_VALUE( boundaryCondition, fftpad->GetBoundaryCondition() );*/
+
+  fftpad->SetInput( reader->GetOutput() );
+
+
+  TRY_EXPECT_NO_EXCEPTION( fftpad->Update() );
+
+
   ImageType::IndexType outIndex = fftpad->GetOutput()->GetLargestPossibleRegion().GetIndex();
   ImageType::SizeType  outSize  = fftpad->GetOutput()->GetLargestPossibleRegion().GetSize();
   std::cout << "Index: " << outIndex << " Size: " << outSize << std::endl;
-  for (unsigned int i = 0; i < Dimension; ++i)
+  for( unsigned int i = 0; i < Dimension; ++i )
     {
-    if(outIndex[i] < 0)
+    if( outIndex[i] < 0 )
       {
-      std::cerr << "Negative index " << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Negative index found." << std::endl;
       return EXIT_FAILURE;
       }
     }
+
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput(fftpad->GetOutput());
-  writer->SetFileName(  argv[2] );
-  writer->Update();
+  writer->SetInput( fftpad->GetOutput() );
+  writer->SetFileName( argv[2] );
+
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
   return EXIT_SUCCESS;
 }

--- a/test/itkFrequencyExpandAndShrinkTest.cxx
+++ b/test/itkFrequencyExpandAndShrinkTest.cxx
@@ -15,61 +15,68 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include <memory>
-#include <string>
-#include <cmath>
-#include <iomanip>
+
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkForwardFFTImageFilter.h"
 #include "itkInverseFFTImageFilter.h"
-#include <itkComplexToRealImageFilter.h>
-#include <itkComplexToImaginaryImageFilter.h>
-#include <itkFrequencyShrinkImageFilter.h>
-#include <itkFrequencyExpandImageFilter.h>
-#include <itkFrequencyShrinkViaInverseFFTImageFilter.h>
-#include <itkFrequencyExpandViaInverseFFTImageFilter.h>
-#include <itkZeroDCImageFilter.h>
-#include <itkComplexToComplexFFTImageFilter.h>
-#include <itkImageRegionConstIterator.h>
-#include <itkImageRegionConstIteratorWithIndex.h>
-#include <itkCastImageFilter.h>
-#include <itkNumberToString.h>
+#include "itkComplexToRealImageFilter.h"
+#include "itkComplexToImaginaryImageFilter.h"
+#include "itkFrequencyShrinkImageFilter.h"
+#include "itkFrequencyExpandImageFilter.h"
+#include "itkFrequencyShrinkViaInverseFFTImageFilter.h"
+#include "itkFrequencyExpandViaInverseFFTImageFilter.h"
+#include "itkZeroDCImageFilter.h"
+#include "itkComplexToComplexFFTImageFilter.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkImageRegionConstIteratorWithIndex.h"
+#include "itkCastImageFilter.h"
+#include "itkNumberToString.h"
 #include "itkIsotropicWaveletTestUtilities.h"
-using namespace std;
-using namespace itk;
+#include "itkTestingMacros.h"
 
-// Visualize for dev/debug purposes. Set in cmake file. Require VTK
+#include <memory>
+#include <string>
+#include <cmath>
+#include <iomanip>
+
+// Visualize for dev/debug purposes. Set in cmake file. Requires VTK
 #ifdef ITK_VISUALIZE_TESTS
 #include "itkViewImage.h"
 #endif
 
-template<unsigned int N>
-int runFrequencyExpandAndShrinkTest(const std::string & inputImage, const std::string & outputImage)
+
+template< unsigned int VDimension >
+int runFrequencyExpandAndShrinkTest( const std::string & inputImage, const std::string & outputImage )
 {
-  const unsigned int dimension = N;
+  const unsigned int Dimension = VDimension;
 
-  typedef double                           PixelType;
-  typedef itk::Image<PixelType, dimension> ImageType;
-  typedef itk::ImageFileReader<ImageType>  ReaderType;
+  typedef double                              PixelType;
+  typedef itk::Image< PixelType, Dimension >  ImageType;
+  typedef itk::ImageFileReader< ImageType >   ReaderType;
+
   typename ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(inputImage);
-  reader->Update();
-  reader->UpdateLargestPossibleRegion();
+  reader->SetFileName( inputImage );
 
-  /***** Calculate mean value and substract: zeroDCFilter ****/
-  typedef itk::ZeroDCImageFilter<ImageType> ZeroDCFilterType;
+  reader->Update();
+
+  // Calculate mean value and subtract
+  typedef itk::ZeroDCImageFilter< ImageType > ZeroDCFilterType;
   typename ZeroDCFilterType::Pointer zeroDCFilter = ZeroDCFilterType::New();
-  zeroDCFilter->SetInput(reader->GetOutput());
+
+  zeroDCFilter->SetInput( reader->GetOutput() );
+
   zeroDCFilter->Update();
-  /**********************************************/
 
   // Perform FFT on input image.
-  typedef itk::ForwardFFTImageFilter<ImageType> FFTFilterType;
+  typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
   typename FFTFilterType::Pointer fftFilter = FFTFilterType::New();
+
   fftFilter->SetInput(zeroDCFilter->GetOutput());
+
   fftFilter->Update();
+
   typedef typename FFTFilterType::OutputImageType                 ComplexImageType;
   typedef itk::InverseFFTImageFilter<ComplexImageType, ImageType> InverseFFTFilterType;
   /*********** EXPAND ***************/
@@ -116,61 +123,88 @@ int runFrequencyExpandAndShrinkTest(const std::string & inputImage, const std::s
   inverseFFT1->Update();
   typename InverseFFTFilterType::Pointer inverseFFT2 = InverseFFTFilterType::New();
   inverseFFT2->SetInput(shrinkViaInverseFFTFilter->GetOutput());
+
   inverseFFT2->Update();
+
 #ifdef ITK_VISUALIZE_TESTS
-  itk::Testing::ViewImage(inverseFFT1->GetOutput(), "ExpandAndShrink via frequency manipulation");
-  itk::Testing::ViewImage(inverseFFT2->GetOutput(), "ExpandAndShrink ViaInverseFFT");
+  itk::Testing::ViewImage( inverseFFT1->GetOutput(), "ExpandAndShrink via frequency manipulation" );
+  itk::Testing::ViewImage( inverseFFT2->GetOutput(), "ExpandAndShrink ViaInverseFFT" );
 #endif
 
-  // Write last output for comparisson
-  typedef itk::Image<float, dimension>                      FloatImageType;
+  // Write output
+  typedef itk::Image< float, Dimension > FloatImageType;
   typedef itk::CastImageFilter< ImageType, FloatImageType > CastType;
   typename CastType::Pointer castFilter = CastType::New();
-  castFilter->SetInput(inverseFFT2->GetOutput());
+  castFilter->SetInput( inverseFFT2->GetOutput() );
 
   typedef itk::ImageFileWriter< FloatImageType > WriterType;
   typename WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( outputImage );
   writer->SetInput( castFilter->GetOutput() );
 
-  try
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
-    std::cerr << "Error writing the FrequencyShrink image: " << std::endl;
-    std::cerr << error << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+
 
 #ifdef ITK_VISUALIZE_TESTS
-  Testing::ViewImage(zeroDCFilter->GetOutput(), "Original");
+  Testing::ViewImage( zeroDCFilter->GetOutput(), "Original" );
 #endif
 
   return EXIT_SUCCESS;
 }
 
-int itkFrequencyExpandAndShrinkTest(int argc, char* argv[])
+int itkFrequencyExpandAndShrinkTest( int argc, char* argv[] )
 {
   if( argc < 3 || argc > 4 )
     {
     std::cerr << "Usage: " << argv[0] << " inputImage outputImage [dimension]" << std::endl;
     return EXIT_FAILURE;
     }
-  const string inputImage  = argv[1];
-  const string outputImage = argv[2];
+  const std::string inputImage  = argv[1];
+  const std::string outputImage = argv[2];
+
+  const unsigned int ImageDimension = 3;
+  typedef double                                  PixelType;
+  typedef itk::Image< PixelType, ImageDimension > ImageType;
+  typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
+  typedef FFTFilterType::OutputImageType          ComplexImageType;
+
+  // Exercise basic object methods
+  // Done outside the helper function in the test because GCC is limited
+  // when calling overloaded base class functions.
+  typedef itk::FrequencyExpandViaInverseFFTImageFilter< ComplexImageType >
+    ExpandViaInverseFFTType;
+  ExpandViaInverseFFTType::Pointer expandViaInverseFFTFilter =
+    ExpandViaInverseFFTType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( expandViaInverseFFTFilter,
+    FrequencyExpandViaInverseFFTImageFilter, ImageToImageFilter );
+
+  typedef itk::FrequencyShrinkViaInverseFFTImageFilter< ComplexImageType >
+    ShrinkViaInverseFFTType;
+  ShrinkViaInverseFFTType::Pointer shrinkViaInverseFFTFilter =
+    ShrinkViaInverseFFTType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( shrinkViaInverseFFTFilter,
+    FrequencyShrinkViaInverseFFTImageFilter, ImageToImageFilter );
+
 
   unsigned int dimension = 3;
-  if (argc == 4)
-    dimension = atoi(argv[3]);
+  if( argc == 4 )
+    {
+    dimension = atoi( argv[3] );
+    }
 
-  if (dimension == 2)
-    return runFrequencyExpandAndShrinkTest<2>(inputImage, outputImage);
-  else if(dimension == 3)
-    return runFrequencyExpandAndShrinkTest<3>(inputImage, outputImage);
+  if (dimension == 2 )
+    {
+    return runFrequencyExpandAndShrinkTest< 2 >( inputImage, outputImage );
+    }
+  else if( dimension == 3 )
+    {
+    return runFrequencyExpandAndShrinkTest< 3 >( inputImage, outputImage );
+    }
   else
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error: only 2 or 3 dimensions allowed, " << dimension << " selected." << std::endl;
     return EXIT_FAILURE;
     }

--- a/test/itkFrequencyExpandTest.cxx
+++ b/test/itkFrequencyExpandTest.cxx
@@ -15,90 +15,106 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include <memory>
-#include <string>
-#include <cmath>
+
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkForwardFFTImageFilter.h"
 #include "itkInverseFFTImageFilter.h"
-#include <itkComplexToRealImageFilter.h>
-#include <itkFrequencyExpandImageFilter.h>
-#include <itkExpandWithZerosImageFilter.h>
-#include <itkComplexToComplexFFTImageFilter.h>
-#include <itkImageRegionConstIterator.h>
-#include <itkZeroDCImageFilter.h>
+#include "itkComplexToRealImageFilter.h"
+#include "itkFrequencyExpandImageFilter.h"
+#include "itkExpandWithZerosImageFilter.h"
+#include "itkComplexToComplexFFTImageFilter.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkZeroDCImageFilter.h"
 #include "itkIsotropicWaveletTestUtilities.h"
-#include <itkCastImageFilter.h>
-using namespace std;
-using namespace itk;
+#include "itkCastImageFilter.h"
+#include "itkTestingMacros.h"
 
-// Visualize for dev/debug purposes. Set in cmake file. Require VTK
+#include <memory>
+#include <string>
+#include <cmath>
+
+// Visualize for dev/debug purposes. Set in cmake file. Requires VTK
 #ifdef ITK_VISUALIZE_TESTS
 #include "itkViewImage.h"
 #endif
 
-template<unsigned int N>
+
+template< unsigned int VDimension >
 int runFrequencyExpandTest(const std::string & inputImage, const std::string & outputImage)
 {
-  const unsigned int dimension = N;
+  const unsigned int Dimension = VDimension;
 
-  typedef double                           PixelType;
-  typedef itk::Image<PixelType, dimension> ImageType;
-  typedef itk::ImageFileReader<ImageType>  ReaderType;
+  typedef double                              PixelType;
+  typedef itk::Image< PixelType, Dimension >  ImageType;
+  typedef itk::ImageFileReader< ImageType >   ReaderType;
+
   typename ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(inputImage);
-  reader->Update();
-  reader->UpdateLargestPossibleRegion();
+  reader->SetFileName( inputImage );
 
-  /***** Calculate mean value and substract: ****/
-  typedef itk::ZeroDCImageFilter<ImageType> ZeroDCFilterType;
+  reader->Update();
+
+  // Calculate mean value and subtract
+  typedef itk::ZeroDCImageFilter< ImageType > ZeroDCFilterType;
   typename ZeroDCFilterType::Pointer zeroDCFilter = ZeroDCFilterType::New();
-  zeroDCFilter->SetInput(reader->GetOutput());
+
+  zeroDCFilter->SetInput( reader->GetOutput() );
+
   zeroDCFilter->Update();
-  /**********************************************/
 
   // Perform FFT on input image.
-  typedef itk::ForwardFFTImageFilter<ImageType> FFTFilterType;
+  typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
   typename FFTFilterType::Pointer fftFilter = FFTFilterType::New();
   // fftFilter->SetInput(subtractFilter->GetOutput());
-  fftFilter->SetInput(zeroDCFilter->GetOutput());
+
+  fftFilter->SetInput( zeroDCFilter->GetOutput() );
+
   typedef typename FFTFilterType::OutputImageType ComplexImageType;
 
   // ExpandFrequency
-  typedef itk::FrequencyExpandImageFilter<ComplexImageType> ExpandType;
+  typedef itk::FrequencyExpandImageFilter< ComplexImageType > ExpandType;
   typename ExpandType::Pointer expandFilter = ExpandType::New();
-  expandFilter->SetInput(fftFilter->GetOutput());
-  expandFilter->SetExpandFactors(2);
+
+  expandFilter->SetInput( fftFilter->GetOutput() );
+
+  unsigned int expandFactor = 2;
+  ExpandType::ExpandFactorsType expandFactors;
+  expandFactors.Fill( expandFactor );
+
+  expandFilter->SetExpandFactors( expandFactors );
+  TEST_SET_GET_VALUE( expandFactors, expandFilter->GetExpandFactors() );
+
   expandFilter->Update();
 
   // InverseFFT
-  typedef itk::InverseFFTImageFilter<ComplexImageType, ImageType> InverseFFTFilterType;
+  typedef itk::InverseFFTImageFilter< ComplexImageType, ImageType > InverseFFTFilterType;
   typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();
-  inverseFFT->SetInput(expandFilter->GetOutput());
+
+  inverseFFT->SetInput( expandFilter->GetOutput() );
+
   inverseFFT->Update();
 
   /***************** Hermitian property (sym) *****************************/
   bool fftIsHermitian    = itk::Testing::ComplexImageIsHermitian(fftFilter->GetOutput());
   bool expandIsHermitian = itk::Testing::ComplexImageIsHermitian(expandFilter->GetOutput());
-  if (!fftIsHermitian)
+  if( !fftIsHermitian )
     {
     std::cerr << "fft is not Hermitian" << std::endl;
     // return EXIT_FAILURE;
     }
-  if (!expandIsHermitian)
+  if( !expandIsHermitian )
     {
     std::cerr << "expand is not Hermitian" << std::endl;
     // return EXIT_FAILURE;
     }
   /***************** Hermitian property *****************************/
     {
-    // Simmetry and hermitian test: ComplexInverseFFT will generate output with zero imaginary part.
-    // Test hermitian properties for even Images. Odd real images are not even hermitian after FFT.
-    FixedArray<bool, dimension> inputSizeIsEven;
-    bool imageIsEven(true);
-    for ( unsigned int dim = 0; dim < dimension; ++dim )
+    // Simmetry and Hermitian test: ComplexInverseFFT will generate output with zero imaginary part.
+    // Test Hermitian properties for even Images. Odd real images are not even Hermitian after FFT.
+    itk::FixedArray< bool, Dimension > inputSizeIsEven;
+    bool imageIsEven = true;
+    for ( unsigned int dim = 0; dim < Dimension; ++dim )
       {
       inputSizeIsEven[dim] = (reader->GetOutput()->GetLargestPossibleRegion().GetSize()[dim] % 2 == 0);
       if (inputSizeIsEven[dim] == false)
@@ -117,28 +133,26 @@ int runFrequencyExpandTest(const std::string & inputImage, const std::string & o
         complexInverseFFT->GetOutput(),
         complexInverseFFT->GetOutput()->GetLargestPossibleRegion());
       complexInverseIt.GoToBegin();
-      unsigned int not_zero_complex_error = 0;
-      double accum_square_difference(0);
-      while(!complexInverseIt.IsAtEnd())
+      unsigned int notZeroComplexError = 0;
+      double accumSqDiff = 0;
+      while( !complexInverseIt.IsAtEnd() )
         {
-        typename ComplexImageType::PixelType::value_type imag_value = complexInverseIt.Get().imag();
-        bool not_equal =
-          itk::Math::NotAlmostEquals<typename ComplexImageType::PixelType::value_type>( imag_value, 0.0);
-        if( not_equal )
+        typename ComplexImageType::PixelType::value_type imageValue = complexInverseIt.Get().imag();
+        if( itk::Math::NotAlmostEquals< typename ComplexImageType::PixelType::value_type >( imageValue, 0.0 ) )
           {
-          ++not_zero_complex_error;
-          accum_square_difference += imag_value * imag_value;
+          ++notZeroComplexError;
+          accumSqDiff += imageValue * imageValue;
           }
 
         ++complexInverseIt;
         }
-      // accum_square_difference /= not_zero_complex_error;
-      if ( not_zero_complex_error > 0 )
+      // accumSqDiff /= notZeroComplexError;
+      if ( notZeroComplexError > 0 )
         {
         std::cout << "Dev note: After the FFT filter the image is not "
           "hermitian. #Not_zero_imag_value Pixels: "
-                  << not_zero_complex_error
-                  << " accumSquareDifference: " << accum_square_difference
+                  << notZeroComplexError
+                  << " accumSquareDifference: " << accumSqDiff
                   << std::endl;
         }
       }
@@ -154,65 +168,56 @@ int runFrequencyExpandTest(const std::string & inputImage, const std::string & o
         complexInverseFFT->GetOutput(),
         complexInverseFFT->GetOutput()->GetLargestPossibleRegion());
       complexInverseIt.GoToBegin();
-      unsigned int not_zero_complex_error = 0;
-      double accum_square_difference(0);
-      while(!complexInverseIt.IsAtEnd())
+      unsigned int notZeroComplexError = 0;
+      double accumSqDiff = 0;
+      while( !complexInverseIt.IsAtEnd() )
         {
-        typename ComplexImageType::PixelType::value_type imag_value = complexInverseIt.Get().imag();
-        bool not_equal =
-          itk::Math::NotAlmostEquals<typename ComplexImageType::PixelType::value_type>( imag_value, 0.0);
-        if( not_equal )
+        typename ComplexImageType::PixelType::value_type imageValue = complexInverseIt.Get().imag();
+        if( itk::Math::NotAlmostEquals< typename ComplexImageType::PixelType::value_type >( imageValue, 0.0 ) )
           {
-          ++not_zero_complex_error;
-          accum_square_difference += imag_value * imag_value;
+          ++notZeroComplexError;
+          accumSqDiff += imageValue * imageValue;
           }
         ++complexInverseIt;
         }
-      // accum_square_difference /= not_zero_complex_error;
-      if ( not_zero_complex_error > 0 )
+      // accumSqDiff /= notZeroComplexError;
+      if( notZeroComplexError > 0 )
         {
         std::cout << "Dev note: After the EXPAND filter the image is not "
-          "hermitian. #Not_zero_imag_value Pixels: "
-                  << not_zero_complex_error
-                  << " accumSquareDifference: " << accum_square_difference
+          "Hermitian. #Not_zero_imag_value Pixels: "
+                  << notZeroComplexError
+                  << " accumSquareDifference: " << accumSqDiff
                   << std::endl;
         }
       }
     }
-  /*************End Hermitian property *****************************/
 
-  // Write Output for comparisson
-  typedef itk::Image<float, dimension>                      FloatImageType;
+  // Write output
+  typedef itk::Image< float, Dimension > FloatImageType;
   typedef itk::CastImageFilter< ImageType, FloatImageType > CastType;
   typename CastType::Pointer castFilter = CastType::New();
-  castFilter->SetInput(inverseFFT->GetOutput());
+
+  castFilter->SetInput( inverseFFT->GetOutput() );
 
   typedef itk::ImageFileWriter< FloatImageType > WriterType;
   typename WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( outputImage );
+
   writer->SetInput( castFilter->GetOutput() );
 
-  try
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
-    std::cerr << "Error writing the FrequencyExpand image: " << std::endl;
-    std::cerr << error << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+
 
 #ifdef ITK_VISUALIZE_TESTS
-  Testing::ViewImage(zeroDCFilter->GetOutput(), "Original");
-  Testing::ViewImage(inverseFFT->GetOutput(), "FrequencyExpander");
-  // //Compare with regular expand filter.
+  Testing::ViewImage( zeroDCFilter->GetOutput(), "Original" );
+  Testing::ViewImage( inverseFFT->GetOutput(), "FrequencyExpander" );
+  // Compare with regular expand filter.
   typedef itk::ExpandWithZerosImageFilter<ImageType, ImageType> RegularExpandType;
   typename RegularExpandType::Pointer regularExpandFilter = RegularExpandType::New();
-  regularExpandFilter->SetInput(reader->GetOutput());
-  regularExpandFilter->SetExpandFactors(2);
+  regularExpandFilter->SetInput( reader->GetOutput() );
+  regularExpandFilter->SetExpandFactors( 2 );
   regularExpandFilter->Update();
-  Testing::ViewImage(regularExpandFilter->GetOutput(), "Regular expander (adding zeros)");
+  Testing::ViewImage( regularExpandFilter->GetOutput(), "Regular expander (adding zeros)" );
 
   // Complex to real
   // typedef itk::ComplexToRealImageFilter<ComplexImageType, ImageType> ComplexToRealFilter;
@@ -229,25 +234,52 @@ int runFrequencyExpandTest(const std::string & inputImage, const std::string & o
   return EXIT_SUCCESS;
 }
 
-int itkFrequencyExpandTest(int argc, char* argv[])
+int itkFrequencyExpandTest( int argc, char* argv[] )
 {
   if( argc < 3 || argc > 4 )
     {
     std::cerr << "Usage: " << argv[0] << " inputImage outputImage [dimension]" << std::endl;
     return EXIT_FAILURE;
     }
-  const string inputImage  = argv[1];
-  const string outputImage = argv[2];
+
+  const std::string inputImage  = argv[1];
+  const std::string outputImage = argv[2];
+  
+  const unsigned int ImageDimension = 3;
+  typedef double                                  PixelType;
+  typedef itk::Image< PixelType, ImageDimension > ImageType;
+  typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
+  typedef FFTFilterType::OutputImageType          ComplexImageType;
+
+  // Exercise basic object methods
+  // Done outside the helper function in the test because GCC is limited
+  // when calling overloaded base class functions.
+  typedef itk::FrequencyExpandImageFilter< ComplexImageType >
+    FrequencyExpandImageFilterType;
+  FrequencyExpandImageFilterType::Pointer expandFilter =
+    FrequencyExpandImageFilterType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( expandFilter, FrequencyExpandImageFilter,
+    ImageToImageFilter );
+
 
   unsigned int dimension = 3;
-  if (argc == 4)
+  if( argc == 4 )
+    {
     dimension = atoi(argv[3]);
-  if (dimension == 2)
-    return runFrequencyExpandTest<2>(inputImage, outputImage);
-  else if(dimension == 3)
-    return runFrequencyExpandTest<3>(inputImage, outputImage);
+    }
+
+  if( dimension == 2 )
+    {
+    return runFrequencyExpandTest< 2 >( inputImage, outputImage );
+    }
+  else if( dimension == 3 )
+    {
+    return runFrequencyExpandTest< 3 >( inputImage, outputImage );
+    }
   else
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error: only 2 or 3 dimensions allowed, " << dimension << " selected." << std::endl;
     return EXIT_FAILURE;
     }

--- a/test/itkFrequencyImageRegionIteratorWithIndexTest.cxx
+++ b/test/itkFrequencyImageRegionIteratorWithIndexTest.cxx
@@ -16,14 +16,15 @@
  *
  *=========================================================================*/
 
-#include <iostream>
 #include "itkFrequencyImageRegionIteratorWithIndex.h"
+#include "itkTestingMacros.h"
+
+#include <iostream>
 #include <complex>
 #include <itkMath.h>
-using namespace std;
-using namespace itk;
 
-template<typename TImage>
+
+template< typename TImage >
 class itkFrequencyImageRegionIteratorWithIndexTester
 {
 public:
@@ -33,12 +34,12 @@ public:
 
   typedef itk::FrequencyImageRegionIteratorWithIndex<ImageType > IteratorType;
 
-  explicit itkFrequencyImageRegionIteratorWithIndexTester( size_t input_size )
+  explicit itkFrequencyImageRegionIteratorWithIndexTester( size_t inputImageSize )
   {
     m_Image = ImageType::New();
 
     typename ImageType::SizeType size;
-    size.Fill(input_size);
+    size.Fill( inputImageSize );
 
     typename ImageType::IndexType start;
     start.Fill(0);
@@ -50,38 +51,40 @@ public:
     m_Image->SetRegions( region );
 
     // Setup the half, positive frequencies region.
-    size.Fill(input_size / 2  );
+    size.Fill( inputImageSize / 2  );
     start.Fill(1);
     m_PositiveHalfRegion.SetSize( size );
     m_PositiveHalfRegion.SetIndex( start );
 
-    m_ImageIsOdd = input_size % 2 == 1 ? 1 : 0;
+    m_ImageIsOdd = inputImageSize % 2 == 1 ? 1 : 0;
     // Setup the half, negative frequencies region.
-    unsigned int one_if_odd = m_ImageIsOdd ? 1 : 0;
-    size.Fill(input_size / 2 );
-    start.Fill(input_size / 2 + one_if_odd );
+    unsigned int isImageSizeOdd = m_ImageIsOdd ? 1 : 0;
+    size.Fill( inputImageSize / 2 );
+    start.Fill( inputImageSize / 2 + isImageSizeOdd );
     m_NegativeHalfRegion.SetSize( size );
     m_NegativeHalfRegion.SetIndex( start );
 
-    /* With default frequency_spacing = 1 ( = sampling frequency)
-     * Nyquist_first = fs * (N/2) / N where N is the size of that dim.
-     * If image is Even, there is only one Nyquist at index = N/2, shared between + and - frequencies.
-     * If Odd, Nyquist Freq  = fs/2 is not represented, but there is still
-     * a largest frequency at half index with value = fs/2 * (N-1)/N
-     */
+    //
+    // With default frequency_spacing = 1 ( = sampling frequency)
+    // Nyquist_first = fs * (N/2) / N where N is the size of that dim.
+    // If image is Even, there is only one Nyquist at index = N/2, shared between + and - frequencies.
+    // If Odd, Nyquist Freq  = fs/2 is not represented, but there is still
+    // a largest frequency at half index with value = fs/2 * (N-1)/N
+    //
 
-    for (unsigned int dim = 0; dim < ImageType::ImageDimension; dim++)
+    for( unsigned int dim = 0; dim < ImageType::ImageDimension; dim++ )
       {
       m_LargestFrequency[dim] = 0.5; // = fs/2 with default spacing = 1.0
-      if ( m_ImageIsOdd )
-        m_LargestFrequency[dim] = 0.5 * (input_size - 1) * (1.0 / input_size);
+      if( m_ImageIsOdd )
+        {
+        m_LargestFrequency[dim] = 0.5 * (inputImageSize - 1) * (1.0 / inputImageSize);
+        }
       }
   }
 
   bool TestIterator()
   {
     typename ImageType::RegionType region = m_Image->GetLargestPossibleRegion();
-    std::cout << "---" << std::endl;
     std::cout << "LargestRegion:" << region << std::endl;
     if( TestLargestRegion() == false )
       {
@@ -91,16 +94,14 @@ public:
 
     if( TestFrequenciesHaveHermitianSimmetry() == false )
       {
-      std::cout << "Failed testing hermitian simmetry." << std::endl;
+      std::cout << "Failed testing Hermitian simmetry." << std::endl;
       return false;
       }
 
     region = m_PositiveHalfRegion;
-    std::cout << "---" << std::endl;
     std::cout << "Positive Half Region (excluding 0 freqs in all dim):" << region << std::endl;
 
     region = m_NegativeHalfRegion;
-    std::cout << "---" << std::endl;
     std::cout << "Negative Half Region: (including Nyquist freq if N even)" << region << std::endl;
 
     if( TestNegativeRegion( region ) == false )
@@ -115,17 +116,18 @@ public:
   bool TestFrequenciesHaveHermitianSimmetry()
   {
     IteratorType it( m_Image, m_PositiveHalfRegion);
-    IteratorType reverseIt( m_Image, m_NegativeHalfRegion);
+    IteratorType reverseIt( m_Image, m_NegativeHalfRegion );
 
     it.GoToBegin();
     reverseIt.GoToReverseBegin();
     while( !it.IsAtEnd() )
       {
-      for (unsigned int dim = 0; dim < ImageType::ImageDimension; dim++)
+      for( unsigned int dim = 0; dim < ImageType::ImageDimension; dim++ )
         {
-        if (it.GetFrequency()[dim] != itk::Math::abs(reverseIt.GetFrequency()[dim]))
+          if( !itk::Math::NotAlmostEquals( it.GetFrequency()[dim],
+            itk::Math::abs(reverseIt.GetFrequency()[dim] ) ) )
           {
-          std::cout << "Failed testing hermitian property at index:"
+          std::cout << "Failed testing Hermitian property at index:"
                     << it.GetIndex() << " freq: " << it.GetFrequency()  << "\n"
                     << " reverseIt: " << reverseIt.GetIndex() << " freq: " << reverseIt.GetFrequency() << std::endl;
           return false;
@@ -137,43 +139,43 @@ public:
     return true;
   }
 
-  // If N is even, the nyquist frequency is stored in the positive region,
+  // If N is even, the Nyquist frequency is stored in the positive region,
   // but shared with the negative region.
   // If N is odd, the largest frequency has a positive and negative component.
-  bool TestNegativeRegion(typename ImageType::RegionType & region)
+  bool TestNegativeRegion( typename ImageType::RegionType & region )
   {
     IteratorType it( m_Image, region );
 
     it.GoToBegin();
-    IndexType half_index_plus_one;
+    IndexType halfIndexPlusOne;
     for (unsigned int dim = 0; dim < ImageType::ImageDimension; dim++)
       {
-      half_index_plus_one[dim] = it.GetHalfIndex()[dim] + 1;
+      halfIndexPlusOne[dim] = it.GetHalfIndex()[dim] + 1;
       }
-    IndexType first_negative_index = m_ImageIsOdd ? half_index_plus_one : it.GetHalfIndex();
-    IndexType smallest_negative_freq_index;
+    IndexType firstNegativeIndex = m_ImageIsOdd ? halfIndexPlusOne : it.GetHalfIndex();
+    IndexType smallestNegativeFreqIndex;
     for (unsigned int dim = 0; dim < ImageType::ImageDimension; dim++)
       {
-      smallest_negative_freq_index[dim] = m_ImageIsOdd ?
-        -first_negative_index[dim] + 1 : first_negative_index[dim];
+      smallestNegativeFreqIndex[dim] = m_ImageIsOdd ?
+        -firstNegativeIndex[dim] + 1 : firstNegativeIndex[dim];
       }
     while( !it.IsAtEnd() )
       {
-      if (it.GetIndex() == first_negative_index)
+      if( it.GetIndex() == firstNegativeIndex )
         {
         // abs value should be equal to largest freq for odd images
         if( m_ImageIsOdd == true &&
             m_LargestFrequency != it.GetFrequency() &&
-            -m_LargestFrequency != it.GetFrequency())
+            -m_LargestFrequency != it.GetFrequency() )
           {
           std::cout << " Frequency value is wrong." << it.GetFrequency()
                     << " should be: " << m_LargestFrequency << std::endl;
           return false;
           }
-        if(it.GetFrequencyBin() != smallest_negative_freq_index )
+        if( it.GetFrequencyBin() != smallestNegativeFreqIndex )
           {
           std::cout << " Smallest negative frequency bin is wrong." << it.GetFrequencyBin()
-                    << " should be: " << smallest_negative_freq_index << ".iterator index: " << it.GetIndex()
+                    << " should be: " << smallestNegativeFreqIndex << ".iterator index: " << it.GetIndex()
                     << std::endl;
           return false;
           }
@@ -188,15 +190,17 @@ public:
     IteratorType it( m_Image, m_Image->GetLargestPossibleRegion() );
 
     typename ImageType::IndexType truthHalfIndex;
-    for (unsigned int dim = 0; dim < ImageType::ImageDimension; dim++)
+    for( unsigned int dim = 0; dim < ImageType::ImageDimension; dim++ )
       {
       truthHalfIndex[dim] =
         m_Image->GetLargestPossibleRegion().GetIndex()[dim]
         + m_Image->GetLargestPossibleRegion().GetSize()[dim] / 2;
-      if ( it.GetHalfIndex()[dim] != truthHalfIndex[dim] )
+      if( it.GetHalfIndex()[dim] != truthHalfIndex[dim] )
         {
-        std::cout << "HalfIndex is wrong! - " << it.GetHalfIndex()
-                  << ". It should be: " << truthHalfIndex << std::endl;
+        std::cerr << "Test failed! " << std::endl;
+        std::cerr << "Error in GetHalfIndex()" << std::endl;
+        std::cerr << "Expected: " << truthHalfIndex << ", but got "
+          << it.GetHalfIndex() << std::endl;
         return false;
         }
       }
@@ -208,7 +212,8 @@ public:
     if( it.GetIndex() == m_Image->GetLargestPossibleRegion().GetIndex() &&
         it.GetFrequencyBin() != zero_freq_index )
       {
-      std::cout << "Error: Zero frequency is not at the minimum index!." << std::endl;
+      std::cerr << "Test failed! " << std::endl;
+      std::cerr << "Error: Zero frequency is not at the minimum index!" << std::endl;
       return false;
       }
 
@@ -216,27 +221,29 @@ public:
       {
       IndexType index = it.GetIndex();
       // Check to see if the index is within allowed bounds
-      bool isInside = m_Image->GetLargestPossibleRegion().IsInside(index);
+      bool isInside = m_Image->GetLargestPossibleRegion().IsInside( index );
       if( !isInside )
         {
-        std::cout << "    Index is not inside region! - " << index << std::endl;
+        std::cerr << "Test failed! " << std::endl;
+        std::cerr << "Index is not inside region!: " << index << std::endl;
         return false;
         }
-      // check repeatibility
+      // Check repeatibility
       if( index != it.GetIndex() )
         {
-        std::cout << "    Failed to repeat GetIndex." << std::endl;
+        std::cerr << "Test failed! " << std::endl;
+        std::cerr << "Failed to repeat GetIndex()" << std::endl;
         return false;
         }
 
-      if (index == it.GetHalfIndex() &&
+      if( index == it.GetHalfIndex() &&
           it.GetFrequency() != m_LargestFrequency &&
-          it.GetFrequencyBin() != it.GetHalfIndex())
+          it.GetFrequencyBin() != it.GetHalfIndex() )
         {
-        std::cout << "    Failed! Largest freq bin is wrong. " << index
-                  << ". Frequency Index: " << it.GetFrequency()
-                  << ". It should be: " << m_LargestFrequency
-                  << std::endl;
+        std::cerr << "Test failed! " << std::endl;
+        std::cerr << "Error in largest frequency bin" << std::endl;
+        std::cerr << "Expected: " << m_LargestFrequency << ", but got "
+          << it.GetFrequency() << std::endl;
         return false;
         }
       // increment and test index
@@ -253,47 +260,60 @@ private:
   bool                           m_ImageIsOdd;
 };
 
-int itkFrequencyImageRegionIteratorWithIndexTest(int, char**)
+
+int itkFrequencyImageRegionIteratorWithIndexTest( int, char* [] )
 {
   bool testPassed = true; // let's be optimistic
 
+  const unsigned int Dimension = 3;
+  typedef char CharPixelType;
+  typedef char FloatPixelType;
+
+  // Even input image size test
     {
-    size_t input_size(8);
-    std::cout << "Testing with EVEN Image< std::complex<float>, 3 > with size: " << input_size << std::endl;
-    itkFrequencyImageRegionIteratorWithIndexTester< itk::Image< std::complex<float>, 3 > > Tester(input_size);
-    if( Tester.TestIterator() == false )
-      {
-      testPassed = false;
-      }
-    }
-    {
-    std::cout << "\n------------------------" << std::endl;
-    size_t input_size(10);
-    std::cout << "Testing with EVEN Image< char, 3 > with size: " << input_size << std::endl;
-    itkFrequencyImageRegionIteratorWithIndexTester< itk::Image< char, 3 > > Tester(input_size);
+    size_t inputImageSize( 8 );
+    std::cout << "Testing with EVEN Image< std::complex<float>, 3 > with size: "
+      << inputImageSize << std::endl;
+    itkFrequencyImageRegionIteratorWithIndexTester<
+      itk::Image< std::complex< FloatPixelType >, Dimension > > Tester( inputImageSize );
     if( Tester.TestIterator() == false )
       {
       testPassed = false;
       }
     }
 
+  // Even input image size test
     {
-    std::cout << "\n------------------------" << std::endl;
-    size_t input_size(9);
-    std::cout << "Testing with ODD Image< char, 3 > with size: " << input_size << std::endl;
-    itkFrequencyImageRegionIteratorWithIndexTester< itk::Image< char, 3 > > Tester(input_size);
+    size_t inputImageSize( 10 );
+    std::cout << "Testing with EVEN Image< char, 3 > with size: " <<
+      inputImageSize << std::endl;
+    itkFrequencyImageRegionIteratorWithIndexTester<
+      itk::Image< CharPixelType, Dimension > > Tester( inputImageSize );
     if( Tester.TestIterator() == false )
       {
       testPassed = false;
       }
     }
 
-  if ( !testPassed )
+  // Odd input image size test
     {
-    std::cout << "\nFailed" << std::endl;
+    size_t inputImageSize(9);
+    std::cout << "Testing with ODD Image< char, 3 > with size: "
+      << inputImageSize << std::endl;
+    itkFrequencyImageRegionIteratorWithIndexTester<
+      itk::Image< CharPixelType, Dimension > > Tester( inputImageSize );
+    if( Tester.TestIterator() == false )
+      {
+      testPassed = false;
+      }
+    }
+
+  if( !testPassed )
+    {
+    std::cout << "Test failed!" << std::endl;
     return EXIT_FAILURE;
     }
 
-  std::cout << "\nSuccess" << std::endl;
+
   return EXIT_SUCCESS;
 }

--- a/test/itkFrequencyShrinkTest.cxx
+++ b/test/itkFrequencyShrinkTest.cxx
@@ -15,270 +15,317 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include <memory>
-#include <string>
-#include <cmath>
-#include <iomanip>
+
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkForwardFFTImageFilter.h"
 #include "itkInverseFFTImageFilter.h"
-#include <itkComplexToRealImageFilter.h>
-#include <itkComplexToImaginaryImageFilter.h>
-#include <itkFrequencyShrinkImageFilter.h>
-#include <itkShrinkImageFilter.h>
-#include <itkZeroDCImageFilter.h>
-#include <itkComplexToComplexFFTImageFilter.h>
-#include <itkImageRegionConstIterator.h>
-#include <itkImageRegionConstIteratorWithIndex.h>
+#include "itkComplexToRealImageFilter.h"
+#include "itkComplexToImaginaryImageFilter.h"
+#include "itkFrequencyShrinkImageFilter.h"
+#include "itkShrinkImageFilter.h"
+#include "itkZeroDCImageFilter.h"
+#include "itkComplexToComplexFFTImageFilter.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkImageRegionConstIteratorWithIndex.h"
 #include <itkCastImageFilter.h>
 #include "itkIsotropicWaveletTestUtilities.h"
-using namespace std;
-using namespace itk;
+#include "itkTestingMacros.h"
 
-// Visualize for dev/debug purposes. Set in cmake file. Require VTK
+#include <memory>
+#include <string>
+#include <cmath>
+#include <iomanip>
+
+// Visualize for dev/debug purposes. Set in cmake file. Requires VTK
 #ifdef ITK_VISUALIZE_TESTS
 #include "itkViewImage.h"
 #endif
 
-template<unsigned int N>
-int runFrequencyShrinkTest(const std::string & inputImage, const std::string & outputImage)
+
+template< unsigned int VDimension >
+int runFrequencyShrinkTest( const std::string & inputImage, const std::string & outputImage )
 {
-  const unsigned int dimension = N;
+  const unsigned int Dimension = VDimension;
 
-  typedef double                           PixelType;
-  typedef itk::Image<PixelType, dimension> ImageType;
-  typedef itk::ImageFileReader<ImageType>  ReaderType;
+  typedef double                              PixelType;
+  typedef itk::Image< PixelType, Dimension >  ImageType;
+  typedef itk::ImageFileReader< ImageType >   ReaderType;
+
   typename ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(inputImage);
-  reader->Update();
-  reader->UpdateLargestPossibleRegion();
+  reader->SetFileName( inputImage );
 
-  /***** Calculate mean value and substract: zeroDCFilter ****/
-  typedef itk::ZeroDCImageFilter<ImageType> ZeroDCFilterType;
+  reader->Update();
+
+  // Calculate mean value and subtract
+  typedef itk::ZeroDCImageFilter< ImageType > ZeroDCFilterType;
   typename ZeroDCFilterType::Pointer zeroDCFilter = ZeroDCFilterType::New();
-  zeroDCFilter->SetInput(reader->GetOutput());
-  /**********************************************/
+
+  zeroDCFilter->SetInput( reader->GetOutput() );
 
   // Perform FFT on input image.
-  typedef itk::ForwardFFTImageFilter<ImageType> FFTFilterType;
+  typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
   typename FFTFilterType::Pointer fftFilter = FFTFilterType::New();
-  fftFilter->SetInput(zeroDCFilter->GetOutput());
+  fftFilter->SetInput( zeroDCFilter->GetOutput() );
   typedef typename FFTFilterType::OutputImageType ComplexImageType;
 
   // ShinkFrequency
-  typedef itk::FrequencyShrinkImageFilter<ComplexImageType> ShrinkType;
+  typedef itk::FrequencyShrinkImageFilter< ComplexImageType > ShrinkType;
   typename ShrinkType::Pointer shrinkFilter = ShrinkType::New();
-  shrinkFilter->SetInput(fftFilter->GetOutput());
-  shrinkFilter->SetShrinkFactors(2);
-  // shrinkFilter->SetDebug(true);
+  
+  unsigned int shrinkFactor = 1;
+  ShrinkType::ShrinkFactorsType shrinkFactors;
+  shrinkFactors.Fill( shrinkFactor );
+  unsigned int index = 0;
+  for( unsigned int i = 0; shrinkFactors.Size(); ++i )
+    {
+    shrinkFilter->SetShrinkFactor( i, shrinkFactors[i] );
+    }
+  TEST_SET_GET_VALUE( shrinkFactors, shrinkFilter->GetShrinkFactors() );
+
+  shrinkFactor = 2;
+  shrinkFactors.Fill( shrinkFactor );
+  shrinkFilter->SetShrinkFactors( shrinkFactors );
+  TEST_SET_GET_VALUE( shrinkFactors, shrinkFilter->GetShrinkFactors() );
+
+  shrinkFilter->SetInput( fftFilter->GetOutput() );
+
   shrinkFilter->Update();
 
   // InverseFFT
-  typedef itk::InverseFFTImageFilter<ComplexImageType, ImageType> InverseFFTFilterType;
+  typedef itk::InverseFFTImageFilter< ComplexImageType, ImageType > InverseFFTFilterType;
   typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();
-  inverseFFT->SetInput(shrinkFilter->GetOutput());
+  inverseFFT->SetInput( shrinkFilter->GetOutput() );
+
   inverseFFT->Update();
 
-  /***************** Hermitian property (sym) *****************************/
-  bool fftIsHermitian    = itk::Testing::ComplexImageIsHermitian(fftFilter->GetOutput());
-  bool shrinkIsHermitian = itk::Testing::ComplexImageIsHermitian(shrinkFilter->GetOutput());
-  if (!fftIsHermitian)
+  // Test Hermitian property (sym)
+  bool fftIsHermitian    = itk::Testing::ComplexImageIsHermitian( fftFilter->GetOutput() );
+  bool shrinkIsHermitian = itk::Testing::ComplexImageIsHermitian( shrinkFilter->GetOutput() );
+  if( !fftIsHermitian )
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "fft is not Hermitian" << std::endl;
     return EXIT_FAILURE;
     }
-  if (!shrinkIsHermitian)
+  if( !shrinkIsHermitian )
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "shrink is not Hermitian" << std::endl;
     return EXIT_FAILURE;
     }
-  /***************** Hermitian property *****************************/
+
+    // Test Hermitian property
     {
-    // Simmetry and hermitian test: ComplexInverseFFT will generate output with zero imaginary part.
+    // Simmetry and Hermitian test: ComplexInverseFFT will generate output with zero imaginary part.
     // Test hermitian properties for even Images. Odd real images are not even hermitian after
-    FixedArray<bool, dimension> inputSizeIsEven;
-    bool imageIsEven(true);
-    for ( unsigned int dim = 0; dim < dimension; ++dim )
+    itk::FixedArray< bool, Dimension > inputSizeIsEven;
+    bool imageIsEven = true;
+    for( unsigned int dim = 0; dim < Dimension; ++dim )
       {
-      inputSizeIsEven[dim] = (zeroDCFilter->GetOutput()->GetLargestPossibleRegion().GetSize()[dim] % 2 == 0);
-      if (inputSizeIsEven[dim] == false)
+      inputSizeIsEven[dim] =
+        ( zeroDCFilter->GetOutput()->GetLargestPossibleRegion().GetSize()[dim] % 2 == 0 );
+      if( inputSizeIsEven[dim] == false )
+        {
         imageIsEven = false;
+        }
       }
     std::cout << "Image Even? " << imageIsEven << std::endl;
     // Check that complex part is almost 0 after FFT and complex inverse FFT.
       {
-      typedef itk::ComplexToComplexFFTImageFilter<ComplexImageType> ComplexFFTType;
+      typedef itk::ComplexToComplexFFTImageFilter< ComplexImageType > ComplexFFTType;
       typename ComplexFFTType::Pointer complexInverseFFT = ComplexFFTType::New();
-      complexInverseFFT->SetTransformDirection(ComplexFFTType::INVERSE);
-      complexInverseFFT->SetInput(fftFilter->GetOutput());
+      complexInverseFFT->SetTransformDirection( ComplexFFTType::INVERSE );
+      complexInverseFFT->SetInput( fftFilter->GetOutput() );
+
       complexInverseFFT->Update();
 
       itk::ImageRegionConstIterator<ComplexImageType> complexInverseIt(
         complexInverseFFT->GetOutput(),
-        complexInverseFFT->GetOutput()->GetLargestPossibleRegion());
+        complexInverseFFT->GetOutput()->GetLargestPossibleRegion() );
       complexInverseIt.GoToBegin();
-      unsigned int not_zero_complex_error = 0;
-      double accum_square_difference(0);
+      unsigned int notZeroComplexError = 0;
+      double accumSqDiff = 0;
       while(!complexInverseIt.IsAtEnd())
         {
-        typename ComplexImageType::PixelType::value_type imag_value = complexInverseIt.Get().imag();
-        bool not_equal =
-          itk::Math::NotAlmostEquals<typename ComplexImageType::PixelType::value_type>( imag_value, 0.0);
-        if( not_equal )
+        typename ComplexImageType::PixelType::value_type imageValue = complexInverseIt.Get().imag();
+        if( itk::Math::NotAlmostEquals< typename ComplexImageType::PixelType::value_type >( imageValue, 0.0 ) )
           {
-          ++not_zero_complex_error;
-          accum_square_difference += imag_value * imag_value;
+          ++notZeroComplexError;
+          accumSqDiff += imageValue * imageValue;
           }
 
         ++complexInverseIt;
         }
-      // accum_square_difference /= not_zero_complex_error;
-      if ( not_zero_complex_error > 0 )
+      // accumSqDiff /= notZeroComplexError;
+      if( notZeroComplexError > 0 )
         {
         std::cout << "Dev note: After the FFT filter the image is not "
-          "hermitian. #Not_zero_imag_value Pixels: "
-                  << not_zero_complex_error
-                  << " accumSquareDifference: " << accum_square_difference
+          "Hermitian. #Not_zero_imag_value Pixels: "
+                  << notZeroComplexError
+                  << " accumSquareDifference: " << accumSqDiff
                   << std::endl;
         }
       }
-    // Check that complex part is almost 0 filter is correct after shrink
+      // Check that complex part is almost 0 filter is correct after shrink
       {
       typedef itk::ComplexToComplexFFTImageFilter<ComplexImageType> ComplexFFTType;
       typename ComplexFFTType::Pointer complexInverseFFT = ComplexFFTType::New();
-      complexInverseFFT->SetTransformDirection(ComplexFFTType::INVERSE);
-      complexInverseFFT->SetInput(shrinkFilter->GetOutput());
+      complexInverseFFT->SetTransformDirection( ComplexFFTType::INVERSE );
+      complexInverseFFT->SetInput( shrinkFilter->GetOutput() );
+
       complexInverseFFT->Update();
 
       itk::ImageRegionConstIterator<ComplexImageType> complexInverseIt(
         complexInverseFFT->GetOutput(),
-        complexInverseFFT->GetOutput()->GetLargestPossibleRegion());
+        complexInverseFFT->GetOutput()->GetLargestPossibleRegion() );
       complexInverseIt.GoToBegin();
-      unsigned int not_zero_complex_error = 0;
-      double accum_square_difference(0);
-      while(!complexInverseIt.IsAtEnd())
+      unsigned int notZeroComplexError = 0;
+      double accumSqDiff = 0;
+      while( !complexInverseIt.IsAtEnd() )
         {
-        typename ComplexImageType::PixelType::value_type imag_value = complexInverseIt.Get().imag();
-        bool not_equal =
-          itk::Math::NotAlmostEquals<typename ComplexImageType::PixelType::value_type>( imag_value, 0.0);
-        if( not_equal )
+        typename ComplexImageType::PixelType::value_type imageValue = complexInverseIt.Get().imag();
+        if( itk::Math::NotAlmostEquals< typename ComplexImageType::PixelType::value_type >( imageValue, 0.0 ) )
           {
-          ++not_zero_complex_error;
-          accum_square_difference += imag_value * imag_value;
+          ++notZeroComplexError;
+          accumSqDiff += imageValue * imageValue;
           }
         ++complexInverseIt;
         }
-      // accum_square_difference /= not_zero_complex_error;
-      if ( not_zero_complex_error > 0 )
+      // accumSqDiff /= notZeroComplexError;
+      if( notZeroComplexError > 0 )
         {
         std::cout << "Dev note: After the SHRINK filter the image is not "
-          "hermitian. #Not_zero_imag_value Pixels: "
-                  << not_zero_complex_error
-                  << " accumSquareDifference: " << accum_square_difference
+          "Hermitian. #Not_zero_imag_value pixels: "
+                  << notZeroComplexError
+                  << " accumSquareDifference: " << accumSqDiff
                   << std::endl;
         }
       }
     }
-  /*************End Hermitian property *****************************/
 
-  /*************Test size and metadata. *****************************/
+
+  // Test size and metadata
   typename ComplexImageType::PointType   fftOrigin     = fftFilter->GetOutput()->GetOrigin();
   typename ComplexImageType::SpacingType fftSpacing    = fftFilter->GetOutput()->GetSpacing();
   typename ComplexImageType::PointType   shrinkOrigin  = shrinkFilter->GetOutput()->GetOrigin();
   typename ComplexImageType::SpacingType shrinkSpacing = shrinkFilter->GetOutput()->GetSpacing();
 
-  if(fftOrigin != shrinkOrigin)
+  if( fftOrigin != shrinkOrigin )
     {
-    std::cerr << "Origin has changed: (afterShrink): "  << shrinkOrigin << " != (fft): " << fftOrigin << std::endl;
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in Origin (has changed afterShrink): " << std::endl;
+    std::cerr << "Expected: " << fftOrigin << ", but got "
+      << shrinkOrigin << std::endl;
     return EXIT_FAILURE;
     }
 
-  if (fftSpacing != shrinkSpacing)
+  if( fftSpacing != shrinkSpacing )
     {
-    std::cerr << "Spacing has changed: (afterShrink): "  << shrinkSpacing << " != (fft): " << fftSpacing << std::endl;
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in Spacing (has changed afterShrink): " << std::endl;
+    std::cerr << "Expected: " << fftSpacing << ", but got "
+      << shrinkSpacing << std::endl;
     return EXIT_FAILURE;
     }
 
-  // Write Output for comparisson
-  typedef itk::Image<float, dimension>                      FloatImageType;
+  // Write output
+  typedef itk::Image< float, Dimension > FloatImageType;
   typedef itk::CastImageFilter< ImageType, FloatImageType > CastType;
   typename CastType::Pointer castFilter = CastType::New();
-  castFilter->SetInput(inverseFFT->GetOutput());
+
+  castFilter->SetInput( inverseFFT->GetOutput() );
 
   typedef itk::ImageFileWriter< FloatImageType > WriterType;
   typename WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( outputImage );
   writer->SetInput( castFilter->GetOutput() );
 
-  try
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
-    std::cerr << "Error writing the FrequencyShrink image: " << std::endl;
-    std::cerr << error << std::endl;
-    return EXIT_FAILURE;
-    }
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+
 
 #ifdef ITK_VISUALIZE_TESTS
-  Testing::ViewImage(zeroDCFilter->GetOutput(), "Original");
-  Testing::ViewImage(inverseFFT->GetOutput(), "FrequencyShrinker");
+  Testing::ViewImage( zeroDCFilter->GetOutput(), "Original" );
+  Testing::ViewImage( inverseFFT->GetOutput(), "FrequencyShrinker" );
   // Compare with regular shrink filter.
-  typedef itk::ShrinkImageFilter<ImageType, ImageType> RegularShrinkType;
+  typedef itk::ShrinkImageFilter< ImageType, ImageType > RegularShrinkType;
   typename RegularShrinkType::Pointer regularShrinkFilter = RegularShrinkType::New();
-  regularShrinkFilter->SetInput(reader->GetOutput());
-  regularShrinkFilter->SetShrinkFactors(2);
+  regularShrinkFilter->SetInput( reader->GetOutput() );
+  regularShrinkFilter->SetShrinkFactors( 2 );
   regularShrinkFilter->Update();
-  Testing::ViewImage(regularShrinkFilter->GetOutput(), "Regular shrinker");
+  Testing::ViewImage( regularShrinkFilter->GetOutput(), "Regular shrinker" );
 
   // Complex to real
-  typedef itk::ComplexToRealImageFilter<ComplexImageType, ImageType> ComplexToRealFilter;
+  typedef itk::ComplexToRealImageFilter< ComplexImageType, ImageType > ComplexToRealFilter;
   typename ComplexToRealFilter::Pointer complexToRealFilter = ComplexToRealFilter::New();
-  complexToRealFilter->SetInput(fftFilter->GetOutput() );
+  complexToRealFilter->SetInput( fftFilter->GetOutput() );
   complexToRealFilter->Update();
-  Testing::ViewImage(complexToRealFilter->GetOutput(), "ComplexToReal. Original");
+  Testing::ViewImage( complexToRealFilter->GetOutput(), "ComplexToReal. Original" );
   typename ComplexToRealFilter::Pointer complexToRealFilterShrink = ComplexToRealFilter::New();
-  complexToRealFilterShrink->SetInput(shrinkFilter->GetOutput() );
+  complexToRealFilterShrink->SetInput( shrinkFilter->GetOutput() );
   complexToRealFilterShrink->Update();
-  Testing::ViewImage(complexToRealFilterShrink->GetOutput(), "ComplexToReal. Shrinked");
+  Testing::ViewImage(complexToRealFilterShrink->GetOutput(), "ComplexToReal. Shrinked" );
 
-  // Complex to imag
-  typedef itk::ComplexToImaginaryImageFilter<ComplexImageType, ImageType> ComplexToImaginaryFilter;
+  // Complex to image
+  typedef itk::ComplexToImaginaryImageFilter< ComplexImageType, ImageType > ComplexToImaginaryFilter;
   typename ComplexToImaginaryFilter::Pointer complexToImaginaryFilter = ComplexToImaginaryFilter::New();
-  complexToImaginaryFilter->SetInput(fftFilter->GetOutput() );
+  complexToImaginaryFilter->SetInput( fftFilter->GetOutput() );
   complexToImaginaryFilter->Update();
-  Testing::ViewImage(complexToImaginaryFilter->GetOutput(), "ComplexToImaginary. Original");
+  Testing::ViewImage( complexToImaginaryFilter->GetOutput(), "ComplexToImaginary. Original" );
   typename ComplexToImaginaryFilter::Pointer complexToImaginaryFilterShrink = ComplexToImaginaryFilter::New();
-  complexToImaginaryFilterShrink->SetInput(shrinkFilter->GetOutput() );
+  complexToImaginaryFilterShrink->SetInput( shrinkFilter->GetOutput() );
   complexToImaginaryFilterShrink->Update();
-  Testing::ViewImage(complexToImaginaryFilterShrink->GetOutput(), "ComplexToImaginary. Shrinked");
+  Testing::ViewImage( complexToImaginaryFilterShrink->GetOutput(), "ComplexToImaginary. Shrinked" );
 #endif
 
   return EXIT_SUCCESS;
 }
 
-int itkFrequencyShrinkTest(int argc, char* argv[])
+int itkFrequencyShrinkTest( int argc, char* argv[] )
 {
   if( argc < 3 || argc > 4 )
     {
     std::cerr << "Usage: " << argv[0] << " inputImage outputImage [dimension]" << std::endl;
     return EXIT_FAILURE;
     }
-  const string inputImage  = argv[1];
-  const string outputImage = argv[2];
+
+  const std::string inputImage  = argv[1];
+  const std::string outputImage = argv[2];
+
+  const unsigned int ImageDimension = 3;
+  typedef double                                  PixelType;
+  typedef itk::Image< PixelType, ImageDimension > ImageType;
+  typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
+  typedef FFTFilterType::OutputImageType          ComplexImageType;
+
+  // Exercise basic object methods
+  // Done outside the helper function in the test because GCC is limited
+  // when calling overloaded base class functions.
+  typedef itk::FrequencyShrinkImageFilter< ComplexImageType > ShrinkType;
+  ShrinkType::Pointer shrinkFilter = ShrinkType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( shrinkFilter, FrequencyShrinkImageFilter,
+    ImageToImageFilter );
+
 
   unsigned int dimension = 3;
-  if (argc == 4)
-    dimension = atoi(argv[3]);
-  if (dimension == 2)
-    return runFrequencyShrinkTest<2>(inputImage, outputImage);
-  else if(dimension == 3)
-    return runFrequencyShrinkTest<3>(inputImage, outputImage);
+  if( argc == 4 )
+    {
+    dimension = atoi( argv[3] );
+    }
+
+  if( dimension == 2 )
+    {
+    return runFrequencyShrinkTest< 2 >( inputImage, outputImage );
+    }
+  else if( dimension == 3 )
+    {
+    return runFrequencyShrinkTest< 3 >( inputImage, outputImage );
+    }
   else
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error: only 2 or 3 dimensions allowed, " << dimension << " selected." << std::endl;
     return EXIT_FAILURE;
     }

--- a/test/itkInd2SubTest.cxx
+++ b/test/itkInd2SubTest.cxx
@@ -15,33 +15,35 @@
  *  limitations under the License.
  *
  *=========================================================================*/
+
 #include "itkInd2Sub.h"
+#include "itkTestingMacros.h"
+
 #include <vector>
 #include <iostream>
-using namespace std;
-using namespace itk;
 
-int itkInd2SubTest(int, char**)
+
+int itkInd2SubTest( int, char* [] )
 {
   // Used for  initializing FixedArray.
   const unsigned int D3 = 3;
 
-  typedef FixedArray<unsigned int, D3> Array3DType;
+  typedef itk::FixedArray<unsigned int, D3> Array3DType;
   Array3DType ass3D; // from assigner3D c++98
   ass3D[0] = 2; ass3D[1] = 2; ass3D[2] = 2;
-  FixedArray<unsigned int, D3> sizes3(ass3D);
+  itk::FixedArray<unsigned int, D3> sizes3(ass3D);
   std::vector<Array3DType>     storeOutput3D;
   std::cout << "sizes: (2,2,2) " << std::endl;
   for (unsigned int n = 0; n < sizes3[0] * sizes3[1] * sizes3[2]; ++n)
     {
     std::cout << "index " << n  << " -> ";
-    Array3DType out = Ind2Sub<D3>(n, sizes3);
+    Array3DType out = itk::Ind2Sub<D3>(n, sizes3);
     storeOutput3D.push_back(out);
-    for (unsigned int i = 0; i < D3; ++i)
+    for( unsigned int i = 0; i < D3; ++i )
       {
       std::cout << out[i] << " , ";
       }
-    std::cout << '\n';
+    std::cout << std::endl;
     }
   // Check results: I have to like c++11 initializer lists.
   std::vector<Array3DType> expectedResult3D;
@@ -61,34 +63,35 @@ int itkInd2SubTest(int, char**)
   expectedResult3D.push_back(ass3D);
   ass3D[0] = 1; ass3D[1] = 1; ass3D[2] = 1; // {1,1,1};
   expectedResult3D.push_back(ass3D);
-  if (storeOutput3D != expectedResult3D)
+  if( storeOutput3D != expectedResult3D )
     {
-    std::cout << "3D Failure " << std::endl;
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "3D Failure " << std::endl;
     return EXIT_FAILURE;
     }
 
-  /*******************************/
 
   const unsigned int D2 = 2;
-  typedef FixedArray<unsigned int, D2> Array2DType;
+  typedef itk::FixedArray<unsigned int, D2> Array2DType;
   Array2DType ass2D;
   ass2D[0] = 3; ass2D[1] = 4;
-  FixedArray<unsigned int, D2> sizes2(ass2D);
+  itk::FixedArray<unsigned int, D2> sizes2(ass2D);
   std::vector<Array2DType>     storeOutput2D;
   std::cout << "sizes: (" << sizes2[0] << "," << sizes2[1] << ")" << std::endl;
-  std::cout << "max_linear_index: (" << sizes2[0] * sizes2[1] - 1  << ")" << std::endl;
+  std::cout << "Max linear index: (" << sizes2[0] * sizes2[1] - 1  << ")" << std::endl;
   for (unsigned int n = 0; n < sizes2[0] * sizes2[1]; ++n)
     {
     std::cout << "index " << n  << " -> ";
-    Array2DType out = Ind2Sub<D2>(n, sizes2);
+    Array2DType out = itk::Ind2Sub<D2>(n, sizes2);
     storeOutput2D.push_back(out);
-    for (unsigned int i = 0; i < D2; ++i)
+    for( unsigned int i = 0; i < D2; ++i )
       {
       std::cout << out[i] << " , ";
       }
-    std::cout << '\n';
+    std::cout << std::endl;
     }
-  // Check results:
+
+  // Check results
   std::vector<Array2DType> expectedResult2D;
   ass2D[0] = 0; ass2D[1] = 0;
   expectedResult2D.push_back(ass2D);
@@ -118,32 +121,37 @@ int itkInd2SubTest(int, char**)
   ass2D[0] = 2; ass2D[1] = 3;
   expectedResult2D.push_back(ass2D);
 
-  if (storeOutput2D != expectedResult2D)
+  if( storeOutput2D != expectedResult2D )
     {
-    std::cout << "2D Failure " << std::endl;
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "2D Failure " << std::endl;
     return EXIT_FAILURE;
     }
 
-  /*******************************/
-  // Itk index/size interface:
+
+  // ITK index/size interface
   typedef itk::Index<D2> Index2DType;
   itk::Size<D2> sizesItk2 = {{3, 4}};
   std::vector<Array2DType> storeOutputIndex2D;
-  for (unsigned int n = 0; n < sizesItk2[0] * sizesItk2[1]; ++n)
+  for( unsigned int n = 0; n < sizesItk2[0] * sizesItk2[1]; ++n )
     {
     std::cout << "indexITK " << n  << " -> ";
-    Index2DType out = Ind2Sub<D2>(n, sizesItk2);
-    ass2D[0] = static_cast<unsigned int>(out[0]);
-    ass2D[1] = static_cast<unsigned int>(out[1]);
-    storeOutputIndex2D.push_back(ass2D);
-    for (unsigned int i = 0; i < D2; ++i)
+    Index2DType out = itk::Ind2Sub< D2 >(n, sizesItk2);
+    ass2D[0] = static_cast< unsigned int >(out[0]);
+    ass2D[1] = static_cast< unsigned int >(out[1]);
+    storeOutputIndex2D.push_back( ass2D );
+
+    for( unsigned int i = 0; i < D2; ++i )
       {
       std::cout << out[i] << " , ";
       }
-    std::cout << '\n';
+    std::cout << std::endl;
     }
-  if (storeOutputIndex2D != expectedResult2D)
+
+  if( storeOutputIndex2D != expectedResult2D )
+    {
     return EXIT_FAILURE;
+    }
 
   return EXIT_SUCCESS;
 }

--- a/test/itkIsotropicWaveletFrequencyFunctionTest.cxx
+++ b/test/itkIsotropicWaveletFrequencyFunctionTest.cxx
@@ -15,8 +15,7 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include <string>
-#include <fstream>
+
 #include "itkHeldIsotropicWavelet.h"
 #include "itkVowIsotropicWavelet.h"
 #include "itkSimoncelliIsotropicWavelet.h"
@@ -26,29 +25,36 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkNumberToString.h"
-using namespace std;
-using namespace itk;
+
+#include "itkTestingMacros.h"
+
+#include <string>
+#include <fstream>
+
+
 namespace itk
 {
 namespace Testing
 {
 // Generate values from a linear space
-std::vector<double> linSpaceForIWFF(double init = 0.0, double end = 1.0, size_t points = 1000)
+std::vector<double> linSpaceForIWFF( double init = 0.0, double end = 1.0, size_t points = 1000 )
 {
-  std::vector<double> w_array(points);
-  if(points <= 1)
-    throw ("linSpace needs more points");
-  double interval = (end - init) / (points - 1);
-  for(unsigned int i = 0; i < points; ++i)
+  std::vector< double > wArray( points );
+  if( points <= 1 )
     {
-    w_array[i] = init + interval * i;
+    throw ("linSpace needs more points");
     }
-  return w_array;
+  double interval = (end - init) / (points - 1);
+  for( unsigned int i = 0; i < points; ++i )
+    {
+    wArray[i] = init + interval * i;
+    }
+  return wArray;
 }
 }
 }
 
-template<unsigned int N, typename TWaveletFunction>
+template< unsigned int VDimension, typename TWaveletFunction >
 int runIsotropicWaveletFrequencyFunctionTest(
   const std::string& profileDataRootPath,
   const std::string& outputImage,
@@ -59,44 +65,48 @@ int runIsotropicWaveletFrequencyFunctionTest(
   typedef TWaveletFunction WaveletFunctionType;
   typename WaveletFunctionType::Pointer motherWavelet =
     WaveletFunctionType::New();
-  motherWavelet->SetHighPassSubBands(inputBands);
+  motherWavelet->SetHighPassSubBands( inputBands );
 
   double init   = 0.0;
   double end    = 1.0;
   size_t points = 1000;
-  std::vector< double > w_array = itk::Testing::linSpaceForIWFF(init, end, points);
+  std::vector< double > wArray = itk::Testing::linSpaceForIWFF( init, end, points );
   // Generate profile data for sub-bands and mother wavelet itself
   std::vector< std::vector< double > > subBandsResults;
-  for(unsigned int k = 0; k < inputBands + 2; ++k)
+  for( unsigned int k = 0; k < inputBands + 2; ++k )
     {
-    std::vector<double> bandResults;
-    for(unsigned int i = 0; i < points; ++i)
+    std::vector< double > bandResults;
+    for( unsigned int i = 0; i < points; ++i )
       {
-      if (k == inputBands + 1) // mother wavelet
-        bandResults.push_back(motherWavelet->EvaluateMagnitude(w_array[i]));
+      if ( k == inputBands + 1 ) // mother wavelet
+        {
+        bandResults.push_back( motherWavelet->EvaluateMagnitude( wArray[i] ) );
+        }
       else // bands
-        bandResults.push_back(motherWavelet->EvaluateForwardSubBand(w_array[i], k));
+        {
+        bandResults.push_back( motherWavelet->EvaluateForwardSubBand( wArray[i], k ) );
+        }
       }
-    subBandsResults.push_back(bandResults);
+    subBandsResults.push_back( bandResults );
     }
 
-  // Write profile.
+  // Write profile
   const std::string outputFilePath = profileDataRootPath + "_" + waveletTypeName +  "_" + n2s(inputBands) + ".txt";
-  std::ofstream     ofs(outputFilePath.c_str(), std::ofstream::out);
-  for(unsigned int i = 0; i < points; ++i)
+  std::ofstream ofs(outputFilePath.c_str(), std::ofstream::out);
+  for( unsigned int i = 0; i < points; ++i )
     {
-    ofs << w_array[i];
-    for(unsigned int k = 0; k < inputBands + 2; ++k)
+    ofs << wArray[i];
+    for( unsigned int k = 0; k < inputBands + 2; ++k )
       {
       ofs << "," << subBandsResults[k][i];
       }
-    ofs << "\n";
+    ofs << std::endl;
     }
   ofs.close();
   return EXIT_SUCCESS;
 }
 
-int itkIsotropicWaveletFrequencyFunctionTest(int argc, char *argv[])
+int itkIsotropicWaveletFrequencyFunctionTest( int argc, char *argv[] )
 {
   if( argc < 5 || argc > 6 )
     {
@@ -104,10 +114,12 @@ int itkIsotropicWaveletFrequencyFunctionTest(int argc, char *argv[])
               << "profileDataRootPath outputImage inputBands waveletFunction [dimension]" << std::endl;
     return EXIT_FAILURE;
     }
-  const string profileDataRootPath = argv[1];
-  const string outputImage = argv[2];
-  const unsigned int inputBands = atoi(argv[3]);
-  const string waveletFunction  = argv[4];
+  const std::string profileDataRootPath = argv[1];
+  const std::string outputImage = argv[2];
+  const unsigned int inputBands = atoi( argv[3] );
+  const std:: string waveletFunction = argv[4];
+
+
   unsigned int dimension = 3;
   if( argc == 6 )
     {
@@ -170,12 +182,14 @@ int itkIsotropicWaveletFrequencyFunctionTest(int argc, char *argv[])
                                                                          waveletFunction);
     else
       {
-      std::cerr << argv[4] << " is an unknown wavelet type " << std::endl;
+    std::cerr << "Test failed!" << std::endl;
+      std::cerr << argv[4] << " wavelet type not supported." << std::endl;
       return EXIT_FAILURE;
       }
     }
   else
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error: only 2 or 3 dimensions allowed, " << dimension << " selected." << std::endl;
     return EXIT_FAILURE;
     }

--- a/test/itkRieszFrequencyFilterBankGeneratorTest.cxx
+++ b/test/itkRieszFrequencyFilterBankGeneratorTest.cxx
@@ -15,70 +15,89 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include <memory>
-#include <string>
-#include <cmath>
+
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkForwardFFTImageFilter.h"
 #include "itkRieszFrequencyFilterBankGenerator.h"
-#include <itkComplexToRealImageFilter.h>
-#include <itkImageRegionConstIterator.h>
-#include <itkNumberToString.h>
-// Visualize for dev/debug purposes. Set in cmake file. Require VTK
+#include "itkComplexToRealImageFilter.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkNumberToString.h"
+#include "itkTestingMacros.h"
+
+#include <memory>
+#include <string>
+#include <cmath>
+
+// Visualize for dev/debug purposes. Set in cmake file. Requires VTK
 #ifdef ITK_VISUALIZE_TESTS
 #include "itkViewImage.h"
 #endif
 
-using namespace std;
-using namespace itk;
 
-int itkRieszFrequencyFilterBankGeneratorTest(int argc, char* argv[])
+int itkRieszFrequencyFilterBankGeneratorTest( int argc, char* argv[] )
 {
   if( argc != 3 )
     {
     std::cerr << "Usage: " << argv[0] << " inputImage outputImage" << std::endl;
     return EXIT_FAILURE;
     }
-  const string inputImage  = argv[1];
-  const string outputImage = argv[2];
+  const std::string inputImage  = argv[1];
+  const std::string outputImage = argv[2];
 
-  const unsigned int dimension = 3;
-  typedef double                           PixelType;
-  typedef itk::Image<PixelType, dimension> ImageType;
-  typedef itk::ImageFileReader<ImageType>  ReaderType;
+  const unsigned int Dimension = 3;
+  typedef double                              PixelType;
+  typedef itk::Image< PixelType, Dimension >  ImageType;
+  typedef itk::ImageFileReader< ImageType >   ReaderType;
+
   ReaderType::Pointer reader = ReaderType::New();
+
   reader->SetFileName(inputImage);
+
   reader->Update();
+
   reader->UpdateLargestPossibleRegion();
 
-  // Perform FFT on input image.
-  typedef itk::ForwardFFTImageFilter<ImageType> FFTFilterType;
+  // Perform FFT on input image
+  typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
   FFTFilterType::Pointer fftFilter = FFTFilterType::New();
-  fftFilter->SetInput(reader->GetOutput());
+
+  fftFilter->SetInput( reader->GetOutput() );
+
   fftFilter->Update();
+
+
   typedef FFTFilterType::OutputImageType ComplexImageType;
 
   // typedef itk::RieszFrequencyFunction<> FunctionType;
-  typedef itk::RieszFrequencyFilterBankGenerator< ComplexImageType> RieszFilterBankType;
+  typedef itk::RieszFrequencyFilterBankGenerator< ComplexImageType > RieszFilterBankType;
   RieszFilterBankType::Pointer filterBank = RieszFilterBankType::New();
-  filterBank->SetSize(fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize());
+
+  EXERCISE_BASIC_OBJECT_METHODS( filterBank, RieszFrequencyFilterBankGenerator,
+    GenerateImageSource );
+
+
+  filterBank->SetSize( fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize() );
+
   filterBank->Update();
 
   // Get real part of complex image for visualization
-  typedef itk::ComplexToRealImageFilter<ComplexImageType, ImageType> ComplexToRealFilter;
+  typedef itk::ComplexToRealImageFilter< ComplexImageType, ImageType > ComplexToRealFilter;
   ComplexToRealFilter::Pointer complexToRealFilter = ComplexToRealFilter::New();
-  std::cout << "Real Part of ComplexImage:" << std::endl;
-  for (unsigned int dir = 0; dir < ImageType::ImageDimension; dir++)
+  std::cout << "Real part of complex image:" << std::endl;
+  for( unsigned int dir = 0; dir < ImageType::ImageDimension; dir++ )
     {
     std::cout << "Direction: " << dir + 1 << " / " << ImageType::ImageDimension << std::endl;
-    complexToRealFilter->SetInput(filterBank->GetOutput(dir) );
+    complexToRealFilter->SetInput( filterBank->GetOutput( dir ) );
+
     complexToRealFilter->Update();
+
 #ifdef ITK_VISUALIZE_TESTS
-    itk::NumberToString<unsigned int> n2s;
-    Testing::ViewImage(complexToRealFilter->GetOutput(), "RealPart of Complex. Direction: " + n2s(
-                         dir + 1) + " / " + n2s(ImageType::ImageDimension));
+    itk::NumberToString< unsigned int > n2s;
+    Testing::ViewImage( complexToRealFilter->GetOutput(), "RealPart of Complex. Direction: " + n2s(
+                         dir + 1) + " / " + n2s( ImageType::ImageDimension ) );
 #endif
+
     }
   return EXIT_SUCCESS;
 }

--- a/test/itkVectorInverseFFTImageFilterTest.cxx
+++ b/test/itkVectorInverseFFTImageFilterTest.cxx
@@ -61,12 +61,13 @@ int itkVectorInverseFFTImageFilterTest(int argc, char* argv[])
   fftInverseFilter->SetInput(fftForwardFilter->GetOutput());
   fftInverseFilter->Update();
 
-  /***** Create VectorImages *****/
-  unsigned int num_components = 2;
+  // Create VectorImages
+  //
+  unsigned int numComponents = 2;
   // Create vector from forwardFFT.
   typedef itk::ComposeImageFilter<ComplexImageType> ComposeComplexFilterType;
   ComposeComplexFilterType::Pointer composeComplexFilter = ComposeComplexFilterType::New();
-  for(unsigned int c = 0; c < num_components; c++)
+  for( unsigned int c = 0; c < numComponents; c++ )
     {
     composeComplexFilter->SetInput(c, fftForwardFilter->GetOutput());
     }
@@ -88,17 +89,19 @@ int itkVectorInverseFFTImageFilterTest(int argc, char* argv[])
   DifferenceFilterType::Pointer differenceFilter = DifferenceFilterType::New();
   differenceFilter->SetToleranceRadius( 0 );
   differenceFilter->SetDifferenceThreshold( 0 );
-  for(unsigned int c = 0; c < num_components; c++ )
+  for( unsigned int c = 0; c < numComponents; c++ )
     {
     vectorCastFilter->SetIndex(c);
     vectorCastFilter->Update();
     differenceFilter->SetValidInput( fftInverseFilter->GetOutput() );
     differenceFilter->SetTestInput( vectorCastFilter->GetOutput() );
     differenceFilter->Update();
-    unsigned int wrong_pixels = differenceFilter->GetNumberOfPixelsWithDifferences();
-    if( wrong_pixels > 0 )
+    unsigned int numberOfDiffPixels = differenceFilter->GetNumberOfPixelsWithDifferences();
+    if( numberOfDiffPixels > 0 )
       {
-      std::cout << "The images are not equal, wrong_pixels= " << wrong_pixels << std::endl;
+      std::cerr << "Test failed! " << std::endl;
+      std::cerr << "Expected images to be equal, but got " << numberOfDiffPixels
+        << "unequal pixels" << std::endl;
       return EXIT_FAILURE;
       }
     }

--- a/test/itkWaveletFrequencyFilterBankGeneratorTest.cxx
+++ b/test/itkWaveletFrequencyFilterBankGeneratorTest.cxx
@@ -15,9 +15,7 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include <memory>
-#include <string>
-#include <cmath>
+
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
@@ -28,108 +26,126 @@
 #include "itkShannonIsotropicWavelet.h"
 #include "itkForwardFFTImageFilter.h"
 #include "itkInverseFFTImageFilter.h"
-#include <itkComplexToRealImageFilter.h>
-#include <itkImageRegionConstIterator.h>
-#include <itkNumberToString.h>
-// Visualize for dev/debug purposes. Set in cmake file. Require VTK
+#include "itkComplexToRealImageFilter.h"
+#include "itkImageRegionConstIterator.h"
+#include "itkNumberToString.h"
+#include "itkTestingMacros.h"
+
+#include <memory>
+#include <string>
+#include <cmath>
+
+// Visualize for dev/debug purposes. Set in cmake file. Requires VTK
 #ifdef ITK_VISUALIZE_TESTS
 #include "itkViewImage.h"
 #endif
-using namespace std;
-using namespace itk;
 
-template<unsigned int N, typename TWaveletFunction>
+
+template< unsigned int VDimension, typename TWaveletFunction >
 int runWaveletFrequencyFilterBankGeneratorTest( const std::string& inputImage,
                                                 const std::string& outputImage,
                                                 const unsigned int& inputBands)
 {
-  const unsigned int dimension = N;
+  const unsigned int Dimension = VDimension;
 
-  typedef float                            PixelType;
-  typedef itk::Image<PixelType, dimension> ImageType;
-  typedef itk::ImageFileReader<ImageType>  ReaderType;
+  typedef float                               PixelType;
+  typedef itk::Image< PixelType, Dimension >  ImageType;
+  typedef itk::ImageFileReader< ImageType >   ReaderType;
+
   typename ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(inputImage);
+
+  reader->SetFileName( inputImage );
+
   reader->Update();
+
   reader->UpdateLargestPossibleRegion();
 
   // Perform FFT on input image.
   typedef itk::ForwardFFTImageFilter<ImageType> FFTFilterType;
   typename FFTFilterType::Pointer fftFilter = FFTFilterType::New();
+
   fftFilter->SetInput(reader->GetOutput());
+
   fftFilter->Update();
+
   typedef typename FFTFilterType::OutputImageType ComplexImageType;
 
-  typedef TWaveletFunction                                                                 WaveletFunctionType;
-  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, WaveletFunctionType> WaveletFilterBankType;
+  typedef TWaveletFunction WaveletFunctionType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, WaveletFunctionType >
+    WaveletFilterBankType;
+
   typename WaveletFilterBankType::Pointer forwardFilterBank = WaveletFilterBankType::New();
-  unsigned int high_sub_bands = inputBands;
-  forwardFilterBank->SetHighPassSubBands(high_sub_bands);
-  forwardFilterBank->SetSize(fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize());
+
+  unsigned int highSubBands = inputBands;
+  forwardFilterBank->SetHighPassSubBands( highSubBands );
+
+  forwardFilterBank->SetSize( fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize() );
+
   forwardFilterBank->Update();
   // forwardFilterBank->Print(std::cout);
 
   // Get real part of complex image for visualization
-  typedef itk::ComplexToRealImageFilter<ComplexImageType, ImageType> ComplexToRealFilter;
+  typedef itk::ComplexToRealImageFilter< ComplexImageType, ImageType > ComplexToRealFilter;
   typename ComplexToRealFilter::Pointer complexToRealFilter = ComplexToRealFilter::New();
-  std::cout << "Real Part of ComplexImage:" << std::endl;
-  for (unsigned int i = 0; i < high_sub_bands + 1; ++i)
+
+  std::cout << "Real part of complex image:" << std::endl;
+  for( unsigned int i = 0; i < highSubBands + 1; ++i )
     {
-    std::cout << "Band: " << i << " / " << forwardFilterBank->GetHighPassSubBands() << std::endl;
+    std::cout << "Band #: " << i << " / " << forwardFilterBank->GetHighPassSubBands() << std::endl;
     // std::cout << "Largest Region: " << forwardFilterBank->GetOutput(i)->GetLargestPossibleRegion() << std::endl;
 
-    complexToRealFilter->SetInput(forwardFilterBank->GetOutput(i) );
+    complexToRealFilter->SetInput( forwardFilterBank->GetOutput(i) );
     complexToRealFilter->Update();
+
 #ifdef ITK_VISUALIZE_TESTS
-    itk::NumberToString<unsigned int> n2s;
-    Testing::ViewImage(complexToRealFilter->GetOutput(),
-                       "RealPart of Complex. Band: " + n2s(i) + "/" + n2s(high_sub_bands));
+    itk::NumberToString< unsigned int > n2s;
+    Testing::ViewImage( complexToRealFilter->GetOutput(),
+                       "RealPart of Complex. Band: " + n2s(i) + "/" + n2s( highSubBands ) );
 #endif
     }
-  // Write only the last band.
-  typedef itk::ImageFileWriter<ImageType> WriterType;
+
+  // Write only the last band
+  typedef itk::ImageFileWriter< ImageType > WriterType;
   typename WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( outputImage );
   writer->SetInput( complexToRealFilter->GetOutput() );
-  try
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
-    std::cerr << "Error writing the last band of WaveletFrequencyFilterBankGeneratorTest: " << std::endl;
-    std::cerr << error << std::endl;
-    return EXIT_FAILURE;
-    }
+
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
   // Inverse FFT Transform
-  typedef itk::InverseFFTImageFilter<ComplexImageType, ImageType> InverseFFTFilterType;
+  typedef itk::InverseFFTImageFilter< ComplexImageType, ImageType >
+    InverseFFTFilterType;
   typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();
-  std::cout << "InverseFFT:"  << std::endl;
-  for (unsigned int i = 0; i < high_sub_bands + 1; ++i)
+  std::cout << "InverseFFT:" << std::endl;
+  for( unsigned int i = 0; i < highSubBands + 1; ++i )
     {
-    std::cout << "Band: " << i << " / " << forwardFilterBank->GetHighPassSubBands() << std::endl;
-    inverseFFT->SetInput(forwardFilterBank->GetOutput(i) );
+    std::cout << "Band #: " << i << " / " << forwardFilterBank->GetHighPassSubBands() << std::endl;
+    inverseFFT->SetInput( forwardFilterBank->GetOutput(i) );
     inverseFFT->Update();
+
 #ifdef ITK_VISUALIZE_TESTS
-    itk::NumberToString<unsigned int> n2s;
-    Testing::ViewImage(inverseFFT->GetOutput(), "InverseFFT. Band: " + n2s(i) + "/" + n2s(high_sub_bands));
+    itk::NumberToString< unsigned int > n2s;
+    Testing::ViewImage( inverseFFT->GetOutput(), "InverseFFT. Band: " + n2s(i) + "/" + n2s( highSubBands ) );
 #endif
     }
 
   // Create a new filter for the inverse Filter Bank
   // TODO if you just change the InverseFlag, the output already generated by the filter will get overriden, and trigger the pipeline.
-  typename WaveletFilterBankType::Pointer inverseFilterBank = WaveletFilterBankType::New();
-  inverseFilterBank->SetInverseBank(true);
-  inverseFilterBank->SetHighPassSubBands(high_sub_bands);
-  inverseFilterBank->SetSize(fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize());
+  typename WaveletFilterBankType::Pointer inverseFilterBank =
+    WaveletFilterBankType::New();
+
+  inverseFilterBank->SetInverseBank( true );
+  inverseFilterBank->SetHighPassSubBands( highSubBands );
+  inverseFilterBank->SetSize
+    ( fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize() );
+
   inverseFilterBank->Update();
 
   // Compare images: TODO use itk test facilities instead of region iterators?
   // itk::Testing::ComparisonImageFilter does not work with complex
   typedef itk::ImageRegionConstIterator<ComplexImageType> ComplexConstRegionIterator;
   unsigned int ne = 0;
-  for (unsigned int i = 0; i < high_sub_bands + 1; ++i)
+  for( unsigned int i = 0; i < highSubBands + 1; ++i )
     {
     typename ComplexImageType::Pointer outForward = forwardFilterBank->GetOutput(i);
     typename ComplexImageType::Pointer outInverse = inverseFilterBank->GetOutput(i);
@@ -137,24 +153,34 @@ int runWaveletFrequencyFilterBankGeneratorTest( const std::string& inputImage,
     ComplexConstRegionIterator itInverse(outInverse, outInverse->GetLargestPossibleRegion() );
     itForward.GoToBegin();
     itInverse.GoToBegin();
-    unsigned int ne_per_band = 0;
-    while(!itForward.IsAtEnd() || !itInverse.IsAtEnd())
+    unsigned int nePerBand = 0;
+    while( !itForward.IsAtEnd() || !itInverse.IsAtEnd() )
       {
-      if(itForward.Get() != itInverse.Get())
-        ++ne_per_band;
+      if( itForward.Get() != itInverse.Get() )
+        {
+        ++nePerBand;
+        }
       ++itForward;
       ++itInverse;
       }
-    ne += ne_per_band;
+    ne += nePerBand;
     }
-  if (ne > 0 )
-    std::cout << "Comparison Error, num of errors: " << ne << '\n';
+
+  if( ne > 0 )
+    {
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Comparison error: number of errors: " << ne << std::endl;
+    return EXIT_FAILURE;
+    }
   else
-    std::cout << "Pass! no comparison errors: " << ne << '\n';
+    {
+    std::cout << "No comparison errors: " << ne << " errors" << std::endl;
+    }
+
   return EXIT_SUCCESS;
 }
 
-int itkWaveletFrequencyFilterBankGeneratorTest(int argc, char *argv[])
+int itkWaveletFrequencyFilterBankGeneratorTest( int argc, char *argv[] )
 {
   if( argc < 5 || argc > 6 )
     {
@@ -162,55 +188,144 @@ int itkWaveletFrequencyFilterBankGeneratorTest(int argc, char *argv[])
               << " inputImage outputImage inputBands waveletFunction [dimension]" << std::endl;
     return EXIT_FAILURE;
     }
-  const string inputImage  = argv[1];
-  const string outputImage = argv[2];
-  const unsigned int inputBands = atoi(argv[3]);
-  const string waveletFunction  = argv[4];
+  const std::string inputImage  = argv[1];
+  const std::string outputImage = argv[2];
+  const unsigned int inputBands = atoi( argv[3] );
+  const std::string waveletFunction  = argv[4];
 
   unsigned int dimension = 3;
   if( argc == 6 )
     {
     dimension = atoi( argv[5] );
     }
+
+  const unsigned int ImageDimension = 2;
+  typedef double                                          PixelType;
+  typedef std::complex< PixelType >                       ComplexPixelType;
+  typedef itk::Point< PixelType, ImageDimension >         PointType;
+  typedef itk::Image< PixelType, ImageDimension >         ImageType;
+  typedef itk::Image< ComplexPixelType, ImageDimension >  ComplexImageType;
+
+  // Exercise basic object methods
+  // Done outside the helper function in the test because GCC is limited
+  // when calling overloaded base class functions.
+  typedef itk::HeldIsotropicWavelet< PixelType, ImageDimension, PointType >
+    HeldIsotropicWaveletType;
+  typedef itk::VowIsotropicWavelet< PixelType, ImageDimension, PointType >
+    VowIsotropicWaveletType;
+  typedef itk::SimoncelliIsotropicWavelet< PixelType, ImageDimension, PointType >
+    SimoncelliIsotropicWaveletType;
+  typedef itk::ShannonIsotropicWavelet< PixelType, ImageDimension, PointType >
+    ShannonIsotropicWaveletType;
+
+  HeldIsotropicWaveletType::Pointer heldIsotropicWavelet =
+    HeldIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( heldIsotropicWavelet, HeldIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+  VowIsotropicWaveletType::Pointer vowIsotropicWavelet =
+    VowIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( vowIsotropicWavelet, VowIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+  SimoncelliIsotropicWaveletType::Pointer simoncellidIsotropicWavelet =
+    SimoncelliIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( simoncellidIsotropicWavelet, SimoncelliIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+  ShannonIsotropicWaveletType::Pointer shannonIsotropicWavelet = ShannonIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( shannonIsotropicWavelet, ShannonIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+
   typedef itk::HeldIsotropicWavelet<>       HeldWavelet;
   typedef itk::VowIsotropicWavelet<>        VowWavelet;
   typedef itk::SimoncelliIsotropicWavelet<> SimoncelliWavelet;
   typedef itk::ShannonIsotropicWavelet<>    ShannonWavelet;
 
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, HeldWavelet >
+    HeldWaveletFilterBankType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, VowWavelet >
+    VowWaveletFilterBankType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, SimoncelliWavelet >
+    SimoncelliWaveletFilterBankType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, ShannonWavelet >
+    ShannonWaveletFilterBankType;
+
+  HeldWaveletFilterBankType::Pointer heldWaveletFilterBankGenerator =
+    HeldWaveletFilterBankType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( heldWaveletFilterBankGenerator,
+    WaveletFrequencyFilterBankGenerator, GenerateImageSource );
+
+  VowWaveletFilterBankType::Pointer vowWaveletFilterBankGenerator =
+    VowWaveletFilterBankType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( vowWaveletFilterBankGenerator,
+    WaveletFrequencyFilterBankGenerator, GenerateImageSource );
+
+  SimoncelliWaveletFilterBankType::Pointer simoncelliWaveletFilterBankGenerator =
+    SimoncelliWaveletFilterBankType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( simoncelliWaveletFilterBankGenerator,
+    WaveletFrequencyFilterBankGenerator, GenerateImageSource );
+
+  ShannonWaveletFilterBankType::Pointer shannonWaveletFilterBankGenerator =
+    ShannonWaveletFilterBankType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( shannonWaveletFilterBankGenerator,
+    WaveletFrequencyFilterBankGenerator, GenerateImageSource );
+
+
   if( dimension == 2 )
     {
-    if (waveletFunction == "Held")
-      return runWaveletFrequencyFilterBankGeneratorTest<2, HeldWavelet>(inputImage, outputImage, inputBands);
-    else if (waveletFunction == "Vow")
-      return runWaveletFrequencyFilterBankGeneratorTest<2, VowWavelet>(inputImage, outputImage, inputBands);
-    else if (waveletFunction == "Simoncelli")
-      return runWaveletFrequencyFilterBankGeneratorTest<2, SimoncelliWavelet>(inputImage, outputImage, inputBands);
-    else if (waveletFunction == "Shannon")
-      return runWaveletFrequencyFilterBankGeneratorTest<2, ShannonWavelet>(inputImage, outputImage, inputBands);
+    if( waveletFunction == "Held" )
+      {
+      return runWaveletFrequencyFilterBankGeneratorTest< 2, HeldWavelet >( inputImage, outputImage, inputBands );
+      }
+    else if( waveletFunction == "Vow" )
+      {
+      return runWaveletFrequencyFilterBankGeneratorTest< 2, VowWavelet >( inputImage, outputImage, inputBands );
+      }
+    else if( waveletFunction == "Simoncelli" )
+      {
+      return runWaveletFrequencyFilterBankGeneratorTest< 2, SimoncelliWavelet >(inputImage, outputImage, inputBands );
+      }
+    else if( waveletFunction == "Shannon" )
+      {
+      return runWaveletFrequencyFilterBankGeneratorTest< 2, ShannonWavelet >( inputImage, outputImage, inputBands );
+      }
     else
       {
-      std::cerr << argv[4] << " is an unknown wavelet type " << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << argv[4] << " wavelet type not supported." << std::endl;
       return EXIT_FAILURE;
       }
     }
   else if( dimension == 3 )
     {
-    if (waveletFunction == "Held")
-      return runWaveletFrequencyFilterBankGeneratorTest<3, HeldWavelet>(inputImage, outputImage, inputBands);
-    else if (waveletFunction == "Vow")
-      return runWaveletFrequencyFilterBankGeneratorTest<3, VowWavelet>(inputImage, outputImage, inputBands);
-    else if (waveletFunction == "Simoncelli")
-      return runWaveletFrequencyFilterBankGeneratorTest<3, SimoncelliWavelet>(inputImage, outputImage, inputBands);
-    else if (waveletFunction == "Shannon")
-      return runWaveletFrequencyFilterBankGeneratorTest<3, ShannonWavelet>(inputImage, outputImage, inputBands);
+    if( waveletFunction == "Held" )
+      {
+      return runWaveletFrequencyFilterBankGeneratorTest< 3, HeldWavelet >( inputImage, outputImage, inputBands );
+      }
+    else if( waveletFunction == "Vow" )
+      {
+      return runWaveletFrequencyFilterBankGeneratorTest< 3, VowWavelet >( inputImage, outputImage, inputBands );
+      }
+    else if( waveletFunction == "Simoncelli" )
+      {
+      return runWaveletFrequencyFilterBankGeneratorTest< 3, SimoncelliWavelet >( inputImage, outputImage, inputBands );
+      }
+    else if( waveletFunction == "Shannon" )
+      {
+      return runWaveletFrequencyFilterBankGeneratorTest< 3, ShannonWavelet >( inputImage, outputImage, inputBands );
+      }
     else
       {
-      std::cerr << argv[4] << " is an unknown wavelet type " << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << argv[4] << " wavelet type not supported." << std::endl;
       return EXIT_FAILURE;
       }
     }
   else
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error: only 2 or 3 dimensions allowed, " << dimension << " selected." << std::endl;
     return EXIT_FAILURE;
     }

--- a/test/itkWaveletFrequencyForwardTest.cxx
+++ b/test/itkWaveletFrequencyForwardTest.cxx
@@ -15,9 +15,7 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include <memory>
-#include <string>
-#include <cmath>
+
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
@@ -29,194 +27,223 @@
 #include "itkShannonIsotropicWavelet.h"
 #include "itkForwardFFTImageFilter.h"
 #include "itkInverseFFTImageFilter.h"
-#include <itkComplexToRealImageFilter.h>
+#include "itkComplexToRealImageFilter.h"
 #include "itkNumberToString.h"
-// Visualize for dev/debug purposes. Set in cmake file. Require VTK
+#include "itkTestingMacros.h"
+
+#include <memory>
+#include <string>
+#include <cmath>
+
+// Visualize for dev/debug purposes. Set in cmake file. Requires VTK
 #ifdef ITK_VISUALIZE_TESTS
 #include "itkViewImage.h"
 #endif
-using namespace std;
-using namespace itk;
 
-std::string append_to_filename(const std::string& filename, const std::string & appendix)
+
+std::string AppendToFilename(const std::string& filename, const std::string & appendix)
 {
-  std::size_t found_dot = filename.find_last_of('.');
-  return filename.substr(0, found_dot) + appendix + filename.substr(found_dot);
+  std::size_t foundDot = filename.find_last_of('.');
+  return filename.substr( 0, foundDot ) + appendix + filename.substr( foundDot );
 }
 
-template<unsigned int N, typename TWaveletFunction>
+template< unsigned int VDimension, typename TWaveletFunction >
 int runWaveletFrequencyForwardTest( const std::string& inputImage,
                                     const std::string& outputImage,
                                     const unsigned int& inputLevels,
                                     const unsigned int& inputBands)
 {
-  const unsigned int dimension = N;
+  const unsigned int Dimension = VDimension;
 
-  typedef float                            PixelType;
-  typedef itk::Image<PixelType, dimension> ImageType;
-  typedef itk::ImageFileReader<ImageType>  ReaderType;
+  typedef float                               PixelType;
+  typedef itk::Image< PixelType, Dimension >  ImageType;
+  typedef itk::ImageFileReader< ImageType >   ReaderType;
+
   typename ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(inputImage);
+
+  reader->SetFileName( inputImage );
+
   reader->Update();
-  reader->UpdateLargestPossibleRegion();
 
   // Perform FFT on input image.
-  typedef itk::ForwardFFTImageFilter<ImageType> FFTFilterType;
+  typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
   typename FFTFilterType::Pointer fftFilter = FFTFilterType::New();
-  fftFilter->SetInput(reader->GetOutput());
+
+  fftFilter->SetInput( reader->GetOutput() );
+
   typedef typename FFTFilterType::OutputImageType ComplexImageType;
 
   // Set the WaveletFunctionType and the WaveletFilterBank
-  typedef TWaveletFunction                                                                        WaveletFunctionType;
-  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, WaveletFunctionType>        WaveletFilterBankType;
-  typedef itk::WaveletFrequencyForward<ComplexImageType, ComplexImageType, WaveletFilterBankType> ForwardWaveletType;
+  typedef TWaveletFunction WaveletFunctionType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, WaveletFunctionType >
+    WaveletFilterBankType;
+  typedef itk::WaveletFrequencyForward< ComplexImageType, ComplexImageType, WaveletFilterBankType >
+    ForwardWaveletType;
+
   typename ForwardWaveletType::Pointer forwardWavelet = ForwardWaveletType::New();
-  unsigned int high_sub_bands = inputBands;
+
+  unsigned int highSubBands = inputBands;
+
   unsigned int levels = inputLevels;
-  forwardWavelet->SetHighPassSubBands(high_sub_bands);
+
+  forwardWavelet->SetHighPassSubBands( highSubBands );
+
   forwardWavelet->SetLevels(levels);
   forwardWavelet->SetInput(fftFilter->GetOutput());
-  forwardWavelet->Print(std::cout);
+
   forwardWavelet->Update();
 
   unsigned int ne = 0;
-  // TEST INTERFACE:
+
+  // Regression tests
   typedef typename ForwardWaveletType::OutputsType OutputsType;
-  OutputsType all_outputs =
+  OutputsType allOutputs =
     forwardWavelet->GetOutputs();
-  if( all_outputs.size() != forwardWavelet->GetTotalOutputs() )
+  unsigned int expectedNumberOfOutputs = forwardWavelet->GetTotalOutputs();
+  unsigned int computedNumberOfOutputs = forwardWavelet->GetOutputs().size();
+  if( computedNumberOfOutputs != expectedNumberOfOutputs )
     {
-    std::cout << "Error all_outputs" << '\n';
+    std::cerr << "Error in GetTotalOutputs()" << std::endl;
+    std::cerr << "Expected: " << expectedNumberOfOutputs << ", but got "
+      << computedNumberOfOutputs << std::endl;
     ++ne;
     }
 
-  typename ForwardWaveletType::OutputImagePointer low_pass =
+  typename ForwardWaveletType::OutputImagePointer lowPass =
     forwardWavelet->GetOutputLowPass();
-  OutputsType all_high_sub_bands = forwardWavelet->GetOutputsHighPass();
-  if( all_high_sub_bands.size() != forwardWavelet->GetTotalOutputs()  - 1)
+
+  OutputsType allHighSubBands = forwardWavelet->GetOutputsHighPass();
+  unsigned int expectedNumberOfHighSubBands =
+    forwardWavelet->GetTotalOutputs() - 1;
+  unsigned int computedNumberOfHighSubBands =
+    forwardWavelet->GetOutputsHighPass().size();
+  if( computedNumberOfHighSubBands != expectedNumberOfHighSubBands )
     {
-    std::cout << "Error all_high_sub_bands" << '\n';
-    ++ne;
-    }
-  OutputsType high_sub_bands_per_level = forwardWavelet->GetOutputsHighPassByLevel(0);
-  if( high_sub_bands_per_level.size() != forwardWavelet->GetHighPassSubBands())
-    {
-    std::cout << "Error high_sub_bands_per_level" << '\n';
+    std::cerr << "Error in GetOutputsHighPass()" << std::endl;
+    std::cerr << "Expected: " << expectedNumberOfHighSubBands << ", but got "
+      << computedNumberOfHighSubBands << std::endl;
     ++ne;
     }
 
-  for (unsigned int nout = 0; nout < forwardWavelet->GetNumberOfOutputs(); ++nout)
+  OutputsType highSubBandsPerLevel = forwardWavelet->GetOutputsHighPassByLevel(0);
+  unsigned int expectedNumberOfHighSubBandsPerLevel =
+    forwardWavelet->GetHighPassSubBands();
+  unsigned int computedNumberOfHighSubBandsPerLevel =
+    forwardWavelet->GetOutputsHighPassByLevel( 0 ).size();
+  if( computedNumberOfHighSubBandsPerLevel != expectedNumberOfHighSubBandsPerLevel )
     {
-    std::pair<unsigned int, unsigned int> pairLvBand =
-      forwardWavelet->OutputIndexToLevelBand(nout);
+    std::cerr << "Error in GetOutputsHighPassByLevel()" << std::endl;
+    std::cerr << "Expected: " << expectedNumberOfHighSubBandsPerLevel << ", but got "
+      << computedNumberOfHighSubBandsPerLevel << std::endl;
+    ++ne;
+    }
+
+  for( unsigned int i = 0; i < forwardWavelet->GetNumberOfOutputs(); ++i )
+    {
+    std::pair< unsigned int, unsigned int > pairLvBand =
+      forwardWavelet->OutputIndexToLevelBand( i );
     unsigned int lv = pairLvBand.first;
     unsigned int b  = pairLvBand.second;
-    std::cout << "InputIndex: " << nout << " --> lv:" << lv << " b:" << b << std::endl;
+    std::cout << "InputIndex: " << i << " --> lv:" << lv << " b:" << b << std::endl;
     }
 
-  /* test OutputIndexToLevelBand */
+  // Test OutputIndexToLevelBand
     {
-    std::pair<unsigned int, unsigned int> pairLvBand =
-      forwardWavelet->OutputIndexToLevelBand(0);
+    std::pair< unsigned int, unsigned int > pairLvBand =
+      forwardWavelet->OutputIndexToLevelBand( 0 );
     unsigned int lv = pairLvBand.first;
     unsigned int b  = pairLvBand.second;
     std::cout << "inputindex: " << 0 << " lv:" << lv << " b:" << b << std::endl;
-    if (lv != levels || b != 0)
+    if( lv != levels || b != 0 )
+      {
       ++ne;
+      }
     }
     {
-    std::pair<unsigned int, unsigned int> pairLvBand =
-      forwardWavelet->OutputIndexToLevelBand(high_sub_bands);
+    std::pair< unsigned int, unsigned int > pairLvBand =
+      forwardWavelet->OutputIndexToLevelBand( highSubBands );
     unsigned int lv = pairLvBand.first;
     unsigned int b  = pairLvBand.second;
-    std::cout << "inputindex: " << high_sub_bands << " lv:" << lv << " b:" << b << std::endl;
-    if (lv != 1 || b != high_sub_bands)
+    std::cout << "inputindex: " << highSubBands << " lv:" << lv << " b:" << b << std::endl;
+    if( lv != 1 || b != highSubBands )
+      {
       ++ne;
+      }
     }
-  if (ne != 0)
+  if( ne != 0 )
     {
-    std::cout << "ERROR in OutputIndexToLevelBand" << std::endl;
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in OutputIndexToLevelBand" << std::endl;
     return EXIT_FAILURE;
     }
 
   // Inverse FFT Transform (Multilevel)
-  typedef itk::InverseFFTImageFilter<ComplexImageType, ImageType> InverseFFTFilterType;
+  typedef itk::InverseFFTImageFilter< ComplexImageType, ImageType > InverseFFTFilterType;
   typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();
-  typedef itk::ImageFileWriter<typename InverseFFTFilterType::OutputImageType> WriterType;
+
+  typedef itk::ImageFileWriter< typename InverseFFTFilterType::OutputImageType > WriterType;
   typename WriterType::Pointer writer = WriterType::New();
-  itk::NumberToString<unsigned int> n2s;
-  for (unsigned int level = 0; level < levels; ++level)
+
+  itk::NumberToString< unsigned int > n2s;
+  for( unsigned int level = 0; level < levels; ++level )
     {
-    for (unsigned int band = 0; band < high_sub_bands; ++band)
+    for( unsigned int band = 0; band < highSubBands; ++band )
       {
-      if (level == 0 && band == 0) // Low pass
+      if( level == 0 && band == 0 ) // Low pass
         {
-        unsigned int n_output = 0;
-        std::cout << "OutputIndex : " << n_output << std::endl;
+        unsigned int nOutput = 0;
+        std::cout << "OutputIndex : " << nOutput << std::endl;
         std::cout << "Level: " << level + 1 << " / " << forwardWavelet->GetLevels() << std::endl;
         std::cout << "Band: " << band  << " / " << forwardWavelet->GetHighPassSubBands() << std::endl;
-        std::cout << "Largest Region: " << forwardWavelet->GetOutput(n_output)->GetLargestPossibleRegion() << std::endl;
-        std::cout << "Origin: " << forwardWavelet->GetOutput(n_output)->GetOrigin() << std::endl;
-        std::cout << "Spacing: " << forwardWavelet->GetOutput(n_output)->GetSpacing() << std::endl;
+        std::cout << "Largest Region: " << forwardWavelet->GetOutput( nOutput )->GetLargestPossibleRegion() << std::endl;
+        std::cout << "Origin: " << forwardWavelet->GetOutput( nOutput )->GetOrigin() << std::endl;
+        std::cout << "Spacing: " << forwardWavelet->GetOutput( nOutput )->GetSpacing() << std::endl;
 
-        inverseFFT->SetInput(forwardWavelet->GetOutput(n_output) );
+        inverseFFT->SetInput(forwardWavelet->GetOutput( nOutput ) );
+
         inverseFFT->Update();
+
 #ifdef ITK_VISUALIZE_TESTS
-        Testing::ViewImage(inverseFFT->GetOutput(),
-                           "Approx coef. n_out: " + n2s(n_output) + " level: " + n2s(levels) + ", band:0/"
-                           + n2s(inputBands));
+        Testing::ViewImage( inverseFFT->GetOutput(),
+                           "Approx coef. n_out: " + n2s( nOutput ) + " level: " + n2s( levels ) + ", band:0/"
+                           + n2s( inputBands ));
 #endif
-        writer->SetFileName(append_to_filename(outputImage, n2s(n_output)) );
-        writer->SetInput(inverseFFT->GetOutput());
-        try
-          {
-          writer->Update();
-          }
-        catch( itk::ExceptionObject & error )
-          {
-          std::cerr << "Error writing the WaveletForward image: " << std::endl;
-          std::cerr << error << std::endl;
-          return EXIT_FAILURE;
-          }
+        writer->SetFileName( AppendToFilename( outputImage, n2s(nOutput) ) );
+        writer->SetInput( inverseFFT->GetOutput() );
+
+        TRY_EXPECT_NO_EXCEPTION( writer->Update() );
         }
-      unsigned int n_output = 1 + level * forwardWavelet->GetHighPassSubBands() + band;
-      std::cout << "OutputIndex : " << n_output << std::endl;
+      unsigned int nOutput = 1 + level * forwardWavelet->GetHighPassSubBands() + band;
+      std::cout << "OutputIndex : " << nOutput << std::endl;
       std::cout << "Level: " << level + 1 << " / " << forwardWavelet->GetLevels() << std::endl;
       std::cout << "Band: " << band + 1 << " / " << forwardWavelet->GetHighPassSubBands() << std::endl;
-      std::cout << "Largest Region: " << forwardWavelet->GetOutput(n_output)->GetLargestPossibleRegion() << std::endl;
-      std::cout << "Origin: " << forwardWavelet->GetOutput(n_output)->GetOrigin() << std::endl;
-      std::cout << "Spacing: " << forwardWavelet->GetOutput(n_output)->GetSpacing() << std::endl;
+      std::cout << "Largest Region: " << forwardWavelet->GetOutput( nOutput )->GetLargestPossibleRegion() << std::endl;
+      std::cout << "Origin: " << forwardWavelet->GetOutput( nOutput )->GetOrigin() << std::endl;
+      std::cout << "Spacing: " << forwardWavelet->GetOutput( nOutput )->GetSpacing() << std::endl;
 
-      inverseFFT->SetInput(forwardWavelet->GetOutput(n_output) );
+      inverseFFT->SetInput( forwardWavelet->GetOutput( nOutput ) );
+
       inverseFFT->Update();
+
 #ifdef ITK_VISUALIZE_TESTS
-      std::pair<unsigned int, unsigned int> pairLvBand =
-        forwardWavelet->OutputIndexToLevelBand(n_output);
-      Testing::ViewImage(inverseFFT->GetOutput(),
-                         "Wavelet coef. n_out: " + n2s(n_output) + " level: " + n2s(pairLvBand.first)
-                         + " , band: " +  n2s(pairLvBand.second) + "/" + n2s(inputBands) );
+      std::pair< unsigned int, unsigned int > pairLvBand =
+        forwardWavelet->OutputIndexToLevelBand( nOutput );
+      Testing::ViewImage( inverseFFT->GetOutput(),
+                         "Wavelet coef. n_out: " + n2s( nOutput ) + " level: " + n2s( pairLvBand.first )
+                         + " , band: " +  n2s( pairLvBand.second ) + "/" + n2s( inputBands ) );
 
 #endif
-      writer->SetFileName(append_to_filename(outputImage, n2s(n_output)) );
-      writer->SetInput(inverseFFT->GetOutput());
+      writer->SetFileName( AppendToFilename( outputImage, n2s( nOutput ) ) );
+      writer->SetInput( inverseFFT->GetOutput() );
 
-      try
-        {
-        writer->Update();
-        }
-      catch( itk::ExceptionObject & error )
-        {
-        std::cerr << "Error writing the WaveletForward image: " << std::endl;
-        std::cerr << error << std::endl;
-        return EXIT_FAILURE;
-        }
+      TRY_EXPECT_NO_EXCEPTION( writer->Update() );
       }
     }
 
   return EXIT_SUCCESS;
 }
 
-int itkWaveletFrequencyForwardTest(int argc, char *argv[])
+int itkWaveletFrequencyForwardTest( int argc, char *argv[] )
 {
   if( argc < 6 || argc > 7 )
     {
@@ -224,55 +251,149 @@ int itkWaveletFrequencyForwardTest(int argc, char *argv[])
               << " inputImage outputImage inputLevels inputBands waveletFunction [dimension]" << std::endl;
     return EXIT_FAILURE;
     }
-  const string inputImage  = argv[1];
-  const string outputImage = argv[2];
-  const unsigned int inputLevels = atoi(argv[3]);
-  const unsigned int inputBands  = atoi(argv[4]);
-  const string waveletFunction   = argv[5];
+  const std::string inputImage  = argv[1];
+  const std::string outputImage = argv[2];
+  const unsigned int inputLevels = atoi (argv[3] );
+  const unsigned int inputBands  = atoi( argv[4] );
+  const std::string waveletFunction = argv[5];
+
   unsigned int dimension = 3;
   if( argc == 7 )
     {
     dimension = atoi( argv[6] );
     }
 
+  const unsigned int ImageDimension = 3;
+  typedef double                                          PixelType;
+  typedef std::complex< PixelType >                       ComplexPixelType;
+  typedef itk::Point< PixelType, ImageDimension >         PointType;
+  typedef itk::Image< PixelType, ImageDimension >         ImageType;
+  typedef itk::Image< ComplexPixelType, ImageDimension >  ComplexImageType;
+
+  // Exercise basic object methods
+  // Done outside the helper function in the test because GCC is limited
+  // when calling overloaded base class functions.
+  typedef itk::HeldIsotropicWavelet< PixelType, ImageDimension, PointType >
+    HeldIsotropicWaveletType;
+  typedef itk::VowIsotropicWavelet< PixelType, ImageDimension, PointType >
+    VowIsotropicWaveletType;
+  typedef itk::SimoncelliIsotropicWavelet< PixelType, ImageDimension, PointType >
+    SimoncelliIsotropicWaveletType;
+  typedef itk::ShannonIsotropicWavelet< PixelType, ImageDimension, PointType >
+    ShannonIsotropicWaveletType;
+
+  HeldIsotropicWaveletType::Pointer heldIsotropicWavelet =
+    HeldIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( heldIsotropicWavelet, HeldIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+  VowIsotropicWaveletType::Pointer vowIsotropicWavelet =
+    VowIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( vowIsotropicWavelet, VowIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+  SimoncelliIsotropicWaveletType::Pointer simoncellidIsotropicWavelet =
+    SimoncelliIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( simoncellidIsotropicWavelet, SimoncelliIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+  ShannonIsotropicWaveletType::Pointer shannonIsotropicWavelet = ShannonIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( shannonIsotropicWavelet, ShannonIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+
   typedef itk::HeldIsotropicWavelet<>       HeldWavelet;
   typedef itk::VowIsotropicWavelet<>        VowWavelet;
   typedef itk::SimoncelliIsotropicWavelet<> SimoncelliWavelet;
   typedef itk::ShannonIsotropicWavelet<>    ShannonWavelet;
+
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, HeldWavelet >
+    HeldWaveletFilterBankType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, VowWavelet >
+    VowWaveletFilterBankType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, SimoncelliWavelet >
+    SimoncelliWaveletFilterBankType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, ShannonWavelet >
+    ShannonWaveletFilterBankType;
+
+  typedef itk::WaveletFrequencyForward< ComplexImageType, ComplexImageType, HeldWaveletFilterBankType >
+    HeldForwardWaveletType;
+  HeldForwardWaveletType::Pointer heldForwardWavelet = HeldForwardWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( heldForwardWavelet, WaveletFrequencyForward,
+    ImageToImageFilter );
+
+  typedef itk::WaveletFrequencyForward< ComplexImageType, ComplexImageType, VowWaveletFilterBankType >
+    VowForwardWaveletType;
+  VowForwardWaveletType::Pointer vowForwardWavelet = VowForwardWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( vowForwardWavelet, WaveletFrequencyForward,
+    ImageToImageFilter );
+
+  typedef itk::WaveletFrequencyForward< ComplexImageType, ComplexImageType, SimoncelliWaveletFilterBankType >
+    SimoncelliForwardWaveletType;
+  SimoncelliForwardWaveletType::Pointer simoncelliForwardWavelet = SimoncelliForwardWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( simoncelliForwardWavelet, WaveletFrequencyForward,
+    ImageToImageFilter );
+
+  typedef itk::WaveletFrequencyForward< ComplexImageType, ComplexImageType, HeldWaveletFilterBankType >
+    ShannonForwardWaveletType;
+  HeldForwardWaveletType::Pointer shannonForwardWavelet = ShannonForwardWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( shannonForwardWavelet, WaveletFrequencyForward,
+    ImageToImageFilter );
+
+
   if( dimension == 2 )
     {
-    if (waveletFunction == "Held")
-      return runWaveletFrequencyForwardTest<2, HeldWavelet>(inputImage, outputImage, inputLevels, inputBands);
-    else if (waveletFunction == "Vow")
-      return runWaveletFrequencyForwardTest<2, VowWavelet>(inputImage, outputImage, inputLevels, inputBands);
-    else if (waveletFunction == "Simoncelli")
-      return runWaveletFrequencyForwardTest<2, SimoncelliWavelet>(inputImage, outputImage, inputLevels, inputBands);
-    else if (waveletFunction == "Shannon")
-      return runWaveletFrequencyForwardTest<2, ShannonWavelet>(inputImage, outputImage, inputLevels, inputBands);
+    if( waveletFunction == "Held" )
+      {
+      return runWaveletFrequencyForwardTest< 2, HeldWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if( waveletFunction == "Vow" )
+      {
+      return runWaveletFrequencyForwardTest< 2, VowWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if( waveletFunction == "Simoncelli" )
+      {
+      return runWaveletFrequencyForwardTest< 2, SimoncelliWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if( waveletFunction == "Shannon" )
+      {
+      return runWaveletFrequencyForwardTest< 2, ShannonWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
     else
       {
-      std::cerr << argv[5] << " is an unknown wavelet type " << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << argv[5] << " wavelet type not supported." << std::endl;
       return EXIT_FAILURE;
       }
     }
   else if( dimension == 3 )
     {
-    if (waveletFunction == "Held")
-      return runWaveletFrequencyForwardTest<3, HeldWavelet>(inputImage, outputImage, inputLevels, inputBands);
-    else if (waveletFunction == "Vow")
-      return runWaveletFrequencyForwardTest<3, VowWavelet>(inputImage, outputImage, inputLevels, inputBands);
-    else if (waveletFunction == "Simoncelli")
-      return runWaveletFrequencyForwardTest<3, SimoncelliWavelet>(inputImage, outputImage, inputLevels, inputBands);
-    else if (waveletFunction == "Shannon")
-      return runWaveletFrequencyForwardTest<3, ShannonWavelet>(inputImage, outputImage, inputLevels, inputBands);
+    if( waveletFunction == "Held" )
+      {
+      return runWaveletFrequencyForwardTest< 3, HeldWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if(waveletFunction == "Vow" )
+      {
+      return runWaveletFrequencyForwardTest< 3, VowWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if( waveletFunction == "Simoncelli" )
+      {
+      return runWaveletFrequencyForwardTest< 3, SimoncelliWavelet >(inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if( waveletFunction == "Shannon" )
+      {
+      return runWaveletFrequencyForwardTest< 3, ShannonWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
     else
       {
-      std::cerr << argv[5] << " is an unknown wavelet type " << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << argv[5] << " wavelet type not supported." << std::endl;
       return EXIT_FAILURE;
       }
     }
   else
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error: only 2 or 3 dimensions allowed, " << dimension << " selected." << std::endl;
     return EXIT_FAILURE;
     }

--- a/test/itkWaveletFrequencyInverseTest.cxx
+++ b/test/itkWaveletFrequencyInverseTest.cxx
@@ -15,9 +15,8 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#include <memory>
-#include <string>
-#include <cmath>
+
+
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
@@ -30,83 +29,100 @@
 #include "itkShannonIsotropicWavelet.h"
 #include "itkForwardFFTImageFilter.h"
 #include "itkInverseFFTImageFilter.h"
-#include <itkComplexToRealImageFilter.h>
+#include "itkComplexToRealImageFilter.h"
+#include "itkTestingMacros.h"
+
+#include <memory>
+#include <string>
+#include <cmath>
+
 #ifdef ITK_VISUALIZE_TESTS
 #include "itkViewImage.h"
 #endif
-using namespace std;
-using namespace itk;
 
-template<unsigned int N, typename TWaveletFunction>
+
+template< unsigned int VDimension, typename TWaveletFunction >
 int runWaveletFrequencyInverseTest( const std::string& inputImage,
                                     const std::string& outputImage,
                                     const unsigned int& inputLevels,
                                     const unsigned int& inputBands)
 {
-  const unsigned int dimension = N;
+  const unsigned int Dimension = VDimension;
 
-  typedef float                            PixelType;
-  typedef itk::Image<PixelType, dimension> ImageType;
-  typedef itk::ImageFileReader<ImageType>  ReaderType;
+  typedef float                               PixelType;
+  typedef itk::Image< PixelType, Dimension >  ImageType;
+  typedef itk::ImageFileReader< ImageType >   ReaderType;
+
   typename ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(inputImage);
+
+  reader->SetFileName( inputImage );
+
   reader->Update();
+
   reader->UpdateLargestPossibleRegion();
 
   // Perform FFT on input image.
-  typedef itk::ForwardFFTImageFilter<ImageType> FFTFilterType;
+  typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
   typename FFTFilterType::Pointer fftFilter = FFTFilterType::New();
-  fftFilter->SetInput(reader->GetOutput());
+
+  fftFilter->SetInput( reader->GetOutput() );
+
   typedef typename FFTFilterType::OutputImageType ComplexImageType;
 
   // Set the WaveletFunctionType and the WaveletFilterBank
-  typedef TWaveletFunction                                                                        WaveletFunctionType;
-  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, WaveletFunctionType>        WaveletFilterBankType;
-  typedef itk::WaveletFrequencyForward<ComplexImageType, ComplexImageType, WaveletFilterBankType> ForwardWaveletType;
+  typedef TWaveletFunction WaveletFunctionType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, WaveletFunctionType >
+    WaveletFilterBankType;
+  typedef itk::WaveletFrequencyForward< ComplexImageType, ComplexImageType, WaveletFilterBankType >
+    ForwardWaveletType;
+
   typename ForwardWaveletType::Pointer forwardWavelet = ForwardWaveletType::New();
-  forwardWavelet->SetHighPassSubBands(inputBands);
-  forwardWavelet->SetLevels(inputLevels);
-  forwardWavelet->SetInput(fftFilter->GetOutput());
+
+  forwardWavelet->SetHighPassSubBands( inputBands );
+  forwardWavelet->SetLevels( inputLevels );
+  forwardWavelet->SetInput( fftFilter->GetOutput() );
+
   forwardWavelet->Update();
+
   unsigned int noutputs = forwardWavelet->GetNumberOfOutputs();
-  std::cout << "Ninputs: " << noutputs << '\n';
-  for (unsigned int i = 0; i < noutputs; ++i)
+
+  std::cout << "Number of inputs: " << noutputs << std::endl;
+  for ( unsigned int i = 0; i < noutputs; ++i )
     {
-    std::cout << " Size of input: " << i << '\n';
-    std::cout << forwardWavelet->GetOutput(i)->GetLargestPossibleRegion() << '\n';
-    std::cout << forwardWavelet->GetOutput(i)->GetSpacing() << '\n';
+    std::cout << " Size of input: " << i << std::endl;
+    std::cout << forwardWavelet->GetOutput(i)->GetLargestPossibleRegion() << std::endl;
+    std::cout << forwardWavelet->GetOutput(i)->GetSpacing() << std::endl;
     }
 
   // Inverse Wavelet Transform
-  typedef itk::WaveletFrequencyInverse<ComplexImageType, ComplexImageType, WaveletFilterBankType> InverseWaveletType;
+  typedef itk::WaveletFrequencyInverse< ComplexImageType, ComplexImageType, WaveletFilterBankType >
+    InverseWaveletType;
   typename InverseWaveletType::Pointer inverseWavelet = InverseWaveletType::New();
-  inverseWavelet->SetHighPassSubBands(inputBands);
-  inverseWavelet->SetLevels(inputLevels);
-  inverseWavelet->SetInputs(forwardWavelet->GetOutputs());
+
+  inverseWavelet->SetHighPassSubBands( inputBands );
+  inverseWavelet->SetLevels( inputLevels );
+  inverseWavelet->SetInputs( forwardWavelet->GetOutputs() );
+
   inverseWavelet->Update();
+
   typedef itk::InverseFFTImageFilter<ComplexImageType, ImageType> InverseFFTFilterType;
   typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();
-  inverseFFT->SetInput(inverseWavelet->GetOutput());
+
+  inverseFFT->SetInput( inverseWavelet->GetOutput() );
+
   inverseFFT->Update();
 
-  // Write Output for comparisson
+  // Write output image
   typedef itk::ImageFileWriter< ImageType > WriterType;
   typename WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( outputImage );
   writer->SetInput( inverseFFT->GetOutput() );
-  try
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
-    std::cerr << "Error writing the WaveletInverse image: " << std::endl;
-    std::cerr << error << std::endl;
-    return EXIT_FAILURE;
-    }
+
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+
 #ifdef ITK_VISUALIZE_TESTS
-  Testing::ViewImage(reader->GetOutput(), "Original");
-  Testing::ViewImage(inverseFFT->GetOutput(), "InverseWavelet");
+  Testing::ViewImage( reader->GetOutput(), "Original" );
+  Testing::ViewImage( inverseFFT->GetOutput(), "InverseWavelet" );
 #endif
 
   return EXIT_SUCCESS;
@@ -120,55 +136,151 @@ int itkWaveletFrequencyInverseTest(int argc, char *argv[])
               << " inputImage outputImage inputLevels inputBands waveletFunction [dimension]" << std::endl;
     return EXIT_FAILURE;
     }
-  const string inputImage  = argv[1];
-  const string outputImage = argv[2];
-  const unsigned int inputLevels = atoi(argv[3]);
-  const unsigned int inputBands  = atoi(argv[4]);
-  const string waveletFunction   = argv[5];
+
+  const std::string inputImage  = argv[1];
+  const std::string outputImage = argv[2];
+  const unsigned int inputLevels = atoi( argv[3] );
+  const unsigned int inputBands  = atoi( argv[4] );
+  const std::string waveletFunction = argv[5];
+
   unsigned int dimension = 3;
   if( argc == 7 )
     {
     dimension = atoi( argv[6] );
     }
 
+  const unsigned int ImageDimension = 3;
+  typedef double                                          PixelType;
+  typedef std::complex< PixelType >                       ComplexPixelType;
+  typedef itk::Point< PixelType, ImageDimension >         PointType;
+  typedef itk::Image< PixelType, ImageDimension >         ImageType;
+  typedef itk::Image< ComplexPixelType, ImageDimension >  ComplexImageType;
+
+  // Exercise basic object methods
+  // Done outside the helper function in the test because GCC is limited
+  // when calling overloaded base class functions.
+  typedef itk::HeldIsotropicWavelet< PixelType, ImageDimension, PointType >
+    HeldIsotropicWaveletType;
+  typedef itk::VowIsotropicWavelet< PixelType, ImageDimension, PointType >
+    VowIsotropicWaveletType;
+  typedef itk::SimoncelliIsotropicWavelet< PixelType, ImageDimension, PointType >
+    SimoncelliIsotropicWaveletType;
+  typedef itk::ShannonIsotropicWavelet< PixelType, ImageDimension, PointType >
+    ShannonIsotropicWaveletType;
+
+  HeldIsotropicWaveletType::Pointer heldIsotropicWavelet =
+    HeldIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( heldIsotropicWavelet, HeldIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+  VowIsotropicWaveletType::Pointer vowIsotropicWavelet =
+    VowIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( vowIsotropicWavelet, VowIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+  SimoncelliIsotropicWaveletType::Pointer simoncellidIsotropicWavelet =
+    SimoncelliIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( simoncellidIsotropicWavelet, SimoncelliIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+  ShannonIsotropicWaveletType::Pointer shannonIsotropicWavelet = ShannonIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( shannonIsotropicWavelet, ShannonIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+
   typedef itk::HeldIsotropicWavelet<>       HeldWavelet;
   typedef itk::VowIsotropicWavelet<>        VowWavelet;
   typedef itk::SimoncelliIsotropicWavelet<> SimoncelliWavelet;
   typedef itk::ShannonIsotropicWavelet<>    ShannonWavelet;
+
+
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, HeldWavelet >
+    HeldWaveletFilterBankType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, VowWavelet >
+    VowWaveletFilterBankType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, SimoncelliWavelet >
+    SimoncelliWaveletFilterBankType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, ShannonWavelet >
+    ShannonWaveletFilterBankType;
+
+  typedef itk::WaveletFrequencyInverse< ComplexImageType, ComplexImageType, HeldWaveletFilterBankType >
+    HeldInverseWaveletType;
+  HeldInverseWaveletType::Pointer heldInverseWavelet = HeldInverseWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( heldInverseWavelet, WaveletFrequencyInverse,
+    ImageToImageFilter );
+
+  typedef itk::WaveletFrequencyInverse< ComplexImageType, ComplexImageType, VowWaveletFilterBankType >
+    VowInverseWaveletType;
+  VowInverseWaveletType::Pointer vowInverseWavelet = VowInverseWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( vowInverseWavelet, WaveletFrequencyInverse,
+    ImageToImageFilter );
+
+  typedef itk::WaveletFrequencyInverse< ComplexImageType, ComplexImageType, SimoncelliWaveletFilterBankType >
+    SimoncelliInverseWaveletType;
+  SimoncelliInverseWaveletType::Pointer simoncelliInverseWavelet = SimoncelliInverseWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( simoncelliInverseWavelet, WaveletFrequencyInverse,
+    ImageToImageFilter );
+
+  typedef itk::WaveletFrequencyInverse< ComplexImageType, ComplexImageType, ShannonWaveletFilterBankType >
+    ShannonInverseWaveletType;
+  ShannonInverseWaveletType::Pointer shannonInverseWavelet = ShannonInverseWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( shannonInverseWavelet, WaveletFrequencyInverse,
+    ImageToImageFilter );
+
+
   if( dimension == 2 )
     {
-    if (waveletFunction == "Held")
-      return runWaveletFrequencyInverseTest<2, HeldWavelet>(inputImage, outputImage, inputLevels, inputBands);
-    else if (waveletFunction == "Vow")
-      return runWaveletFrequencyInverseTest<2, VowWavelet>(inputImage, outputImage, inputLevels, inputBands);
-    else if (waveletFunction == "Simoncelli")
-      return runWaveletFrequencyInverseTest<2, SimoncelliWavelet>(inputImage, outputImage, inputLevels, inputBands);
-    else if (waveletFunction == "Shannon")
-      return runWaveletFrequencyInverseTest<2, ShannonWavelet>(inputImage, outputImage, inputLevels, inputBands);
+    if( waveletFunction == "Held" )
+      {
+      return runWaveletFrequencyInverseTest< 2, HeldWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if( waveletFunction == "Vow" )
+      {
+      return runWaveletFrequencyInverseTest< 2, VowWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if( waveletFunction == "Simoncelli" )
+      {
+      return runWaveletFrequencyInverseTest< 2, SimoncelliWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if( waveletFunction == "Shannon" )
+      {
+      return runWaveletFrequencyInverseTest< 2, ShannonWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
     else
       {
-      std::cerr << argv[5] << " is an unknown wavelet type " << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << argv[5] << " wavelet type not supported." << std::endl;
       return EXIT_FAILURE;
       }
     }
   else if( dimension == 3 )
     {
-    if (waveletFunction == "Held")
-      return runWaveletFrequencyInverseTest<3, HeldWavelet>(inputImage, outputImage, inputLevels, inputBands);
-    else if (waveletFunction == "Vow")
-      return runWaveletFrequencyInverseTest<3, VowWavelet>(inputImage, outputImage, inputLevels, inputBands);
-    else if (waveletFunction == "Simoncelli")
-      return runWaveletFrequencyInverseTest<3, SimoncelliWavelet>(inputImage, outputImage, inputLevels, inputBands);
-    else if (waveletFunction == "Shannon")
-      return runWaveletFrequencyInverseTest<3, ShannonWavelet>(inputImage, outputImage, inputLevels, inputBands);
+    if( waveletFunction == "Held" )
+      {
+      return runWaveletFrequencyInverseTest< 3, HeldWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if( waveletFunction == "Vow" )
+      {
+      return runWaveletFrequencyInverseTest< 3, VowWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if (waveletFunction == "Simoncelli" )
+      {
+      return runWaveletFrequencyInverseTest< 3, SimoncelliWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if( waveletFunction == "Shannon" )
+      {
+      return runWaveletFrequencyInverseTest< 3, ShannonWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
     else
       {
-      std::cerr << argv[5] << " is an unknown wavelet type " << std::endl;
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << argv[5] << " wavelet type not supported." << std::endl;
       return EXIT_FAILURE;
       }
     }
   else
     {
+      std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error: only 2 or 3 dimensions allowed, " << dimension << " selected." << std::endl;
     return EXIT_FAILURE;
     }

--- a/test/itkZeroDCImageFilterTest.cxx
+++ b/test/itkZeroDCImageFilterTest.cxx
@@ -17,53 +17,60 @@
  *=========================================================================*/
 
 #include "itkZeroDCImageFilter.h"
-#include <string>
 #include "itkForwardFFTImageFilter.h"
 #include "itkInverseFFTImageFilter.h"
-
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
-using namespace std;
-using namespace itk;
+#include "itkTestingMacros.h"
 
-template<unsigned int N>
-int runZeroDCImageFilterTest(
-  const std::string& inputImage)
+#include <string>
+
+
+template< unsigned int VDimension >
+int runZeroDCImageFilterTest( const std::string& inputImage )
 {
-  const unsigned int dimension = N;
+  const unsigned int Dimension = VDimension;
 
   // TODO massive difference (-1,4, 3^-10) of 0 freq pixel between (float, double) I guess it is because FFT algorithm not ZeroDC. Maybe because odd size using FFTW.
-  typedef float                            PixelType;
-  typedef itk::Image<PixelType, dimension> ImageType;
-  typedef itk::ImageFileReader<ImageType>  ReaderType;
+  typedef float                               PixelType;
+  typedef itk::Image< PixelType, Dimension >  ImageType;
+  typedef itk::ImageFileReader< ImageType >   ReaderType;
+
   typename ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(inputImage);
-  typedef itk::ZeroDCImageFilter<ImageType> ZeroDCFilterType;
+
+  reader->SetFileName( inputImage );
+
+  typedef itk::ZeroDCImageFilter< ImageType > ZeroDCFilterType;
   typename ZeroDCFilterType::Pointer zeroDCFilter = ZeroDCFilterType::New();
-  zeroDCFilter->SetInput(reader->GetOutput());
+
+  zeroDCFilter->SetInput( reader->GetOutput() );
 
   // Perform FFT on zeroDC image and check freq bin 0 has zero value.
-  typedef itk::ForwardFFTImageFilter<ImageType> FFTForwardFilterType;
+  typedef itk::ForwardFFTImageFilter< ImageType > FFTForwardFilterType;
   typename FFTForwardFilterType::Pointer fftForwardFilter = FFTForwardFilterType::New();
-  fftForwardFilter->SetInput(zeroDCFilter->GetOutput());
-  fftForwardFilter->Update();
+
+  fftForwardFilter->SetInput( zeroDCFilter->GetOutput() );
+
+  TRY_EXPECT_NO_EXCEPTION( fftForwardFilter->Update() );
+
   typedef typename FFTForwardFilterType::OutputImageType ComplexImageType;
   typename ComplexImageType::IndexType zeroIndex;
-  zeroIndex.Fill(0);
+  zeroIndex.Fill( 0 );
 
   typename ComplexImageType::Pointer filteredImg = fftForwardFilter->GetOutput();
   filteredImg->DisconnectPipeline();
-  typename ComplexImageType::PixelType filteredZeroFreqPixelValue = filteredImg->GetPixel(zeroIndex);
+  typename ComplexImageType::PixelType filteredZeroFreqPixelValue = filteredImg->GetPixel( zeroIndex );
   typename ZeroDCFilterType::RealType  mean = zeroDCFilter->GetMean();
 
-  fftForwardFilter->SetInput(reader->GetOutput());
+  fftForwardFilter->SetInput( reader->GetOutput( ));
   fftForwardFilter->Update();
   typename ComplexImageType::Pointer   originalImg = fftForwardFilter->GetOutput();
-  typename ComplexImageType::PixelType originalZeroFreqPixelValue = originalImg->GetPixel(zeroIndex);
+  typename ComplexImageType::PixelType originalZeroFreqPixelValue = originalImg->GetPixel( zeroIndex );
 
-  if (itk::Math::NotAlmostEquals(filteredZeroFreqPixelValue.real(), 0.0))
+  if( itk::Math::NotAlmostEquals( filteredZeroFreqPixelValue.real(), 0.0 ) )
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "DC Component (Index = " << zeroIndex << ") is not zero: " << filteredZeroFreqPixelValue.real()
               << std::endl;
     std::cerr << "DC Component (Index = " << zeroIndex << ") of original image is: "
@@ -75,7 +82,7 @@ int runZeroDCImageFilterTest(
   return EXIT_SUCCESS;
 }
 
-int itkZeroDCImageFilterTest(int argc, char *argv[])
+int itkZeroDCImageFilterTest( int argc, char *argv[] )
 {
   if( argc < 2 || argc > 3 )
     {
@@ -83,19 +90,47 @@ int itkZeroDCImageFilterTest(int argc, char *argv[])
               << " inputImage [dimension]" << std::endl;
     return EXIT_FAILURE;
     }
-  const string inputImage = argv[1];
+
+  const std::string inputImage = argv[1];
   unsigned int dimension  = 3;
   if( argc == 3 )
     {
     dimension = atoi( argv[2] );
     }
 
+
+  const unsigned int ImageDimension = 3;
+  typedef double                                  PixelType;
+  typedef itk::Image< PixelType, ImageDimension > ImageType;
+
+  // Exercise basic object methods
+  // Done outside the helper function in the test because GCC is limited
+  // when calling overloaded base class functions.
+  typedef itk::ZeroDCImageFilter< ImageType > ZeroDCFilterType;
+
+  ZeroDCFilterType::Pointer zeroDCFilter = ZeroDCFilterType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( zeroDCFilter, ZeroDCImageFilter,
+    ImageToImageFilter );
+
+  // Perform FFT on zeroDC image and check freq bin 0 has zero value.
+  typedef itk::ForwardFFTImageFilter< ImageType > FFTForwardFilterType;
+  FFTForwardFilterType::Pointer fftForwardFilter = FFTForwardFilterType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( fftForwardFilter, ForwardFFTImageFilter,
+    ImageToImageFilter );
+
+
   if( dimension == 2 )
-    return runZeroDCImageFilterTest<2>(inputImage);
-  else if (dimension == 3)
-    return runZeroDCImageFilterTest<3>(inputImage);
+    {
+    return runZeroDCImageFilterTest< 2 >( inputImage );
+    }
+  else if( dimension == 3 )
+    {
+    return runZeroDCImageFilterTest< 3 >( inputImage );
+    }
   else
     {
+    std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error: only 2 or 3 dimensions allowed, " << dimension << " selected." << std::endl;
     return EXIT_FAILURE;
     }


### PR DESCRIPTION
Enhance the tests in order to improve the code coverage, and conform to
the ITK style.

Use the TRY_EXPECT_NO_EXCEPTION macro to update filters and save typing
writing try/catch blocks.

Use the TEST_SET_GET_VALUE macro to test class properties.

Re-ordere includes for the sake of readability and used quotes instead of
'<>'.

Improve the exit message when the test fail conditions are met.

Remove some std::cout messages (tests are usually not read by humans).

Conform to ITK style and be uniform throughout the tests: use cammel case
variable names, white spaces, etc.