### PR TITLE
Change ImageInformation:Spacing for WaveletForward Output and layout of output list (approx image is now last instead of first).

### DIFF
--- a/include/itkFrequencyBandImageFilter.hxx
+++ b/include/itkFrequencyBandImageFilter.hxx
@@ -181,7 +181,7 @@ FrequencyBandImageFilter<TImageType>
     // Boundaries: Do not pass threshold frequencies if requested.
     if(!this->m_PassLowFrequencyThreshold)
       {
-      if(f == this->m_LowFrequencyThreshold)
+      if(itk::Math::FloatAlmostEqual(f,this->m_LowFrequencyThreshold))
         {
         // Different boundaries when negative frequencies in the non-radial case.
         if(!this->m_RadialBand
@@ -199,7 +199,7 @@ FrequencyBandImageFilter<TImageType>
 
     if(!this->m_PassHighFrequencyThreshold)
       {
-      if(f == this->m_HighFrequencyThreshold)
+      if(itk::Math::FloatAlmostEqual(f,this->m_HighFrequencyThreshold))
         {
         // Different boundaries when negative frequencies in the non-radial case.
         if(!this->m_RadialBand

--- a/include/itkFrequencyExpandImageFilter.hxx
+++ b/include/itkFrequencyExpandImageFilter.hxx
@@ -286,17 +286,19 @@ FrequencyExpandImageFilter< TImageType >
 
   for ( unsigned int i = 0; i < TImageType::ImageDimension; i++ )
     {
-    outputSpacing[i]    = inputSpacing[i] / (float)m_ExpandFactors[i];
-    outputSize[i]       = inputSize[i] * (SizeValueType)m_ExpandFactors[i];
-    outputStartIndex[i] = inputStartIndex[i] * (IndexValueType)m_ExpandFactors[i];
-    const double fraction = (double)( m_ExpandFactors[i] - 1 ) / (double)m_ExpandFactors[i];
-    inputOriginShift[i] = -( inputSpacing[i] / 2.0 ) * fraction;
+    outputSpacing[i]    = inputSpacing[i] * m_ExpandFactors[i];
+    outputSize[i]       = inputSize[i] * static_cast<SizeValueType>(m_ExpandFactors[i]);
+    outputStartIndex[i] = inputStartIndex[i];
+    // outputStartIndex[i] = inputStartIndex[i] * (IndexValueType)m_ExpandFactors[i];
+    // const double fraction = (double)( m_ExpandFactors[i] - 1 ) / (double)m_ExpandFactors[i];
+    // inputOriginShift[i] = -( inputSpacing[i] / 2.0 ) * fraction;
     }
 
-  const typename TImageType::DirectionType inputDirection    = inputPtr->GetDirection();
-  const typename TImageType::SpacingType   outputOriginShift = inputDirection * inputOriginShift;
-
-  outputOrigin = inputOrigin + outputOriginShift;
+  // const typename TImageType::DirectionType inputDirection    = inputPtr->GetDirection();
+  // const typename TImageType::SpacingType   outputOriginShift = inputDirection * inputOriginShift;
+  //
+  // outputOrigin = inputOrigin + outputOriginShift;
+  outputOrigin = inputOrigin;
 
   outputPtr->SetSpacing(outputSpacing);
   outputPtr->SetOrigin(outputOrigin);

--- a/include/itkFrequencyExpandImageFilter.hxx
+++ b/include/itkFrequencyExpandImageFilter.hxx
@@ -286,7 +286,7 @@ FrequencyExpandImageFilter< TImageType >
 
   for ( unsigned int i = 0; i < TImageType::ImageDimension; i++ )
     {
-    outputSpacing[i]    = inputSpacing[i] * m_ExpandFactors[i];
+    outputSpacing[i]    = inputSpacing[i] / m_ExpandFactors[i];
     outputSize[i]       = inputSize[i] * static_cast<SizeValueType>(m_ExpandFactors[i]);
     outputStartIndex[i] = inputStartIndex[i];
     // outputStartIndex[i] = inputStartIndex[i] * (IndexValueType)m_ExpandFactors[i];

--- a/include/itkFrequencyImageRegionConstIteratorWithIndex.h
+++ b/include/itkFrequencyImageRegionConstIteratorWithIndex.h
@@ -279,9 +279,9 @@ private:
       }
   }
 
-  IndexType m_HalfIndex;
-  IndexType m_MinIndex;
-  IndexType m_MaxIndex;
+  IndexType     m_HalfIndex;
+  IndexType     m_MinIndex;
+  IndexType     m_MaxIndex;
   FrequencyType m_FrequencyOrigin;
   FrequencyType m_FrequencySpacing;
 };

--- a/include/itkFrequencyImageRegionConstIteratorWithIndex.h
+++ b/include/itkFrequencyImageRegionConstIteratorWithIndex.h
@@ -35,8 +35,19 @@ namespace itk
  *
  * This class can be specialized further to iterate over other frequency
  * layouts, for example shifted images (where 0 frequency is in the middle of the image, and Nyquist are in the border).
- * The frequency layout is assumed to be: where fs is frequency sampling, or frequency spacing (1.0 by default).
+ * For different layout, use other frequency iterator.
  *
+ * This iterator is for the frequency layout that results from applying a FFT (vnl or fftw) to an image.
+ * The default ImageInformation is: Origin = {{0}}, Spacing = {{1}}.
+ * In this case the frequency values will be in the range: [-1/2, 1/2] Hz
+ * Or [-pi, pi] rad/s
+ * To modify those ranges:
+ * a) Avoid modifying the origin. The origin index always corresponds to zero frequency after a FFT.
+ *    The range should be always centered around zero.
+ * b) The spacing control the range of frequencies (always around zero).
+ *    If the spacing is = {{0.5}} we get a frequency range of [-1/4, 1/4] or [-pi/2, pi/2].
+ *
+ * The frequency layout is assumed to be: where fs is frequency sampling, or frequency spacing (1.0 by default).
  * If N is even:
  * Nyquist frequency at index=N/2 is shared between + and - regions.
  * <------------positive f ---------------><------------negative f-------------->
@@ -161,15 +172,29 @@ public:
     for (unsigned int dim = 0; dim < TImage::ImageDimension; dim++)
       {
       if (this->m_PositionIndex[dim] <= m_HalfIndex[dim])
+        {
         freqInd[dim] = this->m_PositionIndex[dim] - this->m_MinIndex[dim];
-      //  -. From -N/2 + 1 (Nyquist if even) to -1 (-df in frequency)
-      else
+        }
+      else //  -. From -N/2 + 1 (Nyquist if even) to -1 (-df in frequency)
+        {
         freqInd[dim] = this->m_PositionIndex[dim] - (this->m_MaxIndex[dim] + 1);
+        }
       }
     return freqInd;
   }
 
   /** Note that this method is independent of the region in the constructor.
+   * It takes into account the ImageInformation of the Image in the frequency domain.
+   * This iterator is for the frequency layout that results from applying a FFT (vnl or fftw) to an image.
+   * If your image has a different layout, use other frequency iterator.
+   * The default ImageInformation is: Origin = {{0}}, Spacing = {{1}}.
+   * In this case the frequency values will be in the range: [-1/2, 1/2] Hz
+   * Or [-pi, pi] rad/s
+   * To modify those ranges:
+   * a) Avoid modifying the origin. The origin index always corresponds to zero frequency after a FFT.
+   *    The range should be always centered around zero.
+   * b) The spacing control the range of frequencies (always around zero).
+   *    If the spacing is = {{0.5}} we get a frequency range of [-1/4, 1/4] or [-pi/2, pi/2].
    */
   FrequencyType GetFrequency() const
   {
@@ -197,6 +222,13 @@ public:
     return w2;
   }
 
+  /**
+   * Index corresponding to the first highest frequency (Nyquist) after a FFT transform.
+   * If the size of the image is even, the Nyquist frequency = fs/2 is unique and shared
+   * between positive and negative frequencies.
+   * If odd, Nyquist frequency is not represented, but there is still a largest frequency at this index
+   * = fs/2 * (N-1)/N.
+   */
   typename ImageType::IndexType GetHalfIndex() const
   {
     typename ImageType::IndexType half_index;
@@ -219,19 +251,11 @@ private:
     for (unsigned int dim = 0; dim < ImageType::ImageDimension; dim++)
       {
       this->m_HalfIndex[dim] = static_cast<FrequencyValueType>(
-          this->m_MinIndex[dim]
-          + std::ceil( (this->m_MaxIndex[dim] - this->m_MinIndex[dim] ) / 2.0 )
+          this->m_MinIndex[dim] + std::ceil( (this->m_MaxIndex[dim] - this->m_MinIndex[dim] ) / 2.0 )
           );
       }
   }
 
-  /**
-   * Index corresponding to the first highest frequency (Nyquist) after a FFT transform.
-   * If the size of the image is even, the Nyquist frequency = fs/2 is unique and shared
-   * between positive and negative frequencies.
-   * If odd, Nyquist frequency is not represented, but there is still a largest frequency at this index
-   * = fs/2 * (N-1)/N.
-   */
   IndexType m_HalfIndex;
   IndexType m_MinIndex;
   IndexType m_MaxIndex;

--- a/include/itkFrequencyImageRegionIteratorWithIndex.h
+++ b/include/itkFrequencyImageRegionIteratorWithIndex.h
@@ -108,13 +108,17 @@ public:
 
   /** Set the pixel value */
   void Set(const PixelType & value) const
-  { this->m_PixelAccessorFunctor.Set(*( const_cast< InternalPixelType * >( this->m_Position ) ), value); }
+  {
+    this->m_PixelAccessorFunctor.Set(*( const_cast< InternalPixelType * >( this->m_Position ) ), value);
+  }
 
   /** Return a reference to the pixel.
    * This method will provide the fastest access to pixel
    * data, but it will NOT support ImageAdaptors. */
   PixelType & Value(void)
-  { return *( const_cast< InternalPixelType * >( this->m_Position ) ); }
+  {
+    return *( const_cast< InternalPixelType * >( this->m_Position ) );
+  }
 
 protected:
   /** The construction from a const iterator is declared protected

--- a/include/itkFrequencyShrinkImageFilter.hxx
+++ b/include/itkFrequencyShrinkImageFilter.hxx
@@ -35,7 +35,7 @@ namespace itk
 template<class TImageType>
 FrequencyShrinkImageFilter< TImageType >
 ::FrequencyShrinkImageFilter()
-: m_ApplyBandFilter(true)
+: m_ApplyBandFilter(false)
 {
   for ( unsigned int j = 0; j < ImageDimension; j++ )
     {
@@ -44,7 +44,7 @@ FrequencyShrinkImageFilter< TImageType >
 
   this->m_FrequencyBandFilter = FrequencyBandFilterType::New();
   // The band filter only let pass half of the frequencies.
-  // this->m_FrequencyBandFilter->SetFrequencyThresholdsInRadians( 0.0, Math::pi_over_2 );
+  this->m_FrequencyBandFilter->SetFrequencyThresholdsInRadians( 0.0, Math::pi_over_2 );
   bool lowFreqThresholdPassing  = true;
   bool highFreqThresholdPassing = true;
   this->m_FrequencyBandFilter->SetPassBand( lowFreqThresholdPassing, highFreqThresholdPassing );
@@ -147,8 +147,9 @@ FrequencyShrinkImageFilter<TImageType>
       }
 
     this->m_FrequencyBandFilter->SetInput(this->GetInput());
-    // this->m_FrequencyBandFilter->SetFrequencyThresholdsInRadians( 0.0, Math::pi_over_2);
-    this->m_FrequencyBandFilter->SetFrequencyThresholdsInRadians( 0.0, Math::pi_over_2 * spacingValue );
+    this->m_FrequencyBandFilter->SetFrequencyThresholds(
+        this->m_FrequencyBandFilter->GetLowFrequencyThreshold() * spacingValue,
+        this->m_FrequencyBandFilter->GetHighFrequencyThreshold() * spacingValue );
     this->m_FrequencyBandFilter->Update();
     inputPtr = this->m_FrequencyBandFilter->GetOutput();
     }

--- a/include/itkFrequencyShrinkImageFilter.hxx
+++ b/include/itkFrequencyShrinkImageFilter.hxx
@@ -375,7 +375,7 @@ FrequencyShrinkImageFilter<TImageType>
   // The spacing is taken into account by FrequencyIterators method GetFrequency().
   for ( unsigned int i = 0; i < TImageType::ImageDimension; i++ )
     {
-    outputSpacing[i] = inputSpacing[i] / m_ShrinkFactors[i];
+    outputSpacing[i] = inputSpacing[i] * m_ShrinkFactors[i];
     // inputIndexOutputOrigin[i] = 0.5*(m_ShrinkFactors[i]-1);
     // outputStartIndex[i] =
     //   Math::Ceil<SizeValueType>(inputStartIndex[i]/static_cast<double>( m_ShrinkFactors[i]) );

--- a/include/itkFrequencyShrinkImageFilter.hxx
+++ b/include/itkFrequencyShrinkImageFilter.hxx
@@ -341,10 +341,12 @@ FrequencyShrinkImageFilter<TImageType>
   typename TImageType::PointType   outputOrigin;
   typename TImageType::IndexType   outputStartIndex;
 
-  // TODO Check if you want to modify metada in this filter.
+  // TODO Check if you want to modify metadata in this filter.
+  // Reduce Spacing, a frequency shrinker deletes high frequency domain.
+  // The spacing is taken into account by FrequencyIterators method GetFrequency().
   for ( unsigned int i = 0; i < TImageType::ImageDimension; i++ )
     {
-    // outputSpacing[i] *= m_ShrinkFactors[i];
+    outputSpacing[i] = inputSpacing[i] / m_ShrinkFactors[i];
     // inputIndexOutputOrigin[i] = 0.5*(m_ShrinkFactors[i]-1);
     // outputStartIndex[i] =
     //   Math::Ceil<SizeValueType>(inputStartIndex[i]/static_cast<double>( m_ShrinkFactors[i]) );

--- a/include/itkHeldIsotropicWavelet.hxx
+++ b/include/itkHeldIsotropicWavelet.hxx
@@ -27,7 +27,7 @@ namespace itk
 template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
 HeldIsotropicWavelet< TFunctionValue, VImageDimension, TInput >
 ::HeldIsotropicWavelet()
-  : m_PolynomialOrder(3)
+  : m_PolynomialOrder(5)
 {
 }
 

--- a/include/itkPhaseAnalysisImageFilter.hxx
+++ b/include/itkPhaseAnalysisImageFilter.hxx
@@ -85,7 +85,7 @@ PhaseAnalysisImageFilter< TInputImage, TOutputImage >
       vecValue = inputIt.Get();
       featureAmpSquare = this->ComputeFeatureVectorNormSquare(vecValue);
       ampIt.Set(this->ComputeAmplitude(vecValue, featureAmpSquare));
-      phaseIt.Set(cos(this->ComputePhase(vecValue, featureAmpSquare)));
+      phaseIt.Set(this->ComputePhase(vecValue, featureAmpSquare));
       ++inputIt; ++ampIt; ++phaseIt;
       }
     inputIt.NextLine(); ampIt.NextLine(); phaseIt.NextLine();

--- a/include/itkPhaseAnalysisSoftThresholdImageFilter.hxx
+++ b/include/itkPhaseAnalysisSoftThresholdImageFilter.hxx
@@ -122,8 +122,12 @@ PhaseAnalysisSoftThresholdImageFilter< TInputImage, TOutputImage >
       {
       OutputImagePixelType out_value = cos(phaseIt.Get());
       if(this->GetApplySoftThreshold())
+        {
         if (ampIt.Get() < this->m_Threshold)
-          out_value = out_value * ampIt.Get() / this->m_Threshold;
+          {
+          out_value *= ampIt.Get() / this->m_Threshold;
+          }
+        }
       outIt.Set(out_value);
       ++outIt, ++ampIt, ++phaseIt;
       }

--- a/include/itkRieszFrequencyFunction.h
+++ b/include/itkRieszFrequencyFunction.h
@@ -20,6 +20,7 @@
 
 #include "itkFrequencyFunction.h"
 #include <complex>
+#include <numeric>
 
 namespace itk
 {
@@ -71,13 +72,7 @@ public:
   /** Calculate magnitude (euclidean norm) of input point. **/
   inline double Magnitude(const TInput & point) const
   {
-    double accum(0);
-
-    for (size_t d = 0; d < VImageDimension; ++d)
-      {
-      accum += point[d] * point[d];
-      }
-    return sqrt(accum);
+    return sqrt(std::inner_product( point.Begin(), point.End(), point.Begin(), 0.0 ) );
   }
 
 protected:

--- a/include/itkRieszFrequencyFunction.hxx
+++ b/include/itkRieszFrequencyFunction.hxx
@@ -54,7 +54,9 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
   double magn(this->Magnitude(frequency_point));
 
   if(itk::Math::FloatAlmostEqual(magn, 0.0) )
+    {
     return FunctionValueType(0);
+    }
   return OutputComplexType(0, static_cast<FunctionValueType>( -frequency_point[dimension] / magn ) );
 }
 
