### PR TITLE
STYLE: Delete functions in consistent way.

### DIFF
--- a/include/itkFrequencyBandImageFilter.h
+++ b/include/itkFrequencyBandImageFilter.h
@@ -184,8 +184,7 @@ protected:
                                     ThreadIdType threadId) ITK_OVERRIDE;
 
 private:
-  FrequencyBandImageFilter(const Self&) ITK_DELETE_FUNCTION;
-  void operator=(const Self&) ITK_DELETE_FUNCTION;
+  ITK_DISALLOW_COPY_AND_ASSIGN(FrequencyBandImageFilter);
 
   FrequencyValueType m_LowFrequencyThreshold;
   FrequencyValueType m_HighFrequencyThreshold;

--- a/include/itkFrequencyExpandImageFilter.h
+++ b/include/itkFrequencyExpandImageFilter.h
@@ -168,8 +168,7 @@ protected:
   void GenerateData() ITK_OVERRIDE;
 
 private:
-  FrequencyExpandImageFilter(const Self &) ITK_DELETE_FUNCTION;
-  void operator=(const Self &) ITK_DELETE_FUNCTION;
+  ITK_DISALLOW_COPY_AND_ASSIGN(FrequencyExpandImageFilter);
 
   ExpandFactorsType m_ExpandFactors;
 };

--- a/include/itkFrequencyExpandViaInverseFFTImageFilter.h
+++ b/include/itkFrequencyExpandViaInverseFFTImageFilter.h
@@ -122,8 +122,7 @@ protected:
   void GenerateData() ITK_OVERRIDE;
 
 private:
-  FrequencyExpandViaInverseFFTImageFilter(const Self &) ITK_DELETE_FUNCTION;
-  void operator=(const Self &) ITK_DELETE_FUNCTION;
+  ITK_DISALLOW_COPY_AND_ASSIGN(FrequencyExpandViaInverseFFTImageFilter);
 
   ExpandFactorsType                      m_ExpandFactors;
   typename InverseFFTFilterType::Pointer m_InverseFFT;

--- a/include/itkFrequencyShrinkImageFilter.h
+++ b/include/itkFrequencyShrinkImageFilter.h
@@ -148,8 +148,7 @@ protected:
   void GenerateData() ITK_OVERRIDE;
 
 private:
-  FrequencyShrinkImageFilter(const Self&) ITK_DELETE_FUNCTION;
-  void operator=(const Self&) ITK_DELETE_FUNCTION;
+  ITK_DISALLOW_COPY_AND_ASSIGN(FrequencyShrinkImageFilter);
 
   ShrinkFactorsType                         m_ShrinkFactors;
   bool                                      m_ApplyBandFilter;

--- a/include/itkFrequencyShrinkViaInverseFFTImageFilter.h
+++ b/include/itkFrequencyShrinkViaInverseFFTImageFilter.h
@@ -112,8 +112,7 @@ protected:
   void GenerateData() ITK_OVERRIDE;
 
 private:
-  FrequencyShrinkViaInverseFFTImageFilter(const Self&) ITK_DELETE_FUNCTION;
-  void operator=(const Self&) ITK_DELETE_FUNCTION;
+  ITK_DISALLOW_COPY_AND_ASSIGN(FrequencyShrinkViaInverseFFTImageFilter);
 
   ShrinkFactorsType                      m_ShrinkFactors;
   typename InverseFFTFilterType::Pointer m_InverseFFT;

--- a/include/itkHeldIsotropicWavelet.h
+++ b/include/itkHeldIsotropicWavelet.h
@@ -83,8 +83,7 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
 private:
-  HeldIsotropicWavelet(const Self &) ITK_DELETE_FUNCTION;
-  void operator=(const Self &) ITK_DELETE_FUNCTION;
+  ITK_DISALLOW_COPY_AND_ASSIGN(HeldIsotropicWavelet);
 
   /** The order of the polynom. */
   unsigned int m_PolynomialOrder;

--- a/include/itkShannonIsotropicWavelet.h
+++ b/include/itkShannonIsotropicWavelet.h
@@ -75,8 +75,7 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
 private:
-  ShannonIsotropicWavelet(const Self &) ITK_DELETE_FUNCTION;
-  void operator=(const Self &) ITK_DELETE_FUNCTION;
+  ITK_DISALLOW_COPY_AND_ASSIGN(ShannonIsotropicWavelet);
 };
 } // end namespace itk
 

--- a/include/itkSimoncelliIsotropicWavelet.h
+++ b/include/itkSimoncelliIsotropicWavelet.h
@@ -80,8 +80,7 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
 private:
-  SimoncelliIsotropicWavelet(const Self &) ITK_DELETE_FUNCTION;
-  void operator=(const Self &) ITK_DELETE_FUNCTION;
+  ITK_DISALLOW_COPY_AND_ASSIGN(SimoncelliIsotropicWavelet);
 };
 } // end namespace itk
 

--- a/include/itkVowIsotropicWavelet.h
+++ b/include/itkVowIsotropicWavelet.h
@@ -88,8 +88,7 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
 private:
-  VowIsotropicWavelet(const Self &) ITK_DELETE_FUNCTION;
-  void operator=(const Self &) ITK_DELETE_FUNCTION;
+  ITK_DISALLOW_COPY_AND_ASSIGN(VowIsotropicWavelet);
 
   /** kappa value, default is optimal:0.75 */
   FunctionValueType m_Kappa;

--- a/include/itkWaveletFrequencyFilterBankGenerator.h
+++ b/include/itkWaveletFrequencyFilterBankGenerator.h
@@ -115,8 +115,7 @@ protected:
   virtual void GenerateData() ITK_OVERRIDE;
 
 private:
-  WaveletFrequencyFilterBankGenerator(const Self &) ITK_DELETE_FUNCTION;
-  void operator=(const Self&) ITK_DELETE_FUNCTION;
+  ITK_DISALLOW_COPY_AND_ASSIGN(WaveletFrequencyFilterBankGenerator);
 
   /************ Data Members *************/
   /** Number of M-Bands decomposition of the high pass filters */

--- a/include/itkWaveletFrequencyForward.h
+++ b/include/itkWaveletFrequencyForward.h
@@ -147,8 +147,7 @@ protected:
   virtual void GenerateInputRequestedRegion() ITK_OVERRIDE;
 
 private:
-  WaveletFrequencyForward(const Self &) ITK_DELETE_FUNCTION;
-  void operator=(const Self &) ITK_DELETE_FUNCTION;
+  ITK_DISALLOW_COPY_AND_ASSIGN(WaveletFrequencyForward);
 
   unsigned int m_Levels;
   unsigned int m_HighPassSubBands;

--- a/include/itkWaveletFrequencyInverse.h
+++ b/include/itkWaveletFrequencyInverse.h
@@ -124,8 +124,7 @@ protected:
   virtual void GenerateInputRequestedRegion() ITK_OVERRIDE;
 
 private:
-  WaveletFrequencyInverse(const Self &) ITK_DELETE_FUNCTION;
-  void operator=(const Self &) ITK_DELETE_FUNCTION;
+  ITK_DISALLOW_COPY_AND_ASSIGN(WaveletFrequencyInverse);
 
   unsigned int m_Levels;
   unsigned int m_HighPassSubBands;


### PR DESCRIPTION
Functions that are deleted to avoid implicit compiler definition should be
done so in a consistent way.

Use the ITK_DISALLOW_COPY_AND_ASSIGN macro to provide a more consistent
interface.