@@ -66,7 +68,9 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
   double magn(this->Magnitude(frequency_point));
 
   if(itk::Math::FloatAlmostEqual(magn, 0.0) )
+    {
     return InputType(0);
+    }
   OutputArrayType out;
   for( unsigned int dim = 0; dim < VImageDimension; ++dim)
     {

--- a/include/itkWaveletFrequencyForward.h
+++ b/include/itkWaveletFrequencyForward.h
@@ -82,11 +82,16 @@ public:
                ImageToImageFilter);
   void SetLevels(unsigned int n);
 
-  itkGetMacro(Levels, unsigned int);
+  itkGetConstReferenceMacro(Levels, unsigned int);
   void SetHighPassSubBands(unsigned int n);
 
-  itkGetMacro(HighPassSubBands, unsigned int);
-  itkGetMacro(TotalOutputs, unsigned int);
+  itkGetConstReferenceMacro(HighPassSubBands, unsigned int);
+  itkGetConstReferenceMacro(TotalOutputs, unsigned int);
+
+  /** ScaleFactor for each level in the pyramid.
+   * Set to 2 (dyadic) at constructor and not modifiable, but provides future flexibility */
+  itkGetConstReferenceMacro(ScaleFactor, unsigned int);
+  // itkSetMacro(ScaleFactor, unsigned int);
 
   /** Compute max number of levels depending on the size of the image.
    * Return J: $ J = min_element(J_0,J_1,...) $;
@@ -97,8 +102,13 @@ public:
    */
   static unsigned int ComputeMaxNumberOfLevels(typename InputImageType::SizeType& input_size);
 
+  /** (Level, band) pair.
+   * Level from: [0, m_Levels), and equal to m_Levels only for the low_pass image.
+   * band from [0, m_HighPassSubbands) */
   typedef std::pair<unsigned int, unsigned int> IndexPairType;
-  /** Get the (Level,Band) from a linear index output */
+  /** Get the (Level,Band) from a linear index output.
+   * The index corresponding to the low-pass image is the last one, corresponding to the IndexPairType(this->GetLevels(), 0).
+   */
   IndexPairType OutputIndexToLevelBand(unsigned int linear_index);
 
   /** Retrieve outputs */
@@ -152,8 +162,6 @@ private:
   unsigned int m_Levels;
   unsigned int m_HighPassSubBands;
   unsigned int m_TotalOutputs;
-  /** Shrink/Expand factor
-   * Set to 2, not modifiable, but provides future flexibility */
   unsigned int m_ScaleFactor;
 };
 } // end namespace itk

--- a/include/itkWaveletFrequencyForward.hxx
+++ b/include/itkWaveletFrequencyForward.hxx
@@ -472,10 +472,6 @@ void WaveletFrequencyForward< TInputImage, TOutputImage, TWaveletFilterBank>
   inputPerLevel = changeInputInfoFilter->GetOutput();
   for (unsigned int level = 0; level < this->m_Levels; ++level)
     {
-    /***** Dilation factor (assume dilation is dyadic -2-). **/
-    // double expLevelFactor = - static_cast<double>(level*ImageDimension)/2.0;
-    double expLevelFactor = 0;
-    itkDebugMacro( << "ExpLevelFactor: " << expLevelFactor << ", level: " << level << " 2^expLevelFactor: " << std::pow(2.0, expLevelFactor) );
 
     /******* Set HighPass bands *****/
     itkDebugMacro(<< "Number of FilterBank high pass bands: " << highPassWavelets.size() );
@@ -490,7 +486,10 @@ void WaveletFrequencyForward< TInputImage, TOutputImage, TWaveletFilterBank>
       // double expFactorHigh = - static_cast<double>(1)/static_cast<double>(this->m_HighPassSubBands) * static_cast<double>(ImageDimension)/2.0;
       // double expBandFactor = expLevelFactor;// + static_cast<double>(ImageDimension)/2.0;
       // double expBandFactor = expLevelFactor - static_cast<int>(band)/static_cast<double>(this->m_HighPassSubBands) * static_cast<double>(ImageDimension)/2.0;
-      double expBandFactor = 0;
+      // double expBandFactor = 0;
+      // double expBandFactor = - static_cast<double>(level*ImageDimension)/2.0;
+      double expBandFactor = ( - static_cast<double>(level)
+        + band/ static_cast<double>(this->m_HighPassSubBands) ) * ImageDimension/2.0;
       multiplyByAnalysisBandFactor->SetConstant(std::pow(2.0, expBandFactor));
       // TODO Warning: InPlace here deletes buffered region of input.
       // http://public.kitware.com/pipermail/community/2015-April/008819.html
@@ -527,9 +526,12 @@ void WaveletFrequencyForward< TInputImage, TOutputImage, TWaveletFilterBank>
     if (level == this->m_Levels - 1) // Set low_pass output (index=this->m_TotalOutputs - 1)
       {
       // Apply dilation factor on low band only in the last level.
+      // double expLevelFactor = - static_cast<double>( (level + 1) * ImageDimension ) / 2.0;
+      // double expLevelFactor = - static_cast<double>( level * ImageDimension ) / 2.0;
+      double expLevelFactor = 0;
+      itkDebugMacro( << "ExpLevelFactor: " << expLevelFactor << ", level: " << level << " 2^expLevelFactor: " << std::pow(2.0, expLevelFactor) );
       typename MultiplyFilterType::Pointer multiplyByDilationLevelFactor = MultiplyFilterType::New();
       multiplyByDilationLevelFactor->SetInput1(shrinkFilter->GetOutput());
-      itkDebugMacro( << " ExpLevelFactor: " << expLevelFactor << ", level: " << level << " 2^expLevelFactor: " << std::pow(2.0, expLevelFactor) );
       multiplyByDilationLevelFactor->SetConstant(std::pow(2.0, expLevelFactor));
       multiplyByDilationLevelFactor->InPlaceOn();
       multiplyByDilationLevelFactor->GraftOutput(this->GetOutput(this->m_TotalOutputs - 1));

--- a/include/itkWaveletFrequencyForward.hxx
+++ b/include/itkWaveletFrequencyForward.hxx
@@ -261,7 +261,7 @@ void WaveletFrequencyForward<TInputImage, TOutputImage, TWaveletFilterBank>
       // Spacing
       inputSpacingPerLevel[idim] = inputSpacingPerLevel[idim] * this->m_ScaleFactor;
       // Origin, the same.
-      inputOriginPerLevel[idim] = inputOriginPerLevel[idim] ;
+      // inputOriginPerLevel[idim] = inputOriginPerLevel[idim] ;
       // inputOriginPerLevel[idim] = inputOriginPerLevel[idim] / this->m_ScaleFactor;
       }
 

--- a/include/itkWaveletFrequencyForward.hxx
+++ b/include/itkWaveletFrequencyForward.hxx
@@ -455,6 +455,7 @@ void WaveletFrequencyForward< TInputImage, TOutputImage, TWaveletFilterBank>
   std::vector<OutputImagePointer> highPassWavelets = filterBank->GetOutputsHighPassBands();
   OutputImagePointer lowPassWavelet = filterBank->GetOutputLowPass();
 
+  // typedef itk::FrequencyShrinkViaInverseFFTImageFilter<OutputImageType> ShrinkFilterType;
   typedef itk::FrequencyShrinkImageFilter<OutputImageType> ShrinkFilterType;
   typedef itk::MultiplyImageFilter<OutputImageType> MultiplyFilterType;
   inputPerLevel = changeInputInfoFilter->GetOutput();
@@ -506,7 +507,6 @@ void WaveletFrequencyForward< TInputImage, TOutputImage, TWaveletFilterBank>
     inputPerLevel = multiplyLowFilter->GetOutput();
 
     /******* DownSample stored low band for the next Level iteration *****/
-    // typedef itk::FrequencyShrinkViaInverseFFTImageFilter<OutputImageType> ShrinkFilterType;
     typename ShrinkFilterType::Pointer shrinkFilter = ShrinkFilterType::New();
     shrinkFilter->SetInput(inputPerLevel);
     shrinkFilter->SetShrinkFactors(this->m_ScaleFactor);

--- a/include/itkWaveletFrequencyInverse.h
+++ b/include/itkWaveletFrequencyInverse.h
@@ -123,6 +123,10 @@ protected:
    */
   virtual void GenerateInputRequestedRegion() ITK_OVERRIDE;
 
+  /** Input images do not occupy the same physical space.
+   * Remove the check. */
+  virtual void VerifyInputInformation() ITK_OVERRIDE {};
+
 private:
   ITK_DISALLOW_COPY_AND_ASSIGN(WaveletFrequencyInverse);
 

--- a/include/itkWaveletFrequencyInverse.h
+++ b/include/itkWaveletFrequencyInverse.h
@@ -149,7 +149,7 @@ private:
   unsigned int m_HighPassSubBands;
   unsigned int m_TotalInputs;
   unsigned int m_ScaleFactor;
-  bool m_ApplyReconstructionFactors;
+  bool         m_ApplyReconstructionFactors;
 };
 } // end namespace itk
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/include/itkWaveletFrequencyInverse.h
+++ b/include/itkWaveletFrequencyInverse.h
@@ -69,13 +69,28 @@ public:
   /** Runtime information support. */
   itkTypeMacro(WaveletFrequencyInverse,
                ImageToImageFilter);
+
+  /** Number of levels/scales. Maximum depends on size of image */
   void SetLevels(unsigned int n);
-
   itkGetMacro(Levels, unsigned int);
-  void SetHighPassSubBands(unsigned int n);
 
+  /** Number of high pass subbands, 1 minimum */
+  void SetHighPassSubBands(unsigned int n);
   itkGetMacro(HighPassSubBands, unsigned int);
+
+  /** Total number of inputs required: Levels*HighPassSubBands + 1 */
   itkGetMacro(TotalInputs, unsigned int);
+
+  /** Shrink/Expand factor at each level.
+   * Set to 2 (dyadic), not modifiable, but providing future flexibility */
+  itkGetConstReferenceMacro(ScaleFactor, unsigned int)
+
+  /** 
+   * If On, applies to each input the appropiate Level-Band multiplicative factor. Needed for perfect reconstruction.
+   * It has to be turned off for some applications (phase analysis for example) */
+  itkGetConstReferenceMacro(ApplyReconstructionFactors, bool)
+  itkSetMacro(ApplyReconstructionFactors, bool)
+  itkBooleanMacro(ApplyReconstructionFactors);
 
   typedef std::pair<unsigned int, unsigned int> IndexPairType;
   /** Get the (Level,Band) from a linear index input */
@@ -133,9 +148,8 @@ private:
   unsigned int m_Levels;
   unsigned int m_HighPassSubBands;
   unsigned int m_TotalInputs;
-  /** Shrink/Expand factor
-   * Set to 2, not modifiable, but provides future flexibility */
   unsigned int m_ScaleFactor;
+  bool m_ApplyReconstructionFactors;
 };
 } // end namespace itk
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/include/itkWaveletFrequencyInverse.hxx
+++ b/include/itkWaveletFrequencyInverse.hxx
@@ -324,6 +324,8 @@ void WaveletFrequencyInverse< TInputImage, TOutputImage, TWaveletFilterBank>
     typename MultiplyFilterType::Pointer multiplyUpsampleCorrection = MultiplyFilterType::New();
     multiplyUpsampleCorrection->SetInput1(low_pass_per_level);
     double expUpsampleCorrection = static_cast<double>(ImageDimension);
+    // double expUpsampleCorrection = static_cast<double>(3 * ImageDimension)/2.0;
+    // double expUpsampleCorrection = static_cast<double>(1 + ImageDimension);
     multiplyUpsampleCorrection->SetConstant(std::pow(2.0, expUpsampleCorrection));
     multiplyUpsampleCorrection->InPlaceOn();
     multiplyUpsampleCorrection->Update();
@@ -392,8 +394,9 @@ void WaveletFrequencyInverse< TInputImage, TOutputImage, TWaveletFilterBank>
       // double expFactorHigh = static_cast<int>(band + 1)/static_cast<double>(this->m_HighPassSubBands) * static_cast<double>(ImageDimension)/2.0;
       // double expFactorHigh = static_cast<double>(1)/static_cast<double>(this->m_HighPassSubBands) * static_cast<double>(ImageDimension)/2.0;
       // double expBandFactor = 0;// + static_cast<double>(ImageDimension)/2.0;
-      // double expBandFactor = static_cast<int>(band)/static_cast<double>(this->m_HighPassSubBands) * static_cast<double>(ImageDimension)/2.0;
-      double expBandFactor = 0;
+      double expBandFactor = ( static_cast<double>(level)
+        - band/ static_cast<double>(this->m_HighPassSubBands) ) * ImageDimension/2.0;
+      // double expBandFactor = 0;
       multiplyByReconstructionBandFactor->SetConstant(std::pow(2.0, expBandFactor));
       multiplyByReconstructionBandFactor->InPlaceOn();
       multiplyByReconstructionBandFactor->Update();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ set(IsotropicWaveletsTests
     itkIsotropicWaveletFrequencyFunctionTest.cxx
     #Isotropic Wavelet
     itkWaveletFrequencyFilterBankGeneratorTest.cxx
+    itkWaveletFrequencyFilterBankGeneratorDownsampleTest.cxx
     itkWaveletFrequencyForwardTest.cxx
     itkWaveletFrequencyInverseTest.cxx
     # Phase Analysis
@@ -89,6 +90,12 @@ itk_add_test(NAME itkWaveletFrequencyFilterBankGeneratorTest2D1
   itkWaveletFrequencyFilterBankGeneratorTest DATA{Input/checkershadow_Lch_512x512.tiff}
   ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyFilterBankGeneratorTest2D2.tiff
   2 "Held" 2)
+# Generatator + Downsample
+itk_add_test(NAME itkWaveletFrequencyFilterBankGeneratorDownsampleTest2D
+  COMMAND IsotropicWaveletsTestDriver
+  itkWaveletFrequencyFilterBankGeneratorDownsampleTest DATA{Input/checkershadow_Lch_512x512.tiff}
+  ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyFilterBankGeneratorDownsampleTest2D.tiff
+    2 2 "Held" 2)
 ## Riesz Related
 # RieszGenerator
 itk_add_test(NAME itkRieszFrequencyFilterBankGeneratorTest

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -188,23 +188,23 @@ itk_add_test(NAME itkRieszWaveletPhaseAnalysisTest
   COMMAND IsotropicWaveletsTestDriver
   itkRieszWaveletPhaseAnalysisTest DATA{Input/collagen_32x32x16.tiff}
   ${ITK_TEST_OUTPUT_DIR}/itkRieszWaveletPhaseAnalysisTest.tiff
-  1 1 ${DefaultWavelet} )
+  1 1 ${DefaultWavelet} Apply )
 itk_add_test(NAME itkRieszWaveletPhaseAnalysisTestMultiLevelMultiBand
   COMMAND IsotropicWaveletsTestDriver
   itkRieszWaveletPhaseAnalysisTest DATA{Input/collagen_64x64x16.tiff}
   ${ITK_TEST_OUTPUT_DIR}/itkRieszWaveletPhaseAnalysisTestMultiLevelMultiBand.tiff
-  2 5 ${DefaultWavelet})
+  2 5 ${DefaultWavelet} Apply )
 ###
 itk_add_test(NAME itkRieszWaveletPhaseAnalysisTest2D
   COMMAND IsotropicWaveletsTestDriver
   itkRieszWaveletPhaseAnalysisTest DATA{Input/checkershadow_Lch_512x512.tiff}
   ${ITK_TEST_OUTPUT_DIR}/itkRieszWaveletPhaseAnalysisTest2D.tiff
-  1 1 ${DefaultWavelet} 2 )
+  1 1 ${DefaultWavelet} Apply 2 )
 itk_add_test(NAME itkRieszWaveletPhaseAnalysisTest2DMultiLevelMultiBand
   COMMAND IsotropicWaveletsTestDriver
   itkRieszWaveletPhaseAnalysisTest DATA{Input/checkershadow_Lch_512x512.tiff}
   ${ITK_TEST_OUTPUT_DIR}/itkRieszWaveletPhaseAnalysisTest2DMultiLevelMultiBand.tiff
-  5 5 ${DefaultWavelet} 2 )
+  5 5 ${DefaultWavelet} Apply 2 )
 #IsotropicWaveletFrequencyFunctionTest
 itk_add_test(NAME itkIsotropicWaveletFrequencyFunctionTest
   COMMAND IsotropicWaveletsTestDriver itkIsotropicWaveletFrequencyFunctionTest

--- a/test/itkFrequencyExpandAndShrinkTest.cxx
+++ b/test/itkFrequencyExpandAndShrinkTest.cxx
@@ -114,6 +114,30 @@ int runFrequencyExpandAndShrinkTest( const std::string & inputImage, const std::
   shrinkViaInverseFFTFilter->SetShrinkFactors(resizeFactor);
   shrinkViaInverseFFTFilter->Update();
 
+  // Test size and metadata
+  typename ComplexImageType::PointType   fftOrigin     = fftFilter->GetOutput()->GetOrigin();
+  typename ComplexImageType::SpacingType fftSpacing    = fftFilter->GetOutput()->GetSpacing();
+  typename ComplexImageType::PointType   afterShrinkOrigin  = shrinkFilter->GetOutput()->GetOrigin();
+  typename ComplexImageType::SpacingType afterShrinkSpacing = shrinkFilter->GetOutput()->GetSpacing();
+
+  if( afterShrinkOrigin != fftOrigin )
+    {
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in Origin (has changed afterShrink): " << std::endl;
+    std::cerr << "Expected: " << fftOrigin << ", but got "
+              << afterShrinkOrigin << std::endl;
+    testPassed = false;
+    }
+
+  if( afterShrinkSpacing != fftSpacing )
+    {
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in Spacing : " << std::endl;
+    std::cerr << "Expected: " << fftSpacing  << ", but got "
+              << afterShrinkSpacing << std::endl;
+    testPassed = false;
+    }
+
   /*********** InverseFFT ***************/
 
   typename InverseFFTFilterType::Pointer inverseFFT1 = InverseFFTFilterType::New();

--- a/test/itkFrequencyExpandAndShrinkTest.cxx
+++ b/test/itkFrequencyExpandAndShrinkTest.cxx
@@ -35,6 +35,7 @@
 #include "itkNumberToString.h"
 #include "itkIsotropicWaveletTestUtilities.h"
 #include "itkTestingMacros.h"
+#include "itkTestingComparisonImageFilter.h"
 
 #include <memory>
 #include <string>
@@ -50,6 +51,7 @@
 template< unsigned int VDimension >
 int runFrequencyExpandAndShrinkTest( const std::string & inputImage, const std::string & outputImage )
 {
+  bool testPassed = true;
   const unsigned int Dimension = VDimension;
 
   typedef double                              PixelType;
@@ -58,38 +60,34 @@ int runFrequencyExpandAndShrinkTest( const std::string & inputImage, const std::
 
   typename ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName( inputImage );
-
   reader->Update();
 
   // Calculate mean value and subtract
   typedef itk::ZeroDCImageFilter< ImageType > ZeroDCFilterType;
   typename ZeroDCFilterType::Pointer zeroDCFilter = ZeroDCFilterType::New();
-
   zeroDCFilter->SetInput( reader->GetOutput() );
-
   zeroDCFilter->Update();
 
   // Perform FFT on input image.
   typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
   typename FFTFilterType::Pointer fftFilter = FFTFilterType::New();
-
   fftFilter->SetInput(zeroDCFilter->GetOutput());
-
   fftFilter->Update();
 
   typedef typename FFTFilterType::OutputImageType                 ComplexImageType;
   typedef itk::InverseFFTImageFilter<ComplexImageType, ImageType> InverseFFTFilterType;
+  size_t resizeFactor = 2;
   /*********** EXPAND ***************/
   typedef itk::FrequencyExpandImageFilter<ComplexImageType> ExpandType;
   typename ExpandType::Pointer expandFilter = ExpandType::New();
   expandFilter->SetInput(fftFilter->GetOutput());
-  expandFilter->SetExpandFactors(2);
+  expandFilter->SetExpandFactors(resizeFactor);
   expandFilter->Update();
 
   typedef itk::FrequencyExpandViaInverseFFTImageFilter<ComplexImageType> ExpandViaInverseFFTType;
   typename ExpandViaInverseFFTType::Pointer expandViaInverseFFTFilter = ExpandViaInverseFFTType::New();
   expandViaInverseFFTFilter->SetInput(fftFilter->GetOutput());
-  expandViaInverseFFTFilter->SetExpandFactors(2);
+  expandViaInverseFFTFilter->SetExpandFactors(resizeFactor);
   expandViaInverseFFTFilter->Update();
 
 // #ifdef ITK_VISUALIZE_TESTS
@@ -107,13 +105,13 @@ int runFrequencyExpandAndShrinkTest( const std::string & inputImage, const std::
   typedef itk::FrequencyShrinkImageFilter<ComplexImageType> ShrinkType;
   typename ShrinkType::Pointer shrinkFilter = ShrinkType::New();
   shrinkFilter->SetInput(expandFilter->GetOutput());
-  shrinkFilter->SetShrinkFactors(2);
+  shrinkFilter->SetShrinkFactors(resizeFactor);
   shrinkFilter->Update();
 
   typedef itk::FrequencyShrinkViaInverseFFTImageFilter<ComplexImageType> ShrinkViaInverseFFTType;
   typename ShrinkViaInverseFFTType::Pointer shrinkViaInverseFFTFilter = ShrinkViaInverseFFTType::New();
   shrinkViaInverseFFTFilter->SetInput(expandViaInverseFFTFilter->GetOutput());
-  shrinkViaInverseFFTFilter->SetShrinkFactors(2);
+  shrinkViaInverseFFTFilter->SetShrinkFactors(resizeFactor);
   shrinkViaInverseFFTFilter->Update();
 
   /*********** InverseFFT ***************/
@@ -123,10 +121,44 @@ int runFrequencyExpandAndShrinkTest( const std::string & inputImage, const std::
   inverseFFT1->Update();
   typename InverseFFTFilterType::Pointer inverseFFT2 = InverseFFTFilterType::New();
   inverseFFT2->SetInput(shrinkViaInverseFFTFilter->GetOutput());
-
   inverseFFT2->Update();
 
+  // Comparison
+  // Via direct frequency manipulation.
+  typedef itk::Testing::ComparisonImageFilter< ImageType, ImageType >
+    DifferenceFilterType;
+  typename DifferenceFilterType::Pointer differenceFilter =
+    DifferenceFilterType::New();
+  differenceFilter->SetToleranceRadius( 0 );
+  differenceFilter->SetDifferenceThreshold(0.000001);
+
+  differenceFilter->SetValidInput( zeroDCFilter->GetOutput() );
+  differenceFilter->SetTestInput( inverseFFT1->GetOutput() );
+  differenceFilter->Update();
+
+  unsigned int numberOfDiffPixels = differenceFilter->GetNumberOfPixelsWithDifferences();
+  if( numberOfDiffPixels > 0 )
+    {
+    std::cerr << "Test failed! " << std::endl;
+    std::cerr << "FrequencyExpand + FrequencyShrinker should be equal to input image, but got " << numberOfDiffPixels
+      << " unequal pixels" << std::endl;
+    testPassed = false;
+    }
+
+  // Via inverseFFT and spatial domain manipulation.
+  differenceFilter->SetTestInput( inverseFFT2->GetOutput() );
+  differenceFilter->Update();
+  numberOfDiffPixels = differenceFilter->GetNumberOfPixelsWithDifferences();
+  if( numberOfDiffPixels > 0 )
+    {
+    std::cerr << "Test failed! " << std::endl;
+    std::cerr << "Expand + Shrinker via inverseFFT through spatial domain should be equal to input image, but got " << numberOfDiffPixels
+      << " unequal pixels" << std::endl;
+    testPassed = false;
+    }
+
 #ifdef ITK_VISUALIZE_TESTS
+  itk::Testing::ViewImage( zeroDCFilter->GetOutput(), "Original" );
   itk::Testing::ViewImage( inverseFFT1->GetOutput(), "ExpandAndShrink via frequency manipulation" );
   itk::Testing::ViewImage( inverseFFT2->GetOutput(), "ExpandAndShrink ViaInverseFFT" );
 #endif
@@ -144,12 +176,14 @@ int runFrequencyExpandAndShrinkTest( const std::string & inputImage, const std::
 
   TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-
-#ifdef ITK_VISUALIZE_TESTS
-  itk::Testing::ViewImage( zeroDCFilter->GetOutput(), "Original" );
-#endif
-
-  return EXIT_SUCCESS;
+  if(testPassed)
+    {
+    return EXIT_SUCCESS;
+    }
+  else
+    {
+    return EXIT_FAILURE;
+    }
 }
 
 int itkFrequencyExpandAndShrinkTest( int argc, char* argv[] )

--- a/test/itkFrequencyExpandTest.cxx
+++ b/test/itkFrequencyExpandTest.cxx
@@ -95,7 +95,7 @@ int runFrequencyExpandTest(const std::string & inputImage, const std::string & o
     testPassed = false;
     }
 
-  if( expandSpacing != fftSpacing * expandFactor )
+  if( expandSpacing != fftSpacing / expandFactor )
     {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in Spacing : " << std::endl;

--- a/test/itkFrequencyExpandTest.cxx
+++ b/test/itkFrequencyExpandTest.cxx
@@ -40,34 +40,30 @@
 #include "itkViewImage.h"
 #endif
 
-
 template< unsigned int VDimension >
 int runFrequencyExpandTest(const std::string & inputImage, const std::string & outputImage)
 {
+  bool testPassed = true;
   const unsigned int Dimension = VDimension;
 
-  typedef double                              PixelType;
-  typedef itk::Image< PixelType, Dimension >  ImageType;
-  typedef itk::ImageFileReader< ImageType >   ReaderType;
+  typedef double                             PixelType;
+  typedef itk::Image< PixelType, Dimension > ImageType;
+  typedef itk::ImageFileReader< ImageType >  ReaderType;
 
   typename ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName( inputImage );
-
   reader->Update();
 
   // Calculate mean value and subtract
   typedef itk::ZeroDCImageFilter< ImageType > ZeroDCFilterType;
   typename ZeroDCFilterType::Pointer zeroDCFilter = ZeroDCFilterType::New();
-
   zeroDCFilter->SetInput( reader->GetOutput() );
-
   zeroDCFilter->Update();
 
   // Perform FFT on input image.
   typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
   typename FFTFilterType::Pointer fftFilter = FFTFilterType::New();
   // fftFilter->SetInput(subtractFilter->GetOutput());
-
   fftFilter->SetInput( zeroDCFilter->GetOutput() );
 
   typedef typename FFTFilterType::OutputImageType ComplexImageType;
@@ -75,24 +71,53 @@ int runFrequencyExpandTest(const std::string & inputImage, const std::string & o
   // ExpandFrequency
   typedef itk::FrequencyExpandImageFilter< ComplexImageType > ExpandType;
   typename ExpandType::Pointer expandFilter = ExpandType::New();
-
   expandFilter->SetInput( fftFilter->GetOutput() );
 
   unsigned int expandFactor = 2;
   typename ExpandType::ExpandFactorsType expandFactors;
   expandFactors.Fill( expandFactor );
-
   expandFilter->SetExpandFactors( expandFactors );
   TEST_SET_GET_VALUE( expandFactors, expandFilter->GetExpandFactors() );
-
   expandFilter->Update();
+
+  // Test size and metadata
+  typename ComplexImageType::PointType   fftOrigin     = fftFilter->GetOutput()->GetOrigin();
+  typename ComplexImageType::SpacingType fftSpacing    = fftFilter->GetOutput()->GetSpacing();
+  typename ComplexImageType::PointType   expandOrigin  = expandFilter->GetOutput()->GetOrigin();
+  typename ComplexImageType::SpacingType expandSpacing = expandFilter->GetOutput()->GetSpacing();
+
+  if( expandOrigin != fftOrigin )
+    {
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in Origin (has changed afterExpand): " << std::endl;
+    std::cerr << "Expected: " << fftOrigin << ", but got "
+              << expandOrigin << std::endl;
+    testPassed = false;
+    }
+
+  if( expandSpacing != fftSpacing * expandFactor )
+    {
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error in Spacing : " << std::endl;
+    std::cerr << "Expected: " << fftSpacing * expandFactor << ", but got "
+              << expandSpacing << std::endl;
+    testPassed = false;
+    }
+
+  // typename ComplexImageType::SpacingType defaultSpacing = {{1.0}};
+  // if( fftSpacing != defaultSpacing )
+  //   {
+  //   std::cerr << "Test failed!" << std::endl;
+  //   std::cerr << "After fft the spacing is not default: " << std::endl;
+  //   std::cerr << "Expected: " << defaultSpacing << ", but got "
+  //             << fftSpacing << std::endl;
+  //   testPassed = false;
+  //   }
 
   // InverseFFT
   typedef itk::InverseFFTImageFilter< ComplexImageType, ImageType > InverseFFTFilterType;
   typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();
-
   inverseFFT->SetInput( expandFilter->GetOutput() );
-
   inverseFFT->Update();
 
   /***************** Hermitian property (sym) *****************************/
@@ -118,7 +143,9 @@ int runFrequencyExpandTest(const std::string & inputImage, const std::string & o
       {
       inputSizeIsEven[dim] = (reader->GetOutput()->GetLargestPossibleRegion().GetSize()[dim] % 2 == 0);
       if (inputSizeIsEven[dim] == false)
+        {
         imageIsEven = false;
+        }
       }
     // Check that complex part is almost 0 after FFT and complex inverse FFT.
       {
@@ -207,7 +234,6 @@ int runFrequencyExpandTest(const std::string & inputImage, const std::string & o
 
   TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-
 #ifdef ITK_VISUALIZE_TESTS
   itk::Testing::ViewImage( zeroDCFilter->GetOutput(), "Original" );
   itk::Testing::ViewImage( inverseFFT->GetOutput(), "FrequencyExpander" );
@@ -231,7 +257,14 @@ int runFrequencyExpandTest(const std::string & inputImage, const std::string & o
   // itk::Testing::ViewImage(complexToRealFilterExpand->GetOutput());
 #endif
 
-  return EXIT_SUCCESS;
+  if(testPassed)
+    {
+    return EXIT_SUCCESS;
+    }
+  else
+    {
+    return EXIT_FAILURE;
+    }
 }
 
 int itkFrequencyExpandTest( int argc, char* argv[] )
@@ -244,7 +277,7 @@ int itkFrequencyExpandTest( int argc, char* argv[] )
 
   const std::string inputImage  = argv[1];
   const std::string outputImage = argv[2];
-  
+
   const unsigned int ImageDimension = 3;
   typedef double                                  PixelType;
   typedef itk::Image< PixelType, ImageDimension > ImageType;
@@ -260,8 +293,7 @@ int itkFrequencyExpandTest( int argc, char* argv[] )
     FrequencyExpandImageFilterType::New();
 
   EXERCISE_BASIC_OBJECT_METHODS( expandFilter, FrequencyExpandImageFilter,
-    ImageToImageFilter );
-
+                                 ImageToImageFilter );
 
   unsigned int dimension = 3;
   if( argc == 4 )

--- a/test/itkFrequencyShrinkTest.cxx
+++ b/test/itkFrequencyShrinkTest.cxx
@@ -213,7 +213,7 @@ int runFrequencyShrinkTest( const std::string & inputImage, const std::string & 
   typename ComplexImageType::PointType   shrinkOrigin  = shrinkFilter->GetOutput()->GetOrigin();
   typename ComplexImageType::SpacingType shrinkSpacing = shrinkFilter->GetOutput()->GetSpacing();
 
-  if( fftOrigin != shrinkOrigin )
+  if( shrinkOrigin != fftOrigin )
     {
     std::cerr << "Test failed!" << std::endl;
     std::cerr << "Error in Origin (has changed afterShrink): " << std::endl;
@@ -222,11 +222,11 @@ int runFrequencyShrinkTest( const std::string & inputImage, const std::string & 
     return EXIT_FAILURE;
     }
 
-  if( fftSpacing != shrinkSpacing )
+  if( shrinkSpacing != fftSpacing * 0.5 )
     {
     std::cerr << "Test failed!" << std::endl;
-    std::cerr << "Error in Spacing (has changed afterShrink): " << std::endl;
-    std::cerr << "Expected: " << fftSpacing << ", but got "
+    std::cerr << "Error in Spacing (should be half afterShrink): " << std::endl;
+    std::cerr << "Expected: " << fftSpacing * 0.5 << ", but got "
       << shrinkSpacing << std::endl;
     return EXIT_FAILURE;
     }

--- a/test/itkFrequencyShrinkTest.cxx
+++ b/test/itkFrequencyShrinkTest.cxx
@@ -213,6 +213,7 @@ int runFrequencyShrinkTest( const std::string & inputImage, const std::string & 
   typename ComplexImageType::PointType   shrinkOrigin  = shrinkFilter->GetOutput()->GetOrigin();
   typename ComplexImageType::SpacingType shrinkSpacing = shrinkFilter->GetOutput()->GetSpacing();
 
+    std::cout << "ShrinkOrigin = " << shrinkOrigin <<std::endl;
   if( shrinkOrigin != fftOrigin )
     {
     std::cerr << "Test failed!" << std::endl;
@@ -222,11 +223,12 @@ int runFrequencyShrinkTest( const std::string & inputImage, const std::string & 
     testPassed = false;
     }
 
-  if( shrinkSpacing != fftSpacing * 0.5 )
+    std::cout << "ShrinkSpacing = " << shrinkSpacing <<std::endl;
+  if( shrinkSpacing != fftSpacing * 2.0 )
     {
     std::cerr << "Test failed!" << std::endl;
-    std::cerr << "Error in Spacing (should be half afterShrink): " << std::endl;
-    std::cerr << "Expected: " << fftSpacing * 0.5 << ", but got "
+    std::cerr << "Error in Spacing (should be double after shrink): " << std::endl;
+    std::cerr << "Expected: " << fftSpacing * 2.0 << ", but got "
               << shrinkSpacing << std::endl;
     testPassed = false;
     }

--- a/test/itkFrequencyShrinkTest.cxx
+++ b/test/itkFrequencyShrinkTest.cxx
@@ -239,7 +239,7 @@ int runFrequencyShrinkTest( const std::string & inputImage, const std::string & 
 
   typedef itk::ChangeInformationImageFilter<ComplexImageType> ChangeInformationFilterType;
   typename ChangeInformationFilterType::Pointer changeInputInfoFilter = ChangeInformationFilterType::New();
-  typename ComplexImageType::PointType   origin_new ;
+  typename ComplexImageType::PointType   origin_new;
   origin_new.Fill(0);
   typename ComplexImageType::SpacingType spacing_new;
   spacing_new.Fill(1);

--- a/test/itkRieszFrequencyFilterBankGeneratorTest.cxx
+++ b/test/itkRieszFrequencyFilterBankGeneratorTest.cxx
@@ -51,21 +51,15 @@ int itkRieszFrequencyFilterBankGeneratorTest( int argc, char* argv[] )
   typedef itk::ImageFileReader< ImageType >   ReaderType;
 
   ReaderType::Pointer reader = ReaderType::New();
-
   reader->SetFileName(inputImage);
-
   reader->Update();
-
   reader->UpdateLargestPossibleRegion();
 
   // Perform FFT on input image
   typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
   FFTFilterType::Pointer fftFilter = FFTFilterType::New();
-
   fftFilter->SetInput( reader->GetOutput() );
-
   fftFilter->Update();
-
 
   typedef FFTFilterType::OutputImageType ComplexImageType;
 
@@ -73,12 +67,9 @@ int itkRieszFrequencyFilterBankGeneratorTest( int argc, char* argv[] )
   typedef itk::RieszFrequencyFilterBankGenerator< ComplexImageType > RieszFilterBankType;
   RieszFilterBankType::Pointer filterBank = RieszFilterBankType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS( filterBank, RieszFrequencyFilterBankGenerator,
-    GenerateImageSource );
-
+  EXERCISE_BASIC_OBJECT_METHODS( filterBank, RieszFrequencyFilterBankGenerator, GenerateImageSource );
 
   filterBank->SetSize( fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize() );
-
   filterBank->Update();
 
   // Get real part of complex image for visualization
@@ -89,7 +80,6 @@ int itkRieszFrequencyFilterBankGeneratorTest( int argc, char* argv[] )
     {
     std::cout << "Direction: " << dir + 1 << " / " << ImageType::ImageDimension << std::endl;
     complexToRealFilter->SetInput( filterBank->GetOutput( dir ) );
-
     complexToRealFilter->Update();
 
 #ifdef ITK_VISUALIZE_TESTS
@@ -97,7 +87,6 @@ int itkRieszFrequencyFilterBankGeneratorTest( int argc, char* argv[] )
     itk::Testing::ViewImage( complexToRealFilter->GetOutput(), "RealPart of Complex. Direction: " + n2s(
                          dir + 1) + " / " + n2s( ImageType::ImageDimension ) );
 #endif
-
     }
   return EXIT_SUCCESS;
 }

--- a/test/itkRieszWaveletPhaseAnalysisTest.cxx
+++ b/test/itkRieszWaveletPhaseAnalysisTest.cxx
@@ -151,8 +151,11 @@ int runRieszWaveletPhaseAnalysisTest( const std::string& inputImage,
 
 #ifdef ITK_VISUALIZE_TESTS
   // Visualize and compare modified wavelets coefficients (and approx image)
-  for( unsigned int i = 0; i < forwardWavelet->GetNumberOfOutputs(); ++i )
+  bool visualizeCoefficients = false;
+  if(visualizeCoefficients)
     {
+    for( unsigned int i = 0; i < forwardWavelet->GetNumberOfOutputs(); ++i )
+      {
       itk::NumberToString< unsigned int > n2s;
       typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();
       inverseFFT->SetInput(analysisWavelets[i]);
@@ -161,6 +164,7 @@ int runRieszWaveletPhaseAnalysisTest( const std::string& inputImage,
       inverseFFT->SetInput(modifiedWavelets[i]);
       inverseFFT->Update();
       itk::Testing::ViewImage( inverseFFT->GetOutput(), "WaveletCoef. PhaseAnalyzed #" + n2s(i) );
+      }
     }
 #endif
 

--- a/test/itkRieszWaveletPhaseAnalysisTest.cxx
+++ b/test/itkRieszWaveletPhaseAnalysisTest.cxx
@@ -38,7 +38,6 @@
 
 #include "itkGaussianSpatialFunction.h" 
 #include "itkFrequencyImageRegionIteratorWithIndex.h"
-
 #include "itkTestingMacros.h"
 
 #include <string>
@@ -63,7 +62,6 @@ int runRieszWaveletPhaseAnalysisTest( const std::string& inputImage,
 
   typename ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName( inputImage );
-
   reader->Update();
 
   // Wavelet analysis (forward)
@@ -74,16 +72,13 @@ int runRieszWaveletPhaseAnalysisTest( const std::string& inputImage,
   typedef itk::ZeroDCImageFilter< ImageType > ZeroDCFilterType;
   typename ZeroDCFilterType::Pointer zeroDCFilter = ZeroDCFilterType::New();
   zeroDCFilter->SetInput( reader->GetOutput() );
-
   zeroDCFilter->Update();
 
   // Perform FFT on input image.
   typedef itk::ForwardFFTImageFilter< typename ZeroDCFilterType::OutputImageType >
     FFTForwardFilterType;
   typename FFTForwardFilterType::Pointer fftForwardFilter = FFTForwardFilterType::New();
-
   fftForwardFilter->SetInput( zeroDCFilter->GetOutput() );
-
   fftForwardFilter->Update();
 
   typedef typename FFTForwardFilterType::OutputImageType ComplexImageType;
@@ -95,16 +90,12 @@ int runRieszWaveletPhaseAnalysisTest( const std::string& inputImage,
   typedef itk::WaveletFrequencyForward< ComplexImageType, ComplexImageType, WaveletFilterBankType >
     ForwardWaveletType;
   typename ForwardWaveletType::Pointer forwardWavelet = ForwardWaveletType::New();
-
   unsigned int highSubBands = inputBands;
   unsigned int levels = inputLevels;
   forwardWavelet->SetHighPassSubBands( highSubBands );
   forwardWavelet->SetLevels( levels );
-
   forwardWavelet->SetInput( fftForwardFilter->GetOutput() );
-
   forwardWavelet->Update();
-
   typename ForwardWaveletType::OutputsType analysisWavelets =
     forwardWavelet->GetOutputs();
 
@@ -119,11 +110,12 @@ int runRieszWaveletPhaseAnalysisTest( const std::string& inputImage,
     PhaseAnalysisFilter;
 
   typename ForwardWaveletType::OutputsType modifiedWavelets;
-  unsigned int numberOfOutouts = forwardWavelet->GetNumberOfOutputs();
+  unsigned int numberOfOutputs = forwardWavelet->GetNumberOfOutputs();
   for( unsigned int i = 0; i < forwardWavelet->GetNumberOfOutputs(); ++i )
     {
-    std::cout << "Output #: " << i << " / " << numberOfOutouts << std::endl;
-    if( i == 12000 ) // TODO check this. avoid phase analysis in last approximation (low_pass).
+    std::cout << "Output #: " << i << " / " << numberOfOutputs << std::endl;
+    // if( i == 12000 ) // TODO check this. avoid phase analysis in last approximation (low_pass).
+    if( i == numberOfOutputs - 1 ) // TODO check this. avoid phase analysis in last approximation (low_pass).
       {
       modifiedWavelets.push_back( analysisWavelets[i] );
       continue;
@@ -141,31 +133,25 @@ int runRieszWaveletPhaseAnalysisTest( const std::string& inputImage,
     monoFilter->Update();
 
     vecInverseFFT->SetInput( monoFilter->GetOutput() );
-
     vecInverseFFT->Update();
 
     phaseAnalyzer->SetInput( vecInverseFFT->GetOutput() );
     phaseAnalyzer->SetApplySoftThreshold( false );
-
     phaseAnalyzer->Update();
 
     fftForwardPhaseFilter->SetInput( phaseAnalyzer->GetOutputCosPhase() );
-
     fftForwardPhaseFilter->Update();
 
     modifiedWavelets.push_back( fftForwardPhaseFilter->GetOutput() );
     modifiedWavelets.back()->DisconnectPipeline();
-
     }
 
   typedef itk::WaveletFrequencyInverse< ComplexImageType, ComplexImageType, WaveletFilterBankType >
     InverseWaveletType;
   typename InverseWaveletType::Pointer inverseWavelet = InverseWaveletType::New();
-
   inverseWavelet->SetHighPassSubBands( highSubBands );
-  inverseWavelet->SetLevels( levels);
+  inverseWavelet->SetLevels( levels );
   inverseWavelet->SetInputs( modifiedWavelets );
-
   inverseWavelet->Update();
 
   // bool apply_gaussian = false;
@@ -213,7 +199,6 @@ int runRieszWaveletPhaseAnalysisTest( const std::string& inputImage,
   typedef itk::InverseFFTImageFilter< ComplexImageType, ImageType > InverseFFTFilterType;
   typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();
   inverseFFT->SetInput( inverseWavelet->GetOutput() );
-
   inverseFFT->Update();
 
 #ifdef ITK_VISUALIZE_TESTS

--- a/test/itkWaveletFrequencyForwardTest.cxx
+++ b/test/itkWaveletFrequencyForwardTest.cxx
@@ -198,7 +198,7 @@ int runWaveletFrequencyForwardTest( const std::string& inputImage,
     {
     double scaleFactorPerLevel = std::pow( static_cast<double>(forwardWavelet->GetScaleFactor()), level);
     unsigned int nOutput;
-    for (unsigned int i = 0; i < Dimension ; ++i)
+    for (unsigned int i = 0; i < Dimension; ++i)
     {
       expectedSize[i] = inputSize[i] / scaleFactorPerLevel;
       expectedOrigin[i] = inputOrigin[i];

--- a/test/itkWaveletFrequencyForwardTest.cxx
+++ b/test/itkWaveletFrequencyForwardTest.cxx
@@ -202,7 +202,7 @@ int runWaveletFrequencyForwardTest( const std::string& inputImage,
     {
       expectedSize[i] = inputSize[i] / scaleFactorPerLevel;
       expectedOrigin[i] = inputOrigin[i];
-      expectedSpacing[i] = inputSpacing[i] / scaleFactorPerLevel;
+      expectedSpacing[i] = inputSpacing[i] * scaleFactorPerLevel;
     }
     for( unsigned int band = 0; band < highSubBands; ++band )
       {
@@ -224,17 +224,17 @@ int runWaveletFrequencyForwardTest( const std::string& inputImage,
 
       if(expectedSize != forwardWavelet->GetOutput( nOutput )->GetLargestPossibleRegion().GetSize())
         {
-        std::cerr << "Size of the output is not as expected." << std::endl;
+        std::cerr << "Size of the output is not as expected: " << expectedSize << std::endl;
         sizeIsCorrect = false;
         }
       if(expectedOrigin != forwardWavelet->GetOutput( nOutput )->GetOrigin())
         {
-        std::cerr << "Origin of the output is not as expected." << std::endl;
+        std::cerr << "Origin of the output is not as expected: " << expectedOrigin << std::endl;
         originIsCorrect = false;
         }
       if(expectedSpacing != forwardWavelet->GetOutput( nOutput )->GetSpacing())
         {
-        std::cerr << "Spacing of the output is not as expected." << std::endl;
+        std::cerr << "Spacing of the output is not as expected: " << expectedSpacing << std::endl;
         spacingIsCorrect = false;
         }
 

--- a/test/itkWaveletFrequencyInverseTest.cxx
+++ b/test/itkWaveletFrequencyInverseTest.cxx
@@ -54,17 +54,13 @@ int runWaveletFrequencyInverseTest( const std::string& inputImage,
   typedef itk::ImageFileReader< ImageType >   ReaderType;
 
   typename ReaderType::Pointer reader = ReaderType::New();
-
   reader->SetFileName( inputImage );
-
   reader->Update();
-
   reader->UpdateLargestPossibleRegion();
 
   // Perform FFT on input image.
   typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
   typename FFTFilterType::Pointer fftFilter = FFTFilterType::New();
-
   fftFilter->SetInput( reader->GetOutput() );
 
   typedef typename FFTFilterType::OutputImageType ComplexImageType;
@@ -81,7 +77,6 @@ int runWaveletFrequencyInverseTest( const std::string& inputImage,
   forwardWavelet->SetHighPassSubBands( inputBands );
   forwardWavelet->SetLevels( inputLevels );
   forwardWavelet->SetInput( fftFilter->GetOutput() );
-
   forwardWavelet->Update();
 
   unsigned int noutputs = forwardWavelet->GetNumberOfOutputs();
@@ -89,9 +84,9 @@ int runWaveletFrequencyInverseTest( const std::string& inputImage,
   std::cout << "Number of inputs: " << noutputs << std::endl;
   for ( unsigned int i = 0; i < noutputs; ++i )
     {
-    std::cout << " Size of input: " << i << std::endl;
-    std::cout << forwardWavelet->GetOutput(i)->GetLargestPossibleRegion() << std::endl;
-    std::cout << forwardWavelet->GetOutput(i)->GetSpacing() << std::endl;
+    std::cout << "Input number: " << i << std::endl;
+    std::cout << "Region: " << forwardWavelet->GetOutput(i)->GetLargestPossibleRegion() << std::endl;
+    std::cout << "Spacing: " << forwardWavelet->GetOutput(i)->GetSpacing() << std::endl;
     }
 
   // Inverse Wavelet Transform
@@ -102,14 +97,11 @@ int runWaveletFrequencyInverseTest( const std::string& inputImage,
   inverseWavelet->SetHighPassSubBands( inputBands );
   inverseWavelet->SetLevels( inputLevels );
   inverseWavelet->SetInputs( forwardWavelet->GetOutputs() );
-
   inverseWavelet->Update();
 
   typedef itk::InverseFFTImageFilter<ComplexImageType, ImageType> InverseFFTFilterType;
   typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();
-
   inverseFFT->SetInput( inverseWavelet->GetOutput() );
-
   inverseFFT->Update();
 
   // Write output image

--- a/test/itkWaveletFrequencyInverseTest.cxx
+++ b/test/itkWaveletFrequencyInverseTest.cxx
@@ -47,6 +47,7 @@ int runWaveletFrequencyInverseTest( const std::string& inputImage,
                                     const unsigned int& inputLevels,
                                     const unsigned int& inputBands)
 {
+  bool testPassed = true;
   const unsigned int Dimension = VDimension;
 
   typedef float                               PixelType;
@@ -99,6 +100,41 @@ int runWaveletFrequencyInverseTest( const std::string& inputImage,
   inverseWavelet->SetInputs( forwardWavelet->GetOutputs() );
   inverseWavelet->Update();
 
+  //Check Metadata: Spacing, Origin
+  typename ComplexImageType::SpacingType outputSpacing =
+    inverseWavelet->GetOutput()->GetSpacing();
+  typename ComplexImageType::SpacingType expectedSpacing = {{1.0}};
+  typename ComplexImageType::PointType outputOrigin =
+    inverseWavelet->GetOutput()->GetOrigin();
+  typename ComplexImageType::PointType expectedOrigin = {{0.0}};
+  typename ComplexImageType::SizeType outputSize =
+    inverseWavelet->GetOutput()->GetLargestPossibleRegion().GetSize();
+  typename ComplexImageType::SizeType expectedSize =
+    fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize();
+
+  if(outputSpacing != expectedSpacing)
+    {
+    std::cout << "outputSpacing is wrong: " << outputSpacing
+      << " expectedSpacing: " << expectedSpacing
+      << std::endl;
+    testPassed = false;
+    }
+  if(outputOrigin != expectedOrigin)
+    {
+    std::cout << "outputOrigin is wrong: " << outputOrigin
+      << " expectedOrigin: " << expectedOrigin
+      << std::endl;
+    testPassed = false;
+    }
+  if(outputSize != expectedSize)
+    {
+    std::cout << "outputSize is wrong: " << outputSize
+      << " expectedSize: " << expectedSize
+      << std::endl;
+    testPassed = false;
+    }
+
+
   typedef itk::InverseFFTImageFilter<ComplexImageType, ImageType> InverseFFTFilterType;
   typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();
   inverseFFT->SetInput( inverseWavelet->GetOutput() );
@@ -117,7 +153,14 @@ int runWaveletFrequencyInverseTest( const std::string& inputImage,
   itk::Testing::ViewImage( inverseFFT->GetOutput(), "InverseWavelet" );
 #endif
 
-  return EXIT_SUCCESS;
+  if(testPassed)
+    {
+    return EXIT_SUCCESS;
+    }
+  else
+    {
+    return EXIT_FAILURE;
+    }
 }
 
 int itkWaveletFrequencyInverseTest(int argc, char *argv[])
@@ -141,82 +184,82 @@ int itkWaveletFrequencyInverseTest(int argc, char *argv[])
     dimension = atoi( argv[6] );
     }
 
-  const unsigned int ImageDimension = 3;
-  typedef double                                          PixelType;
-  typedef std::complex< PixelType >                       ComplexPixelType;
-  typedef itk::Point< PixelType, ImageDimension >         PointType;
-  typedef itk::Image< ComplexPixelType, ImageDimension >  ComplexImageType;
+  // const unsigned int ImageDimension = 3;
+  // typedef double                                          PixelType;
+  // typedef std::complex< PixelType >                       ComplexPixelType;
+  // typedef itk::Point< PixelType, ImageDimension >         PointType;
+  // typedef itk::Image< ComplexPixelType, ImageDimension >  ComplexImageType;
 
-  // Exercise basic object methods
-  // Done outside the helper function in the test because GCC is limited
-  // when calling overloaded base class functions.
-  typedef itk::HeldIsotropicWavelet< PixelType, ImageDimension, PointType >
-    HeldIsotropicWaveletType;
-  typedef itk::VowIsotropicWavelet< PixelType, ImageDimension, PointType >
-    VowIsotropicWaveletType;
-  typedef itk::SimoncelliIsotropicWavelet< PixelType, ImageDimension, PointType >
-    SimoncelliIsotropicWaveletType;
-  typedef itk::ShannonIsotropicWavelet< PixelType, ImageDimension, PointType >
-    ShannonIsotropicWaveletType;
-
-  HeldIsotropicWaveletType::Pointer heldIsotropicWavelet =
-    HeldIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS( heldIsotropicWavelet, HeldIsotropicWavelet,
-    IsotropicWaveletFrequencyFunction );
-
-  VowIsotropicWaveletType::Pointer vowIsotropicWavelet =
-    VowIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS( vowIsotropicWavelet, VowIsotropicWavelet,
-    IsotropicWaveletFrequencyFunction );
-
-  SimoncelliIsotropicWaveletType::Pointer simoncellidIsotropicWavelet =
-    SimoncelliIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS( simoncellidIsotropicWavelet, SimoncelliIsotropicWavelet,
-    IsotropicWaveletFrequencyFunction );
-
-  ShannonIsotropicWaveletType::Pointer shannonIsotropicWavelet = ShannonIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS( shannonIsotropicWavelet, ShannonIsotropicWavelet,
-    IsotropicWaveletFrequencyFunction );
-
-
+  // // Exercise basic object methods
+  // // Done outside the helper function in the test because GCC is limited
+  // // when calling overloaded base class functions.
+  // typedef itk::HeldIsotropicWavelet< PixelType, ImageDimension, PointType >
+  //   HeldIsotropicWaveletType;
+  // typedef itk::VowIsotropicWavelet< PixelType, ImageDimension, PointType >
+  //   VowIsotropicWaveletType;
+  // typedef itk::SimoncelliIsotropicWavelet< PixelType, ImageDimension, PointType >
+  //   SimoncelliIsotropicWaveletType;
+  // typedef itk::ShannonIsotropicWavelet< PixelType, ImageDimension, PointType >
+  //   ShannonIsotropicWaveletType;
+  //
+  // HeldIsotropicWaveletType::Pointer heldIsotropicWavelet =
+  //   HeldIsotropicWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( heldIsotropicWavelet, HeldIsotropicWavelet,
+  //   IsotropicWaveletFrequencyFunction );
+  //
+  // VowIsotropicWaveletType::Pointer vowIsotropicWavelet =
+  //   VowIsotropicWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( vowIsotropicWavelet, VowIsotropicWavelet,
+  //   IsotropicWaveletFrequencyFunction );
+  //
+  // SimoncelliIsotropicWaveletType::Pointer simoncellidIsotropicWavelet =
+  //   SimoncelliIsotropicWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( simoncellidIsotropicWavelet, SimoncelliIsotropicWavelet,
+  //   IsotropicWaveletFrequencyFunction );
+  //
+  // ShannonIsotropicWaveletType::Pointer shannonIsotropicWavelet = ShannonIsotropicWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( shannonIsotropicWavelet, ShannonIsotropicWavelet,
+  //   IsotropicWaveletFrequencyFunction );
+  //
+  //
   typedef itk::HeldIsotropicWavelet<>       HeldWavelet;
   typedef itk::VowIsotropicWavelet<>        VowWavelet;
   typedef itk::SimoncelliIsotropicWavelet<> SimoncelliWavelet;
   typedef itk::ShannonIsotropicWavelet<>    ShannonWavelet;
-
-
-  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, HeldWavelet >
-    HeldWaveletFilterBankType;
-  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, VowWavelet >
-    VowWaveletFilterBankType;
-  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, SimoncelliWavelet >
-    SimoncelliWaveletFilterBankType;
-  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, ShannonWavelet >
-    ShannonWaveletFilterBankType;
-
-  typedef itk::WaveletFrequencyInverse< ComplexImageType, ComplexImageType, HeldWaveletFilterBankType >
-    HeldInverseWaveletType;
-  HeldInverseWaveletType::Pointer heldInverseWavelet = HeldInverseWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS( heldInverseWavelet, WaveletFrequencyInverse,
-    ImageToImageFilter );
-
-  typedef itk::WaveletFrequencyInverse< ComplexImageType, ComplexImageType, VowWaveletFilterBankType >
-    VowInverseWaveletType;
-  VowInverseWaveletType::Pointer vowInverseWavelet = VowInverseWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS( vowInverseWavelet, WaveletFrequencyInverse,
-    ImageToImageFilter );
-
-  typedef itk::WaveletFrequencyInverse< ComplexImageType, ComplexImageType, SimoncelliWaveletFilterBankType >
-    SimoncelliInverseWaveletType;
-  SimoncelliInverseWaveletType::Pointer simoncelliInverseWavelet = SimoncelliInverseWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS( simoncelliInverseWavelet, WaveletFrequencyInverse,
-    ImageToImageFilter );
-
-  typedef itk::WaveletFrequencyInverse< ComplexImageType, ComplexImageType, ShannonWaveletFilterBankType >
-    ShannonInverseWaveletType;
-  ShannonInverseWaveletType::Pointer shannonInverseWavelet = ShannonInverseWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS( shannonInverseWavelet, WaveletFrequencyInverse,
-    ImageToImageFilter );
+  //
+  //
+  // typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, HeldWavelet >
+  //   HeldWaveletFilterBankType;
+  // typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, VowWavelet >
+  //   VowWaveletFilterBankType;
+  // typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, SimoncelliWavelet >
+  //   SimoncelliWaveletFilterBankType;
+  // typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, ShannonWavelet >
+  //   ShannonWaveletFilterBankType;
+  //
+  // typedef itk::WaveletFrequencyInverse< ComplexImageType, ComplexImageType, HeldWaveletFilterBankType >
+  //   HeldInverseWaveletType;
+  // HeldInverseWaveletType::Pointer heldInverseWavelet = HeldInverseWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( heldInverseWavelet, WaveletFrequencyInverse,
+  //   ImageToImageFilter );
+  //
+  // typedef itk::WaveletFrequencyInverse< ComplexImageType, ComplexImageType, VowWaveletFilterBankType >
+  //   VowInverseWaveletType;
+  // VowInverseWaveletType::Pointer vowInverseWavelet = VowInverseWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( vowInverseWavelet, WaveletFrequencyInverse,
+  //   ImageToImageFilter );
+  //
+  // typedef itk::WaveletFrequencyInverse< ComplexImageType, ComplexImageType, SimoncelliWaveletFilterBankType >
+  //   SimoncelliInverseWaveletType;
+  // SimoncelliInverseWaveletType::Pointer simoncelliInverseWavelet = SimoncelliInverseWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( simoncelliInverseWavelet, WaveletFrequencyInverse,
+  //   ImageToImageFilter );
+  //
+  // typedef itk::WaveletFrequencyInverse< ComplexImageType, ComplexImageType, ShannonWaveletFilterBankType >
+  //   ShannonInverseWaveletType;
+  // ShannonInverseWaveletType::Pointer shannonInverseWavelet = ShannonInverseWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( shannonInverseWavelet, WaveletFrequencyInverse,
+  //   ImageToImageFilter );
 
 
   if( dimension == 2 )


### PR DESCRIPTION
Forward Wavelet outputs now have their spacing modified.
The output list layout has been changed, now the approximation/low pass image is last. This makes the output list ordered by level.

RieszPhaseAnalysis test now reproduces Held work. It was done suppressing the multiplication by reconstruction factors in the inverse wavelet transform.

Also the wavelet filters are now downsampled instead of recalculated.
FrequencyIterator now have some members that can be seen as ImageInformation (metadata) for the frequency image. 

