### PR TITLE
Expand RieszFrequencyFunction to a generalized version.

### DIFF
--- a/include/itkMonogenicSignalFrequencyImageFilter.h
+++ b/include/itkMonogenicSignalFrequencyImageFilter.h
@@ -21,6 +21,7 @@
 #include <itkImageToImageFilter.h>
 #include <itkVectorImage.h>
 #include <itkFrequencyImageRegionConstIteratorWithIndex.h>
+#include "itkRieszFrequencyFunction.h"
 namespace itk
 {
 /** \class MonogenicSignalFrequencyImageFilter
@@ -78,9 +79,16 @@ public:
   typedef typename Superclass::OutputImagePointer    OutputImagePointer;
   typedef typename Superclass::OutputImageRegionType OutputImageRegionType;
 
+  /** RieszFunction typedefs. */
+  typedef RieszFrequencyFunction< typename InputImageType::PixelType, ImageDimension> RieszFunctionType;
+  typedef typename RieszFunctionType::Pointer                                         RieszFunctionPointer;
+
+  /** Get the riesz function type */
+  itkGetModifiableObjectMacro(Evaluator, RieszFunctionType);
 protected:
   MonogenicSignalFrequencyImageFilter();
   ~MonogenicSignalFrequencyImageFilter() {}
+  virtual void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
   virtual void GenerateOutputInformation() ITK_OVERRIDE;
 
@@ -89,6 +97,7 @@ protected:
 
 private:
   ITK_DISALLOW_COPY_AND_ASSIGN(MonogenicSignalFrequencyImageFilter);
+  RieszFunctionPointer m_Evaluator;
 };
 } // end namespace itk
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/include/itkMonogenicSignalFrequencyImageFilter.hxx
+++ b/include/itkMonogenicSignalFrequencyImageFilter.hxx
@@ -57,7 +57,7 @@ MonogenicSignalFrequencyImageFilter<TInputImage, TFrequencyImageRegionConstItera
 
   for (inFreqIt.GoToBegin(), outIt.GoToBegin(); !inFreqIt.IsAtEnd(); ++inFreqIt, ++outIt)
     {
-    typename RieszFunctionType::OutputArrayType evaluatedArray =
+    typename RieszFunctionType::OutputComplexArrayType evaluatedArray =
       evaluator->EvaluateArray(inFreqIt.GetFrequency());
     typename OutputImageType::PixelType out_value = outIt.Get();
     out_value[0] = inFreqIt.Get();

--- a/include/itkMonogenicSignalFrequencyImageFilter.hxx
+++ b/include/itkMonogenicSignalFrequencyImageFilter.hxx
@@ -19,13 +19,14 @@
 #define itkMonogenicSignalFrequencyImageFilter_hxx
 #include "itkMonogenicSignalFrequencyImageFilter.h"
 #include "itkImageRegionIterator.h"
-#include "itkRieszFrequencyFunction.h"
 namespace itk
 {
 template< typename TInputImage, typename TFrequencyImageRegionConstIterator>
 MonogenicSignalFrequencyImageFilter<TInputImage, TFrequencyImageRegionConstIterator>
 ::MonogenicSignalFrequencyImageFilter()
 {
+  m_Evaluator = RieszFunctionType::New();
+  m_Evaluator->SetOrder(1);
 }
 
 template< typename TInputImage, typename TFrequencyImageRegionConstIterator>
@@ -50,16 +51,12 @@ MonogenicSignalFrequencyImageFilter<TInputImage, TFrequencyImageRegionConstItera
   InputFrequencyImageRegionConstIterator inFreqIt(this->GetInput(), outputRegionForThread);
   ImageRegionIterator< OutputImageType > outIt(this->GetOutput(), outputRegionForThread);
 
-  typedef RieszFrequencyFunction<
-    typename InputImageType::PixelType,
-    ImageDimension> RieszFunctionType;
-  typename RieszFunctionType::Pointer evaluator = RieszFunctionType::New();
-
+  typename RieszFunctionType::OutputComponentsType evaluatedArray;
+  typename OutputImageType::PixelType out_value;
   for (inFreqIt.GoToBegin(), outIt.GoToBegin(); !inFreqIt.IsAtEnd(); ++inFreqIt, ++outIt)
     {
-    typename RieszFunctionType::OutputComplexArrayType evaluatedArray =
-      evaluator->EvaluateArray(inFreqIt.GetFrequency());
-    typename OutputImageType::PixelType out_value = outIt.Get();
+    evaluatedArray = this->m_Evaluator->EvaluateAllComponents(inFreqIt.GetFrequency());
+    out_value = outIt.Get();
     out_value[0] = inFreqIt.Get();
     for (unsigned int dir = 0; dir < ImageDimension; ++dir)
       {
@@ -67,6 +64,23 @@ MonogenicSignalFrequencyImageFilter<TInputImage, TFrequencyImageRegionConstItera
       out_value[dir + 1] = inFreqIt.Get() * evaluatedArray[dir];
       }
     outIt.Set(out_value);
+    }
+}
+
+template< typename TInputImage, typename TFrequencyImageRegionConstIterator>
+void
+MonogenicSignalFrequencyImageFilter<TInputImage, TFrequencyImageRegionConstIterator>
+::PrintSelf(std::ostream & os, Indent indent) const
+{
+  Superclass::PrintSelf(os,indent);
+  os << indent << "m_Evaluator: ";
+  if(!this->m_Evaluator)
+    {
+    os << "0" << std::endl;
+    }
+  else
+    {
+    os << this->m_Evaluator << std::endl;
     }
 }
 } // end namespace itk

--- a/include/itkMonogenicSignalFrequencyImageFilter.hxx
+++ b/include/itkMonogenicSignalFrequencyImageFilter.hxx
@@ -51,7 +51,7 @@ MonogenicSignalFrequencyImageFilter<TInputImage, TFrequencyImageRegionConstItera
   ImageRegionIterator< OutputImageType > outIt(this->GetOutput(), outputRegionForThread);
 
   typedef RieszFrequencyFunction<
-    typename InputImageType::PixelType::value_type,
+    typename InputImageType::PixelType,
     ImageDimension> RieszFunctionType;
   typename RieszFunctionType::Pointer evaluator = RieszFunctionType::New();
 

--- a/include/itkRieszFrequencyFilterBankGenerator.h
+++ b/include/itkRieszFrequencyFilterBankGenerator.h
@@ -78,9 +78,8 @@ public:
   std::vector<OutputImagePointer> GetOutputs();
 
 // #ifdef ITK_USE_CONCEPT_CHECKING
-//  /// This ensure that OutputPixelType is complex<float||double>
-//   itkConceptMacro( OutputPixelTypeIsComplexAndFloatCheck,
-//                    ( Concept::IsFloatingPoint< typename OutputImageType::PixelType::value_type > ) );
+//   itkConceptMacro( OutputPixelTypeIsFloatCheck,
+//                    ( Concept::IsFloatingPoint< typename OutputImageType::PixelType > ) );
 // #endif
 
 protected:

--- a/include/itkRieszFrequencyFilterBankGenerator.h
+++ b/include/itkRieszFrequencyFilterBankGenerator.h
@@ -27,6 +27,11 @@
 namespace itk
 {
 /** \class RieszFrequencyFilterBankGenerator
+ * Generate a filter bank of M components.
+ * M = p(N,d); where N = Order of the RieszTransform, and d = ImageDimension.
+ * M := p(N,d) = \frac{(N+d-1)!}{(d-1)! N!}
+ *
+ * TODO: OLD DELETE ME 
  * \brief Generate filter bank of RieszFrequencyFunction.
  * RieszFrequencyFunction returns a complex value,
  * but the output of this generator is real , representing the imaginary part
@@ -42,7 +47,7 @@ namespace itk
  * \ingroup IsotropicWavelets
  */
 template<typename TOutputImage,
-  typename TRieszFunction = itk::RieszFrequencyFunction<double, TOutputImage::ImageDimension>,
+  typename TRieszFunction = itk::RieszFrequencyFunction<std::complex<double>, TOutputImage::ImageDimension>,
   typename TFrequencyRegionIterator = FrequencyImageRegionIteratorWithIndex< TOutputImage> >
 class RieszFrequencyFilterBankGenerator:
   public itk::GenerateImageSource< TOutputImage >

--- a/include/itkRieszFrequencyFilterBankGenerator.h
+++ b/include/itkRieszFrequencyFilterBankGenerator.h
@@ -73,6 +73,7 @@ public:
   typedef typename OutputImageType::RegionType OutputImageRegionType;
   /** RieszFunction types */
   typedef TRieszFunction                                RieszFunctionType;
+  typedef typename RieszFunctionType::Pointer           RieszFunctionPointer;
   typedef typename RieszFunctionType::FunctionValueType FunctionValueType;
 
   /** Dimension */
@@ -87,6 +88,32 @@ public:
 //                    ( Concept::IsFloatingPoint< typename OutputImageType::PixelType > ) );
 // #endif
 
+  /** Order of the generalized riesz transform. */
+  virtual void SetOrder(const unsigned int inputOrder)
+    {
+    // Precondition
+    if (inputOrder < 1)
+      {
+      itkExceptionMacro(<<"Error: inputOrder = " << inputOrder << ". It has to be greater than 0.");
+      }
+
+    if ( this->m_Order != inputOrder )
+      {
+      this->m_Order = inputOrder;
+      this->m_Evaluator->SetOrder(inputOrder);
+
+      this->SetNumberOfRequiredOutputs(this->m_Evaluator->ComputeNumberOfComponents(inputOrder));
+      for (unsigned int comp = 0; comp < this->GetNumberOfRequiredOutput(); ++comp)
+        {
+        this->SetNthOutput(comp, this->MakeOutput(comp));
+        }
+      this->Modified();
+      }
+    }
+  itkGetConstReferenceMacro(Order, unsigned int);
+
+  /** Modifiable pointer to the Generalized RieszFunction */
+  itkGetModifiableObjectMacro(Evaluator, RieszFunctionType);
 protected:
   RieszFrequencyFilterBankGenerator();
   virtual ~RieszFrequencyFilterBankGenerator() {}
@@ -97,6 +124,8 @@ protected:
 
 private:
   ITK_DISALLOW_COPY_AND_ASSIGN(RieszFrequencyFilterBankGenerator);
+  unsigned int         m_Order;
+  RieszFunctionPointer m_Evaluator;
 }; // end of class
 } // end namespace itk
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/include/itkRieszFrequencyFilterBankGenerator.h
+++ b/include/itkRieszFrequencyFilterBankGenerator.h
@@ -103,7 +103,7 @@ public:
       this->m_Evaluator->SetOrder(inputOrder);
 
       this->SetNumberOfRequiredOutputs(this->m_Evaluator->ComputeNumberOfComponents(inputOrder));
-      for (unsigned int comp = 0; comp < this->GetNumberOfRequiredOutput(); ++comp)
+      for (unsigned int comp = 0; comp < this->GetNumberOfRequiredOutputs(); ++comp)
         {
         this->SetNthOutput(comp, this->MakeOutput(comp));
         }

--- a/include/itkRieszFrequencyFilterBankGenerator.hxx
+++ b/include/itkRieszFrequencyFilterBankGenerator.hxx
@@ -29,12 +29,6 @@ RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction, TFrequencyRegio
 {
   this->m_Evaluator = RieszFunctionType::New();
   this->SetOrder(1);
-
-  this->SetNumberOfRequiredOutputs(ImageDimension);
-  for (unsigned int dir = 0; dir < ImageDimension; ++dir)
-    {
-    this->SetNthOutput(dir, this->MakeOutput(dir));
-    }
 }
 
 template<typename TOutputImage, typename TRieszFunction, typename TFrequencyRegionIterator>
@@ -43,15 +37,7 @@ void RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction, TFrequency
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "m_Order: " << this->m_Order << std::endl;
-  os << indent << "m_Evaluator: ";
-  if(!this->m_Evaluator)
-    {
-    os << "0" << std::endl;
-    }
-  else
-    {
-    os << this->m_Evaluator << std::endl;
-    }
+  itkPrintSelfObjectMacro(Evaluator)
 }
 
 /* ******* Get Outputs *****/
@@ -62,9 +48,9 @@ RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction, TFrequencyRegio
 ::GetOutputs()
 {
   std::vector<OutputImagePointer> outputList;
-  for (unsigned int dir = 0; dir < ImageDimension; ++dir)
+  for (unsigned int comp = 0; comp < this->GetNumberOfOutputs(); ++comp)
     {
-    outputList.push_back(this->GetOutput(dir));
+    outputList.push_back(this->GetOutput(comp));
     }
   return outputList;
 }
@@ -93,7 +79,7 @@ void RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction, TFrequency
   OutputRegionIterator frequencyIt(outputList[0], outputList[0]->GetRequestedRegion());
   for (frequencyIt.GoToBegin(); !frequencyIt.IsAtEnd(); ++frequencyIt)
     {
-    typename TRieszFunction::OutputComponentType evaluatedArray =
+    typename TRieszFunction::OutputComponentsType evaluatedArray =
       this->m_Evaluator->EvaluateAllComponents(frequencyIt.GetFrequency());
     for (unsigned int comp = 0; comp < this->GetNumberOfOutputs(); ++comp)
       {
@@ -103,7 +89,7 @@ void RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction, TFrequency
     itkDebugMacro(<< "w_vector: " << frequencyIt.GetFrequency()
                   << " w2: " << frequencyIt.GetFrequencyModuloSquare()
                   << "  frequencyItIndex: " << frequencyIt.GetIndex()
-                  << "  Evaluated Riesz Components: " << evaluatedArray
+                  // << "  Evaluated Riesz Components: " << evaluatedArray
                   << " outputIndex: " << outputItList[0].GetIndex());
     }
 }

--- a/include/itkRieszFrequencyFilterBankGenerator.hxx
+++ b/include/itkRieszFrequencyFilterBankGenerator.hxx
@@ -80,7 +80,7 @@ void RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction, TFrequency
   OutputRegionIterator frequencyIt(outputList[0], outputList[0]->GetRequestedRegion());
   for (frequencyIt.GoToBegin(); !frequencyIt.IsAtEnd(); ++frequencyIt)
     {
-    typename TRieszFunction::OutputArrayType evaluatedArray =
+    typename TRieszFunction::OutputComplexArrayType evaluatedArray =
       evaluator->EvaluateArray(frequencyIt.GetFrequency());
     for (unsigned int dir = 0; dir < ImageDimension; ++dir)
       {

--- a/include/itkRieszFrequencyFilterBankGenerator.hxx
+++ b/include/itkRieszFrequencyFilterBankGenerator.hxx
@@ -25,7 +25,11 @@ namespace itk
 template<typename TOutputImage, typename TRieszFunction, typename TFrequencyRegionIterator>
 RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction, TFrequencyRegionIterator>
 ::RieszFrequencyFilterBankGenerator()
+: m_Order(0)
 {
+  this->m_Evaluator = RieszFunctionType::New();
+  this->SetOrder(1);
+
   this->SetNumberOfRequiredOutputs(ImageDimension);
   for (unsigned int dir = 0; dir < ImageDimension; ++dir)
     {
@@ -38,6 +42,16 @@ void RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction, TFrequency
 ::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
+  os << indent << "m_Order: " << this->m_Order << std::endl;
+  os << indent << "m_Evaluator: ";
+  if(!this->m_Evaluator)
+    {
+    os << "0" << std::endl;
+    }
+  else
+    {
+    os << this->m_Evaluator << std::endl;
+    }
 }
 
 /* ******* Get Outputs *****/
@@ -59,14 +73,13 @@ template<typename TOutputImage, typename TRieszFunction, typename TFrequencyRegi
 void RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction, TFrequencyRegionIterator>
 ::GenerateData()
 {
-  typename RieszFunctionType::Pointer evaluator = RieszFunctionType::New();
 
   /***************** Allocate Outputs *****************/
   std::vector<OutputImagePointer>   outputList;
   std::vector<OutputRegionIterator> outputItList;
-  for (unsigned int dir = 0; dir < ImageDimension; ++dir)
+  for (unsigned int comp = 0; comp < this->GetNumberOfOutputs(); ++comp)
     {
-    outputList.push_back(this->GetOutput(dir));
+    outputList.push_back(this->GetOutput(comp));
     OutputImagePointer& outputPtr = outputList.back();
     // GenerateImageSource superclass allocates primary output, so use its region.
     outputPtr->SetRegions(outputList[0]->GetLargestPossibleRegion());
@@ -80,12 +93,12 @@ void RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction, TFrequency
   OutputRegionIterator frequencyIt(outputList[0], outputList[0]->GetRequestedRegion());
   for (frequencyIt.GoToBegin(); !frequencyIt.IsAtEnd(); ++frequencyIt)
     {
-    typename TRieszFunction::OutputComplexArrayType evaluatedArray =
-      evaluator->EvaluateArray(frequencyIt.GetFrequency());
-    for (unsigned int dir = 0; dir < ImageDimension; ++dir)
+    typename TRieszFunction::OutputComponentType evaluatedArray =
+      this->m_Evaluator->EvaluateAllComponents(frequencyIt.GetFrequency());
+    for (unsigned int comp = 0; comp < this->GetNumberOfOutputs(); ++comp)
       {
-      outputItList[dir].Set( outputItList[dir].Get() + evaluatedArray[dir].imag());
-      ++outputItList[dir];
+      outputItList[comp].Set( evaluatedArray[comp] );
+      ++outputItList[comp];
       }
     itkDebugMacro(<< "w_vector: " << frequencyIt.GetFrequency()
                   << " w2: " << frequencyIt.GetFrequencyModuloSquare()

--- a/include/itkRieszFrequencyFunction.h
+++ b/include/itkRieszFrequencyFunction.h
@@ -63,16 +63,25 @@ public:
   typedef std::set<IndicesArrayType, std::greater<IndicesArrayType> > SetType;
 
   /**
+   * Compute number of components p(N, d), where N = Order, d = Dimension.
+   * p(N,d) = (N + d - 1)!/( (d-1)! N! )
+   *
+   * @param order N or this->m_Order
+   *
+   * @return NumberOfComponents given the order.
+   */
+  static unsigned int ComputeNumberOfComponents(unsigned int order);
+  /**
    * Compute all possible unique indices given the subIndice: (X, 0, ..., 0). Where X can be any number greater than 0, but probably want to use this->m_Order.
    */
   static void ComputeUniqueIndices(IndicesArrayType subIndice, unsigned int init,
       SetType &uniqueIndices);
+
   /**
    * Compute all the permutations from a set of uniqueIndices.
    */
   static SetType ComputeAllPermutations(const SetType & uniqueIndices);
 
-  // static std::vector<IndicesArrayType> GetAllPossibleIndices();
   /** Evaluate the function at a given frequency point. */
   virtual FunctionValueType Evaluate(const TInput &) const ITK_OVERRIDE
   {

--- a/include/itkRieszFrequencyFunction.h
+++ b/include/itkRieszFrequencyFunction.h
@@ -63,7 +63,7 @@ public:
   typedef std::set<IndicesArrayType, std::greater<IndicesArrayType> > SetType;
 
   /**
-   * Compute all possible unique indices given the subIndice: (X, 0, 0, ..., 0). Where X can be any number greater than 0, but probably want to use this->m_Order.
+   * Compute all possible unique indices given the subIndice: (X, 0, ..., 0). Where X can be any number greater than 0, but probably want to use this->m_Order.
    */
   static void ComputeUniqueIndices(IndicesArrayType subIndice, unsigned int init,
       SetType &uniqueIndices);

--- a/include/itkRieszFrequencyFunction.h
+++ b/include/itkRieszFrequencyFunction.h
@@ -19,6 +19,7 @@
 #define itkRieszFrequencyFunction_h
 
 #include "itkFrequencyFunction.h"
+#include <set>
 #include <complex>
 #include <numeric>
 
@@ -30,7 +31,7 @@ namespace itk
  * \ingroup SpatialFunctions
  * \ingroup IsotropicWavelets
  */
-template< typename TFunctionValue = double,
+template< typename TFunctionValue = std::complex<double>,
   unsigned int VImageDimension    = 3,
   typename TInput = Point< SpacePrecisionType, VImageDimension > >
 class RieszFrequencyFunction:
@@ -47,17 +48,31 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(RieszFrequencyFunction, SpatialFunction);
+  itkTypeMacro(RieszFrequencyFunction, FrequencyFunction);
 
   /** Input type for the function. */
   typedef typename Superclass::InputType InputType;
 
   typedef typename Superclass::OutputType FunctionValueType;
-  /** Output type for the function. */
-  typedef std::complex<typename Superclass::OutputType>                                   OutputComplexType;
-  typedef itk::FixedArray<std::complex<typename Superclass::OutputType>, VImageDimension> OutputComplexArrayType;
-  typedef itk::FixedArray<unsigned int, VImageDimension>                                  IndicesArrayType;
+  typedef typename Superclass::OutputType                                   OutputType;
+  typedef typename Superclass::OutputType                                   OutputComplexType;
+  typedef itk::FixedArray<OutputType, VImageDimension> OutputComplexArrayType;
+  typedef itk::FixedArray<unsigned int, VImageDimension>                                  IndicesFixedArrayType;
+  typedef std::vector<unsigned int> IndicesArrayType;
+  typedef std::vector<OutputType> OutputComponentsType;
+  typedef std::set<IndicesArrayType, std::greater<IndicesArrayType> > SetType;
 
+  /**
+   * Compute all possible unique indices given the subIndice: (X, 0, 0, ..., 0). Where X can be any number greater than 0, but probably want to use this->m_Order.
+   */
+  static void ComputeUniqueIndices(IndicesArrayType subIndice, unsigned int init,
+      SetType &uniqueIndices);
+  /**
+   * Compute all the permutations from a set of uniqueIndices.
+   */
+  static SetType ComputeAllPermutations(const SetType & uniqueIndices);
+
+  // static std::vector<IndicesArrayType> GetAllPossibleIndices();
   /** Evaluate the function at a given frequency point. */
   virtual FunctionValueType Evaluate(const TInput &) const ITK_OVERRIDE
   {
@@ -76,8 +91,19 @@ public:
 
   virtual OutputComplexArrayType EvaluateArray(const TInput & frequency_point) const;
 
+  /**
+   * Compute RieszTransform component based on indices. It takes into account m_Order.
+   *
+   * @param frequency_point w (array)
+   * @param indices
+   * Precondition: sum(n1,n2,...,nd) = N (m_Order)
+   * n = (n1,n2,...nd) := indices vector. d-array, where d is the Dimension of the image.
+   *
+   * @return R^n = (-j)^N * sqrt(N!/(n1!*n2!...nd!)) * (w1^n1 * w2^n2 * ... wd^nd) * 1.0 / ||w||^N
+   * R^n = complex_component * normalizing_factor * frequency_factor * 1.0/freq_magnitude_factor
+   */
   virtual OutputComplexType EvaluateWithIndices(const TInput & frequency_point,
-                             const IndicesArrayType & indices) const;
+                             const IndicesFixedArrayType & indices);
 
   /** Calculate magnitude (euclidean norm) of input point. **/
   inline double Magnitude(const TInput & point) const
@@ -105,17 +131,64 @@ public:
     // Precondition
     if (inputOrder < 1)
       {
-      itkExceptionMacro(<<"Error: inputOrder = " << inputOrder << ". It has to be greater than 0.")
+      itkExceptionMacro(<<"Error: inputOrder = " << inputOrder << ". It has to be greater than 0.");
       }
 
     if ( this->m_Order != inputOrder )
       {
       this->m_Order = inputOrder;
-      this->m_OrderFactorial = static_cast<unsigned long>(
-        Self::Factorial(inputOrder) );
+      // Invalidate m_Indices (0,0,...,0)
+      this->m_Indices.Fill(0);
       this->Modified();
       }
     }
+
+  virtual void SetIndices(const IndicesFixedArrayType &indices)
+    {
+    if ( this->m_Indices == indices )
+      {
+      return;
+      }
+    // Precondition
+    unsigned int sum = 0;
+    for( unsigned int dim = 0; dim < VImageDimension; ++dim)
+      {
+      sum += indices[dim];
+      }
+
+    if(sum != this->m_Order)
+      {
+      itkExceptionMacro(<<"Invalid input indices = " << indices << ". The sum of its components (" << sum <<" must be equal to the current Order = " << this->m_Order << ".");
+      }
+
+    this->m_Indices = indices;
+
+    // normalizeFactor: sqrt(m_Order!/(n1!n2!...nd!))
+    typename OutputComplexType::value_type normalizeFactor(1);
+    for( unsigned int dim = 0; dim < VImageDimension; ++dim)
+      {
+      normalizeFactor *= Self::Factorial(indices[dim]);
+      }
+    normalizeFactor = sqrt( Self::Factorial(this->m_Order) / normalizeFactor );
+
+    std::complex<long double> longComplex(0,-1);
+    // calculate (-j)^m_Order
+    itkDebugMacro(<<"\n normalizeFactor = " << normalizeFactor << "\n" 
+        <<"extra precision: (-j)^Order: "<< longComplex);
+    this->m_NormalizingIndicesComplexFactor = std::pow(longComplex,
+        static_cast<long double>(this->m_Order) );
+    itkDebugMacro(<< "\n (-j)^Order: "<< this->m_NormalizingIndicesComplexFactor << " extra precision: " << std::pow(longComplex,
+        static_cast<long double>(this->m_Order) ) );
+    // (-j)^{m_Order} * sqrt(m_Order!/(n1!n2!...nd!))
+    this->m_NormalizingIndicesComplexFactor *= normalizeFactor;
+    this->Modified();
+    }
+
+#ifdef ITK_USE_CONCEPT_CHECKING
+  itkConceptMacro( OutputTypeIsComplexCheck,
+                   ( Concept::IsFloatingPoint< typename TFunctionValue::value_type > ) );
+#endif
+
 protected:
   RieszFrequencyFunction();
   virtual ~RieszFrequencyFunction();
@@ -124,7 +197,8 @@ protected:
 private:
   ITK_DISALLOW_COPY_AND_ASSIGN(RieszFrequencyFunction);
   unsigned int  m_Order;
-  unsigned long m_OrderFactorial;
+  IndicesFixedArrayType m_Indices;
+  OutputComplexType m_NormalizingIndicesComplexFactor;
 };
 } // end namespace itk
 

--- a/include/itkRieszFrequencyFunction.h
+++ b/include/itkRieszFrequencyFunction.h
@@ -55,19 +55,29 @@ public:
   typedef typename Superclass::OutputType FunctionValueType;
   /** Output type for the function. */
   typedef std::complex<typename Superclass::OutputType>                                   OutputComplexType;
-  typedef itk::FixedArray<std::complex<typename Superclass::OutputType>, VImageDimension> OutputArrayType;
+  typedef itk::FixedArray<std::complex<typename Superclass::OutputType>, VImageDimension> OutputComplexArrayType;
+  typedef itk::FixedArray<unsigned int, VImageDimension>                                  IndicesArrayType;
 
   /** Evaluate the function at a given frequency point. */
   virtual FunctionValueType Evaluate(const TInput &) const ITK_OVERRIDE
   {
     itkExceptionMacro("Evaluate(TInput&) is not valid for RieszFrequencyFunction."
-                      "Use EvaluateArray instead, returning an OutputArrayType,"
-                      "or Evaluate(point, dimension) that returns a complex value .");
+                      "Use EvaluateArray instead, returning an OutputComplexArrayType,"
+                      "or Evaluate(point, direction) that returns a complex value .");
   };
-  OutputComplexType Evaluate(const TInput & frequency_point,
-                             const unsigned int & dimension) const;
+  /** Calculate first order (m_Order = 1) riesz function at indicated direction.
+   * Equivalent to:
+   * EvaluateWithIndices(frequency_point, indices) with:
+   * m_Order = 1,
+   * indices = 1 at index == direction, 0 elsewhere.
+   */
+  virtual OutputComplexType Evaluate(const TInput & frequency_point,
+                             const unsigned int & direction) const;
 
-  OutputArrayType EvaluateArray(const TInput & frequency_point) const;
+  virtual OutputComplexArrayType EvaluateArray(const TInput & frequency_point) const;
+
+  virtual OutputComplexType EvaluateWithIndices(const TInput & frequency_point,
+                             const IndicesArrayType & indices) const;
 
   /** Calculate magnitude (euclidean norm) of input point. **/
   inline double Magnitude(const TInput & point) const
@@ -75,6 +85,37 @@ public:
     return sqrt(std::inner_product( point.Begin(), point.End(), point.Begin(), 0.0 ) );
   }
 
+  /// Factorial
+  static long Factorial(long n)
+    {
+    if (n <= 1)
+      {
+      return 1;
+      }
+    else
+      {
+      return n * Self::Factorial(n-1);
+      }
+    }
+
+  /** Order of the generalized riesz transform. */
+  itkGetConstReferenceMacro(Order, unsigned int);
+  virtual void SetOrder(const unsigned int inputOrder)
+    {
+    // Precondition
+    if (inputOrder < 1)
+      {
+      itkExceptionMacro(<<"Error: inputOrder = " << inputOrder << ". It has to be greater than 0.")
+      }
+
+    if ( this->m_Order != inputOrder )
+      {
+      this->m_Order = inputOrder;
+      this->m_OrderFactorial = static_cast<unsigned long>(
+        Self::Factorial(inputOrder) );
+      this->Modified();
+      }
+    }
 protected:
   RieszFrequencyFunction();
   virtual ~RieszFrequencyFunction();
@@ -82,6 +123,8 @@ protected:
 
 private:
   ITK_DISALLOW_COPY_AND_ASSIGN(RieszFrequencyFunction);
+  unsigned int  m_Order;
+  unsigned long m_OrderFactorial;
 };
 } // end namespace itk
 

--- a/include/itkRieszFrequencyFunction.hxx
+++ b/include/itkRieszFrequencyFunction.hxx
@@ -114,6 +114,14 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
     }
   return out;
 }
+template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
+unsigned int
+RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
+::ComputeNumberOfComponents(unsigned int order)
+{
+  return Self::Factorial(order + VImageDimension - 1 )
+    /( Self::Factorial(VImageDimension - 1)*Self::Factorial(order));
+}
 
 template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
 void

--- a/include/itkRieszFrequencyFunction.hxx
+++ b/include/itkRieszFrequencyFunction.hxx
@@ -38,42 +38,33 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
 {
 }
 
-template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
-void
-RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
-::PrintSelf(std::ostream & os, Indent indent) const
-{
-  Superclass::PrintSelf(os, indent);
-  os << indent << "m_Order: " << this->m_Order << std::endl;
-}
-
-template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
-typename RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >::OutputComplexType
-RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
-::Evaluate(
-  const TInput & frequency_point,
-  const unsigned int & direction) const
-{
-  double magn(this->Magnitude(frequency_point));
-
-  if(itk::Math::FloatAlmostEqual(magn, 0.0) )
-    {
-    return OutputComplexType(0);
-    }
-  return OutputComplexType(0, static_cast<typename OutputComplexType::value_type>( -frequency_point[direction] / magn ) );
-}
+// template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
+// typename RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >::OutputComplexType
+// RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
+// ::Evaluate(
+//   const TInput & frequency_point,
+//   const unsigned int & direction) const
+// {
+//   double magn(this->Magnitude(frequency_point));
+//
+//   if(itk::Math::FloatAlmostEqual(magn, 0.0) )
+//     {
+//     return OutputComplexType(0);
+//     }
+//   return OutputComplexType(0, static_cast<typename OutputComplexType::value_type>( -frequency_point[direction] / magn ) );
+// }
 
 template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
 typename RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >::OutputComplexType
 RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
 ::EvaluateWithIndices(
   const TInput & frequency_point,
-  const IndicesFixedArrayType & indices)
+  const IndicesArrayType & indices)
 {
-  this->SetIndices(indices);
   double magn(this->Magnitude(frequency_point));
 
   // Precondition:
+  // TODO: default precision ok? : https://itk.org/Doxygen/html/namespaceitk_1_1Math.html#ae9f0d6137957033eecb66c0e1356d022
   if(itk::Math::FloatAlmostEqual(magn, 0.0) )
     {
     return OutputComplexType(0);
@@ -88,9 +79,10 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
       freqProduct *= frequency_point[dim];
       }
     }
+  
 
   // rieszComponent = (-j)^{m_Order} * sqrt(m_Order!/(n1!n2!...nd!)) * w1^n1...wd^nd / ||w||^m_Order
-  return this->m_NormalizingIndicesComplexFactor
+  return this->ComputeNormalizingFactor(indices)
     * static_cast<typename OutputComplexType::value_type>( freqProduct
     / std::pow(magn, static_cast<double>(this->m_Order)) ) ;
 }
@@ -102,7 +94,6 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
 {
   double magn(this->Magnitude(frequency_point));
 
-  // TODO: default precision ok? : https://itk.org/Doxygen/html/namespaceitk_1_1Math.html#ae9f0d6137957033eecb66c0e1356d022
   if(itk::Math::FloatAlmostEqual(magn, 0.0) )
     {
     return OutputComplexArrayType(0);
@@ -252,7 +243,6 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
         freqProduct *= frequency_point[dim];
         }
       }
-
     // rieszComponent = (-j)^{m_Order} * sqrt(m_Order!/(n1!n2!...nd!)) * w1^n1...wd^nd / ||w||^m_Order
     OutputComplexType outPerIndice = this->ComputeNormalizingFactor(indice);
     outPerIndice *= static_cast<typename OutputComplexType::value_type>(
@@ -261,6 +251,15 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
     }
 
   return out;
+}
+
+template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
+void
+RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
+::PrintSelf(std::ostream & os, Indent indent) const
+{
+  Superclass::PrintSelf(os, indent);
+  os << indent << "m_Order: " << this->m_Order << std::endl;
 }
 
 } // end namespace itk

--- a/include/itkRieszFrequencyFunction.hxx
+++ b/include/itkRieszFrequencyFunction.hxx
@@ -28,8 +28,10 @@ namespace itk
 template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
 RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
 ::RieszFrequencyFunction()
-: m_Order(1)
+: m_Order(0)
 {
+  // SetOrder also sets m_Indices.
+  this->SetOrder(1); 
 }
 
 template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
@@ -84,27 +86,9 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
   // rieszComponent = (-j)^{m_Order} * sqrt(m_Order!/(n1!n2!...nd!)) * w1^n1...wd^nd / ||w||^m_Order
   return this->ComputeNormalizingFactor(indices)
     * static_cast<typename OutputComplexType::value_type>( freqProduct
-    / std::pow(magn, static_cast<double>(this->m_Order)) ) ;
+    / std::pow(magn, static_cast<double>(this->m_Order)) );
 }
 
-template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
-typename RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >::OutputComplexArrayType
-RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
-::EvaluateArray(const TInput & frequency_point) const
-{
-  double magn(this->Magnitude(frequency_point));
-
-  if(itk::Math::FloatAlmostEqual(magn, 0.0) )
-    {
-    return OutputComplexArrayType(0);
-    }
-  OutputComplexArrayType out;
-  for( unsigned int dim = 0; dim < VImageDimension; ++dim)
-    {
-    out[dim] = OutputComplexType(0, static_cast<typename OutputComplexType::value_type>( -frequency_point[dim] / magn ) );
-    }
-  return out;
-}
 template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
 unsigned int
 RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
@@ -222,13 +206,7 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
     return OutputComponentsType(RieszFrequencyFunction::ComputeNumberOfComponents(this->m_Order));
     }
 
-  // Calculate all the possible indices.
-  IndicesArrayType initIndice;
-  initIndice.resize(VImageDimension);
-  initIndice[0] = this->m_Order;
-  SetType uniqueIndices;
-  Self::ComputeUniqueIndices(initIndice, uniqueIndices);
-  SetType allIndices = Self::ComputeAllPermutations(uniqueIndices);
+  const SetType &allIndices = this->m_Indices;
 
   OutputComponentsType out;
   for(typename SetType::const_iterator it = allIndices.begin(); it != allIndices.end(); ++it)
@@ -260,6 +238,16 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "m_Order: " << this->m_Order << std::endl;
+  os << indent << "m_Indices:" << std::endl;
+  for (typename SetType::const_iterator it = this->m_Indices.begin(); it != this->m_Indices.end(); ++it)
+    {
+    std::cout << "(";
+    for (unsigned int i = 0; i<VImageDimension; ++i)
+      {
+      std::cout << (*it)[i] << ", ";
+      }
+    std::cout << ")" << std::endl;
+    }
 }
 
 } // end namespace itk

--- a/include/itkRieszFrequencyFunction.hxx
+++ b/include/itkRieszFrequencyFunction.hxx
@@ -128,7 +128,7 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
     }
 
   // If OK, store it.
-  if(std::distance(subIndice.begin(), std::max_element(subIndice.begin() + init, subIndice.end())) <= init)
+  if(std::distance(subIndice.begin(), std::max_element(subIndice.begin(), subIndice.end(), std::greater<unsigned int>())) <= VImageDimension - 1)
     {
     IndicesArrayType subIndiceCopy = subIndice;
     std::sort(subIndiceCopy.rbegin(), subIndiceCopy.rend());
@@ -148,9 +148,10 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
     {
     return;
     }
-
   // Process modified subIndice.
   Self::ComputeUniqueIndices(subIndice, init, uniqueIndices);
+  // Process modified init.
+  Self::ComputeUniqueIndices(subIndice, init + 1, uniqueIndices);
 }
 
 template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -106,10 +106,17 @@ itk_add_test(NAME itkRieszFrequencyFunctionTest3D
   COMMAND IsotropicWaveletsTestDriver
   itkRieszFrequencyFunctionTest 3)
 # RieszGenerator
-itk_add_test(NAME itkRieszFrequencyFilterBankGeneratorTest
+itk_add_test(NAME itkRieszFrequencyFilterBankGeneratorTest1
   COMMAND IsotropicWaveletsTestDriver
   itkRieszFrequencyFilterBankGeneratorTest DATA{Input/collagen_64x64x16.tiff}
-  ${ITK_TEST_OUTPUT_DIR}/itkRieszFrequencyFilterBankGeneratorTest.tiff
+  ${ITK_TEST_OUTPUT_DIR}/itkRieszFrequencyFilterBankGeneratorTest1.tiff
+  1
+  )
+itk_add_test(NAME itkRieszFrequencyFilterBankGeneratorTest2
+  COMMAND IsotropicWaveletsTestDriver
+  itkRieszFrequencyFilterBankGeneratorTest DATA{Input/collagen_64x64x16.tiff}
+  ${ITK_TEST_OUTPUT_DIR}/itkRieszFrequencyFilterBankGeneratorTest2.tiff
+  2
   )
 # Monogenic Analysis
 itk_add_test(NAME itkMonogenicSignalFrequencyImageFilterTest

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ set(IsotropicWaveletsTests
     # Phase Analysis
     itkPhaseAnalysisSoftThresholdImageFilterTest.cxx
     # Riesz / Monogenic
+    itkRieszFrequencyFunctionTest.cxx
     itkRieszFrequencyFilterBankGeneratorTest.cxx
     itkMonogenicSignalFrequencyImageFilterTest.cxx
     # StructureTensor
@@ -97,6 +98,13 @@ itk_add_test(NAME itkWaveletFrequencyFilterBankGeneratorDownsampleTest2D
   ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyFilterBankGeneratorDownsampleTest2D.tiff
     2 2 "Held" 2)
 ## Riesz Related
+# RieszFunction
+itk_add_test(NAME itkRieszFrequencyFunctionTest2D
+  COMMAND IsotropicWaveletsTestDriver
+  itkRieszFrequencyFunctionTest 2)
+itk_add_test(NAME itkRieszFrequencyFunctionTest3D
+  COMMAND IsotropicWaveletsTestDriver
+  itkRieszFrequencyFunctionTest 3)
 # RieszGenerator
 itk_add_test(NAME itkRieszFrequencyFilterBankGeneratorTest
   COMMAND IsotropicWaveletsTestDriver

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -201,7 +201,7 @@ itk_add_test(NAME itkRieszWaveletPhaseAnalysisTestMultiLevelMultiBand
   COMMAND IsotropicWaveletsTestDriver
   itkRieszWaveletPhaseAnalysisTest DATA{Input/collagen_64x64x16.tiff}
   ${ITK_TEST_OUTPUT_DIR}/itkRieszWaveletPhaseAnalysisTestMultiLevelMultiBand.tiff
-  2 5 ${DefaultWavelet} Apply )
+  2 3 ${DefaultWavelet} Apply )
 ###
 itk_add_test(NAME itkRieszWaveletPhaseAnalysisTest2D
   COMMAND IsotropicWaveletsTestDriver
@@ -212,7 +212,7 @@ itk_add_test(NAME itkRieszWaveletPhaseAnalysisTest2DMultiLevelMultiBand
   COMMAND IsotropicWaveletsTestDriver
   itkRieszWaveletPhaseAnalysisTest DATA{Input/checkershadow_Lch_512x512.tiff}
   ${ITK_TEST_OUTPUT_DIR}/itkRieszWaveletPhaseAnalysisTest2DMultiLevelMultiBand.tiff
-  5 5 ${DefaultWavelet} Apply 2 )
+  5 2 ${DefaultWavelet} Apply 2 )
 #IsotropicWaveletFrequencyFunctionTest
 itk_add_test(NAME itkIsotropicWaveletFrequencyFunctionTest
   COMMAND IsotropicWaveletsTestDriver itkIsotropicWaveletFrequencyFunctionTest

--- a/test/itkRieszFrequencyFilterBankGeneratorTest.cxx
+++ b/test/itkRieszFrequencyFilterBankGeneratorTest.cxx
@@ -21,6 +21,7 @@
 #include "itkForwardFFTImageFilter.h"
 #include "itkRieszFrequencyFilterBankGenerator.h"
 #include "itkComplexToRealImageFilter.h"
+#include "itkComplexToImaginaryImageFilter.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkTestingMacros.h"
 
@@ -37,13 +38,14 @@
 
 int itkRieszFrequencyFilterBankGeneratorTest( int argc, char* argv[] )
 {
-  if( argc != 3 )
+  if( argc != 4 )
     {
-    std::cerr << "Usage: " << argv[0] << " inputImage outputImage" << std::endl;
+    std::cerr << "Usage: " << argv[0] << " inputImage outputImage inputOrder" << std::endl;
     return EXIT_FAILURE;
     }
   const std::string inputImage  = argv[1];
   const std::string outputImage = argv[2];
+  unsigned int inputOrder = atoi(argv[3]);
 
   const unsigned int Dimension = 3;
   typedef double                              PixelType;
@@ -63,30 +65,78 @@ int itkRieszFrequencyFilterBankGeneratorTest( int argc, char* argv[] )
 
   typedef FFTFilterType::OutputImageType ComplexImageType;
 
-//   // typedef itk::RieszFrequencyFunction<> FunctionType;
-//   typedef itk::RieszFrequencyFilterBankGenerator< ComplexImageType > RieszFilterBankType;
-//   RieszFilterBankType::Pointer filterBank = RieszFilterBankType::New();
-//
-//   EXERCISE_BASIC_OBJECT_METHODS( filterBank, RieszFrequencyFilterBankGenerator, GenerateImageSource );
-//
-//   filterBank->SetSize( fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize() );
-//   filterBank->Update();
-//
-//   // Get real part of complex image for visualization
-//   typedef itk::ComplexToRealImageFilter< ComplexImageType, ImageType > ComplexToRealFilter;
-//   ComplexToRealFilter::Pointer complexToRealFilter = ComplexToRealFilter::New();
-//   std::cout << "Real part of complex image:" << std::endl;
-//   for( unsigned int dir = 0; dir < ImageType::ImageDimension; dir++ )
-//     {
-//     std::cout << "Direction: " << dir + 1 << " / " << ImageType::ImageDimension << std::endl;
-//     complexToRealFilter->SetInput( filterBank->GetOutput( dir ) );
-//     complexToRealFilter->Update();
-//
-// #ifdef ITK_VISUALIZE_TESTS
-//     itk::NumberToString< unsigned int > n2s;
-//     itk::Testing::ViewImage( complexToRealFilter->GetOutput(), "RealPart of Complex. Direction: " + n2s(
-//                          dir + 1) + " / " + n2s( ImageType::ImageDimension ) );
-// #endif
-    // }
+  // typedef itk::RieszFrequencyFunction<> FunctionType;
+  typedef itk::RieszFrequencyFilterBankGenerator< ComplexImageType > RieszFilterBankType;
+  RieszFilterBankType::Pointer filterBank = RieszFilterBankType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( filterBank, RieszFrequencyFilterBankGenerator, GenerateImageSource );
+
+  filterBank->SetSize( fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize() );
+  filterBank->SetOrder(inputOrder);
+  filterBank->Update();
+
+  // Get iterator to Indices of RieszFunction.
+  typedef RieszFilterBankType::RieszFunctionType::SetType IndicesType;
+  IndicesType indices = filterBank->GetModifiableEvaluator()->GetIndices();
+  IndicesType::const_iterator indicesIt = indices.begin();
+
+  // Get real part of complex image for visualization
+  typedef itk::ComplexToRealImageFilter< ComplexImageType, ImageType > ComplexToRealFilter;
+  ComplexToRealFilter::Pointer complexToRealFilter = ComplexToRealFilter::New();
+  typedef itk::ComplexToImaginaryImageFilter< ComplexImageType, ImageType > ComplexToImaginaryFilter;
+  ComplexToImaginaryFilter::Pointer complexToImaginaryFilter = ComplexToImaginaryFilter::New();
+  std::cout << "Order: " << inputOrder << std::endl;
+  bool orderIsEven = (inputOrder % 2 == 0);
+  if(orderIsEven)
+    {
+    std::cout << "Real part of complex image:" << std::endl;
+    for( unsigned int comp = 0; comp < filterBank->GetNumberOfOutputs(); comp++ )
+      {
+      std::ostringstream oss;
+      oss << "(";
+      std::cout << "Component: " << comp << " / " << filterBank->GetNumberOfOutputs() - 1  << std::endl;
+      for (unsigned int i = 0; i<Dimension; ++i)
+        {
+        oss << (*indicesIt)[i] << ", ";
+        }
+      ++indicesIt;
+      oss << ")";
+      std::cout << "  Indice: " << oss.str() << std::endl;
+
+      complexToRealFilter->SetInput( filterBank->GetOutput( comp ) );
+      complexToRealFilter->Update();
+#ifdef ITK_VISUALIZE_TESTS
+      itk::NumberToString< unsigned int > n2s;
+      itk::Testing::ViewImage( complexToRealFilter->GetOutput(), "RealPart of Complex. Component: " + n2s(
+          comp ) + " / " + n2s( filterBank->GetNumberOfOutputs() - 1 ) + ". Indices: " + oss.str() );
+#endif
+      }
+    }
+  else
+    {
+    std::cout << "Imaginary part of complex image:" << std::endl;
+    for( unsigned int comp = 0; comp < filterBank->GetNumberOfOutputs(); comp++ )
+      {
+      std::ostringstream oss;
+      oss << "(";
+      std::cout << "Component: " << comp << " / " << filterBank->GetNumberOfOutputs() - 1  << std::endl;
+      for (unsigned int i = 0; i<Dimension; ++i)
+        {
+        oss << (*indicesIt)[i] << ", ";
+        }
+      ++indicesIt;
+      oss << ")";
+      std::cout << "  Indice: " << oss.str() << std::endl;
+
+      complexToImaginaryFilter->SetInput( filterBank->GetOutput( comp ) );
+      complexToImaginaryFilter->Update();
+#ifdef ITK_VISUALIZE_TESTS
+      itk::NumberToString< unsigned int > n2s;
+      itk::Testing::ViewImage( complexToImaginaryFilter->GetOutput(), "ImaginaryPart of Complex. Component: " + n2s(
+          comp ) + " / " + n2s( filterBank->GetNumberOfOutputs() - 1 ) + ". Indices: " + oss.str() );
+#endif
+      }
+    }
+
   return EXIT_SUCCESS;
 }

--- a/test/itkRieszFrequencyFilterBankGeneratorTest.cxx
+++ b/test/itkRieszFrequencyFilterBankGeneratorTest.cxx
@@ -22,7 +22,6 @@
 #include "itkRieszFrequencyFilterBankGenerator.h"
 #include "itkComplexToRealImageFilter.h"
 #include "itkImageRegionConstIterator.h"
-#include "itkNumberToString.h"
 #include "itkTestingMacros.h"
 
 #include <memory>
@@ -31,6 +30,7 @@
 
 // Visualize for dev/debug purposes. Set in cmake file. Requires VTK
 #ifdef ITK_VISUALIZE_TESTS
+#include "itkNumberToString.h"
 #include "itkViewImage.h"
 #endif
 
@@ -63,30 +63,30 @@ int itkRieszFrequencyFilterBankGeneratorTest( int argc, char* argv[] )
 
   typedef FFTFilterType::OutputImageType ComplexImageType;
 
-  // typedef itk::RieszFrequencyFunction<> FunctionType;
-  typedef itk::RieszFrequencyFilterBankGenerator< ComplexImageType > RieszFilterBankType;
-  RieszFilterBankType::Pointer filterBank = RieszFilterBankType::New();
-
-  EXERCISE_BASIC_OBJECT_METHODS( filterBank, RieszFrequencyFilterBankGenerator, GenerateImageSource );
-
-  filterBank->SetSize( fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize() );
-  filterBank->Update();
-
-  // Get real part of complex image for visualization
-  typedef itk::ComplexToRealImageFilter< ComplexImageType, ImageType > ComplexToRealFilter;
-  ComplexToRealFilter::Pointer complexToRealFilter = ComplexToRealFilter::New();
-  std::cout << "Real part of complex image:" << std::endl;
-  for( unsigned int dir = 0; dir < ImageType::ImageDimension; dir++ )
-    {
-    std::cout << "Direction: " << dir + 1 << " / " << ImageType::ImageDimension << std::endl;
-    complexToRealFilter->SetInput( filterBank->GetOutput( dir ) );
-    complexToRealFilter->Update();
-
-#ifdef ITK_VISUALIZE_TESTS
-    itk::NumberToString< unsigned int > n2s;
-    itk::Testing::ViewImage( complexToRealFilter->GetOutput(), "RealPart of Complex. Direction: " + n2s(
-                         dir + 1) + " / " + n2s( ImageType::ImageDimension ) );
-#endif
-    }
+//   // typedef itk::RieszFrequencyFunction<> FunctionType;
+//   typedef itk::RieszFrequencyFilterBankGenerator< ComplexImageType > RieszFilterBankType;
+//   RieszFilterBankType::Pointer filterBank = RieszFilterBankType::New();
+//
+//   EXERCISE_BASIC_OBJECT_METHODS( filterBank, RieszFrequencyFilterBankGenerator, GenerateImageSource );
+//
+//   filterBank->SetSize( fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize() );
+//   filterBank->Update();
+//
+//   // Get real part of complex image for visualization
+//   typedef itk::ComplexToRealImageFilter< ComplexImageType, ImageType > ComplexToRealFilter;
+//   ComplexToRealFilter::Pointer complexToRealFilter = ComplexToRealFilter::New();
+//   std::cout << "Real part of complex image:" << std::endl;
+//   for( unsigned int dir = 0; dir < ImageType::ImageDimension; dir++ )
+//     {
+//     std::cout << "Direction: " << dir + 1 << " / " << ImageType::ImageDimension << std::endl;
+//     complexToRealFilter->SetInput( filterBank->GetOutput( dir ) );
+//     complexToRealFilter->Update();
+//
+// #ifdef ITK_VISUALIZE_TESTS
+//     itk::NumberToString< unsigned int > n2s;
+//     itk::Testing::ViewImage( complexToRealFilter->GetOutput(), "RealPart of Complex. Direction: " + n2s(
+//                          dir + 1) + " / " + n2s( ImageType::ImageDimension ) );
+// #endif
+    // }
   return EXIT_SUCCESS;
 }

--- a/test/itkRieszFrequencyFunctionTest.cxx
+++ b/test/itkRieszFrequencyFunctionTest.cxx
@@ -34,7 +34,7 @@
 #endif
 
 template<unsigned int VDimension>
-int runRieszFrequencyFunctionTest(unsigned int order)
+int runRieszFrequencyFunctionTest(unsigned int inputOrder)
 {
   bool testPassed = true;
   const unsigned int Dimension = VDimension;
@@ -48,7 +48,6 @@ int runRieszFrequencyFunctionTest(unsigned int order)
   InputType frequencyPoint;
   frequencyPoint.Fill(0.1);
   OutputType resultFirstOrder = rieszFunction->Evaluate(frequencyPoint, 0 );
-  rieszFunction->DebugOn();
   rieszFunction->SetOrder(1);
   typename RieszFrequencyFunctionType::IndicesFixedArrayType indices;
   indices.Fill(0);
@@ -65,7 +64,7 @@ int runRieszFrequencyFunctionTest(unsigned int order)
   // Init indice has to be sorted in descending order, example:(3,0,0)
   typename RieszFrequencyFunctionType::IndicesArrayType initIndice;
   initIndice.resize(Dimension);
-  initIndice[0] = order;
+  initIndice[0] = inputOrder;
   typedef typename RieszFrequencyFunctionType::SetType SetType;
   SetType uniqueIndices;
   unsigned int positionToStartProcessing = 0;
@@ -94,8 +93,35 @@ int runRieszFrequencyFunctionTest(unsigned int order)
     std::cout << ")" << std::endl;
     }
 
+  unsigned int expectedNumberOfComponents = RieszFrequencyFunctionType::ComputeNumberOfComponents(inputOrder);
+  unsigned int actualNumberOfComponents = allPermutations.size();
+  if (actualNumberOfComponents != expectedNumberOfComponents)
+    {
+    std::cerr << "Error. NumberOfComponents for inputOrder: " << inputOrder << " ; actual: " << actualNumberOfComponents << " expected: " << expectedNumberOfComponents << " are not equal!" << std::endl;
+    testPassed = false;
+    }
+
+  // Regression test.
+  for (unsigned int order = 1; order < 6; ++order )
+    {
+    uniqueIndices.clear();
+    allPermutations.clear();
+    initIndice[0] = order;
+    RieszFrequencyFunctionType::ComputeUniqueIndices(initIndice, 0, uniqueIndices);
+    allPermutations = RieszFrequencyFunctionType::ComputeAllPermutations(uniqueIndices);
+    actualNumberOfComponents = allPermutations.size();
+    expectedNumberOfComponents = RieszFrequencyFunctionType::ComputeNumberOfComponents(order);
+    if (actualNumberOfComponents != expectedNumberOfComponents)
+      {
+      std::cerr << "Error. NumberOfComponents for order: " << order << " ; actual: " << actualNumberOfComponents << " expected: " << expectedNumberOfComponents << " are not equal!" << std::endl;
+      testPassed = false;
+      }
+    }
+
+
   if(testPassed)
     {
+    std::cout << "Test Passed!" << std::endl;
     return EXIT_SUCCESS;
     }
   else

--- a/test/itkRieszFrequencyFunctionTest.cxx
+++ b/test/itkRieszFrequencyFunctionTest.cxx
@@ -1,0 +1,152 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkRieszFrequencyFunction.h"
+#include "itkImage.h"
+#include "itkImageFileReader.h"
+#include "itkForwardFFTImageFilter.h"
+#include "itkComplexToRealImageFilter.h"
+#include "itkTestingMacros.h"
+
+#include <memory>
+#include <string>
+#include <cmath>
+
+// Visualize for dev/debug purposes. Set in cmake file. Requires VTK
+#ifdef ITK_VISUALIZE_TESTS
+#include "itkNumberToString.h"
+#include "itkViewImage.h"
+#endif
+
+template<unsigned int VDimension>
+int runRieszFrequencyFunctionTest()
+{
+  bool testPassed = true;
+  const unsigned int Dimension = VDimension;
+  typedef std::complex<double>                            OutputType;
+  typedef itk::Point< itk::SpacePrecisionType, Dimension> InputType;
+
+  typedef itk::RieszFrequencyFunction<OutputType, Dimension, InputType> RieszFrequencyFunctionType;
+  typename RieszFrequencyFunctionType::Pointer rieszFunction =
+    RieszFrequencyFunctionType::New();
+
+  InputType frequencyPoint;
+  frequencyPoint.Fill(0.1);
+  OutputType resultFirstOrder = rieszFunction->Evaluate(frequencyPoint, 0 );
+  rieszFunction->DebugOn();
+  rieszFunction->SetOrder(1);
+  typename RieszFrequencyFunctionType::IndicesFixedArrayType indices;
+  indices.Fill(0);
+  indices[0] = 1;
+  OutputType resultFirstOrderWithIndices = rieszFunction->EvaluateWithIndices(frequencyPoint, indices );
+
+  if( itk::Math::NotAlmostEquals(resultFirstOrder, resultFirstOrderWithIndices) )
+    {
+    std::cerr << "Should be equal: " << resultFirstOrder << " == " << resultFirstOrderWithIndices << std::endl;
+    testPassed = false;
+    }
+
+  // Test getting subIndices
+  // Init indice has to be sorted in descending order, example:(3,0,0)
+  typename RieszFrequencyFunctionType::IndicesArrayType initIndice;
+  initIndice.resize(Dimension);
+  initIndice[0] = 1;
+  typedef typename RieszFrequencyFunctionType::SetType SetType;
+  SetType uniqueIndices;
+  unsigned int positionToStartProcessing = 0;
+  RieszFrequencyFunctionType::ComputeUniqueIndices(initIndice, positionToStartProcessing, uniqueIndices);
+  std::cout <<"UniqueIndices: " << uniqueIndices.size() << std::endl; 
+  for (typename SetType::const_iterator it = uniqueIndices.begin(); it != uniqueIndices.end(); ++it)
+    {
+    std::cout << "(" ;
+    for (unsigned int i = 0; i<Dimension; ++i)
+      {
+      std::cout << (*it)[i]<< ", ";
+      }
+    std::cout << ")" << std::endl;
+    }
+
+  SetType allPermutations =
+    RieszFrequencyFunctionType::ComputeAllPermutations(uniqueIndices);
+
+  std::cout <<"AllPermutations: " << allPermutations.size() << std::endl; 
+  for (typename SetType::const_iterator it = allPermutations.begin(); it != allPermutations.end(); ++it)
+    {
+    std::cout << "(" ;
+    for (unsigned int i = 0; i<Dimension; ++i)
+      {
+      std::cout << (*it)[i]<< ", ";
+      }
+    std::cout << ")" << std::endl;
+    }
+
+  if(testPassed)
+    {
+    return EXIT_SUCCESS;
+    }
+  else
+    {
+    return EXIT_FAILURE;
+    }
+
+
+
+
+//   // Get real part of complex image for visualization
+//   typedef itk::ComplexToRealImageFilter< ComplexImageType, ImageType > ComplexToRealFilter;
+//   ComplexToRealFilter::Pointer complexToRealFilter = ComplexToRealFilter::New();
+//   std::cout << "Real part of complex image:" << std::endl;
+//   for( unsigned int dir = 0; dir < ImageType::ImageDimension; dir++ )
+//     {
+//     std::cout << "Direction: " << dir + 1 << " / " << ImageType::ImageDimension << std::endl;
+//     complexToRealFilter->SetInput( filterBank->GetOutput( dir ) );
+//     complexToRealFilter->Update();
+//
+// #ifdef ITK_VISUALIZE_TESTS
+//     itk::NumberToString< unsigned int > n2s;
+//     itk::Testing::ViewImage( complexToRealFilter->GetOutput(), "RealPart of Complex. Direction: " + n2s(
+//                          dir + 1) + " / " + n2s( ImageType::ImageDimension ) );
+// #endif
+}
+
+int itkRieszFrequencyFunctionTest( int argc, char* argv[] )
+{
+  if( argc != 2 )
+    {
+    std::cerr << "Usage: " << argv[0]
+              << "dimension" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  unsigned int dimension = atoi( argv[1] );
+
+  if( dimension == 2 )
+    {
+      return runRieszFrequencyFunctionTest<2>();
+    }
+  else if( dimension == 3 )
+    {
+      return runRieszFrequencyFunctionTest<3>();
+    }
+  else
+    {
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error: only 2 or 3 dimensions allowed, " << dimension << " selected." << std::endl;
+    return EXIT_FAILURE;
+    }
+}

--- a/test/itkRieszFrequencyFunctionTest.cxx
+++ b/test/itkRieszFrequencyFunctionTest.cxx
@@ -68,7 +68,7 @@ int runRieszFrequencyFunctionTest(unsigned int inputOrder)
   typedef typename RieszFrequencyFunctionType::SetType SetType;
   SetType uniqueIndices;
   unsigned int positionToStartProcessing = 0;
-  RieszFrequencyFunctionType::ComputeUniqueIndices(initIndice, positionToStartProcessing, uniqueIndices);
+  RieszFrequencyFunctionType::ComputeUniqueIndices(initIndice, uniqueIndices, positionToStartProcessing);
   std::cout <<"UniqueIndices: " << uniqueIndices.size() << std::endl; 
   for (typename SetType::const_iterator it = uniqueIndices.begin(); it != uniqueIndices.end(); ++it)
     {
@@ -101,13 +101,13 @@ int runRieszFrequencyFunctionTest(unsigned int inputOrder)
     testPassed = false;
     }
 
-  // Regression test.
+  // Regression test for indice calculation.
   for (unsigned int order = 1; order < 6; ++order )
     {
     uniqueIndices.clear();
     allPermutations.clear();
     initIndice[0] = order;
-    RieszFrequencyFunctionType::ComputeUniqueIndices(initIndice, 0, uniqueIndices);
+    RieszFrequencyFunctionType::ComputeUniqueIndices(initIndice, uniqueIndices /*, 0 */);
     allPermutations = RieszFrequencyFunctionType::ComputeAllPermutations(uniqueIndices);
     actualNumberOfComponents = allPermutations.size();
     expectedNumberOfComponents = RieszFrequencyFunctionType::ComputeNumberOfComponents(order);
@@ -118,6 +118,18 @@ int runRieszFrequencyFunctionTest(unsigned int inputOrder)
       }
     }
 
+  //Evaluate All Components:
+  rieszFunction->SetOrder(inputOrder);
+  rieszFunction->DebugOn();
+  typedef typename  RieszFrequencyFunctionType::OutputComponentsType OutputComponentType;
+
+  OutputComponentType allComponents = rieszFunction->EvaluateAllComponents(frequencyPoint);
+    std::cout << "allComponents:" <<std::endl;
+  for (typename OutputComponentType::const_iterator it = allComponents.begin(); it != allComponents.end(); ++it)
+  {
+    std::cout << *it << ",";
+  }
+  std::cout << std::endl;
 
   if(testPassed)
     {

--- a/test/itkRieszFrequencyFunctionTest.cxx
+++ b/test/itkRieszFrequencyFunctionTest.cxx
@@ -34,7 +34,7 @@
 #endif
 
 template<unsigned int VDimension>
-int runRieszFrequencyFunctionTest()
+int runRieszFrequencyFunctionTest(unsigned int order)
 {
   bool testPassed = true;
   const unsigned int Dimension = VDimension;
@@ -65,7 +65,7 @@ int runRieszFrequencyFunctionTest()
   // Init indice has to be sorted in descending order, example:(3,0,0)
   typename RieszFrequencyFunctionType::IndicesArrayType initIndice;
   initIndice.resize(Dimension);
-  initIndice[0] = 1;
+  initIndice[0] = order;
   typedef typename RieszFrequencyFunctionType::SetType SetType;
   SetType uniqueIndices;
   unsigned int positionToStartProcessing = 0;
@@ -83,7 +83,6 @@ int runRieszFrequencyFunctionTest()
 
   SetType allPermutations =
     RieszFrequencyFunctionType::ComputeAllPermutations(uniqueIndices);
-
   std::cout <<"AllPermutations: " << allPermutations.size() << std::endl; 
   for (typename SetType::const_iterator it = allPermutations.begin(); it != allPermutations.end(); ++it)
     {
@@ -104,9 +103,6 @@ int runRieszFrequencyFunctionTest()
     return EXIT_FAILURE;
     }
 
-
-
-
 //   // Get real part of complex image for visualization
 //   typedef itk::ComplexToRealImageFilter< ComplexImageType, ImageType > ComplexToRealFilter;
 //   ComplexToRealFilter::Pointer complexToRealFilter = ComplexToRealFilter::New();
@@ -126,22 +122,27 @@ int runRieszFrequencyFunctionTest()
 
 int itkRieszFrequencyFunctionTest( int argc, char* argv[] )
 {
-  if( argc != 2 )
+  if( argc < 2 || argc > 3 )
     {
     std::cerr << "Usage: " << argv[0]
-              << "dimension" << std::endl;
+              << "dimension [order]" << std::endl;
     return EXIT_FAILURE;
     }
 
   unsigned int dimension = atoi( argv[1] );
+  unsigned int order = 5;
+  if(argc == 3)
+    {
+    order = atoi( argv[2] );
+    }
 
   if( dimension == 2 )
     {
-      return runRieszFrequencyFunctionTest<2>();
+      return runRieszFrequencyFunctionTest<2>(order);
     }
   else if( dimension == 3 )
     {
-      return runRieszFrequencyFunctionTest<3>();
+      return runRieszFrequencyFunctionTest<3>(order);
     }
   else
     {

--- a/test/itkRieszFrequencyFunctionTest.cxx
+++ b/test/itkRieszFrequencyFunctionTest.cxx
@@ -64,7 +64,7 @@ int runRieszFrequencyFunctionTest(unsigned int inputOrder)
   std::cout <<"UniqueIndices: " << uniqueIndices.size() << std::endl; 
   for (typename SetType::const_iterator it = uniqueIndices.begin(); it != uniqueIndices.end(); ++it)
     {
-    std::cout << "(" ;
+    std::cout << "(";
     for (unsigned int i = 0; i<Dimension; ++i)
       {
       std::cout << (*it)[i]<< ", ";
@@ -77,7 +77,7 @@ int runRieszFrequencyFunctionTest(unsigned int inputOrder)
   std::cout <<"AllPermutations: " << allPermutations.size() << std::endl; 
   for (typename SetType::const_iterator it = allPermutations.begin(); it != allPermutations.end(); ++it)
     {
-    std::cout << "(" ;
+    std::cout << "(";
     for (unsigned int i = 0; i<Dimension; ++i)
       {
       std::cout << (*it)[i]<< ", ";
@@ -89,7 +89,10 @@ int runRieszFrequencyFunctionTest(unsigned int inputOrder)
   unsigned int actualNumberOfComponents = allPermutations.size();
   if (actualNumberOfComponents != expectedNumberOfComponents)
     {
-    std::cerr << "Error. NumberOfComponents for inputOrder: " << inputOrder << " ; actual: " << actualNumberOfComponents << " expected: " << expectedNumberOfComponents << " are not equal!" << std::endl;
+    std::cerr << "Error. NumberOfComponents for inputOrder: " << inputOrder 
+      << " ; actual: " << actualNumberOfComponents 
+      << " expected: " << expectedNumberOfComponents 
+      << " are not equal!" << std::endl;
     testPassed = false;
     }
 

--- a/test/itkRieszFrequencyFunctionTest.cxx
+++ b/test/itkRieszFrequencyFunctionTest.cxx
@@ -47,18 +47,10 @@ int runRieszFrequencyFunctionTest(unsigned int inputOrder)
 
   InputType frequencyPoint;
   frequencyPoint.Fill(0.1);
-  OutputType resultFirstOrder = rieszFunction->Evaluate(frequencyPoint, 0 );
   rieszFunction->SetOrder(1);
-  typename RieszFrequencyFunctionType::IndicesFixedArrayType indices;
-  indices.Fill(0);
+  typename RieszFrequencyFunctionType::IndicesArrayType indices(VDimension);
   indices[0] = 1;
   OutputType resultFirstOrderWithIndices = rieszFunction->EvaluateWithIndices(frequencyPoint, indices );
-
-  if( itk::Math::NotAlmostEquals(resultFirstOrder, resultFirstOrderWithIndices) )
-    {
-    std::cerr << "Should be equal: " << resultFirstOrder << " == " << resultFirstOrderWithIndices << std::endl;
-    testPassed = false;
-    }
 
   // Test getting subIndices
   // Init indice has to be sorted in descending order, example:(3,0,0)

--- a/test/itkRieszWaveletPhaseAnalysisTest.cxx
+++ b/test/itkRieszWaveletPhaseAnalysisTest.cxx
@@ -34,10 +34,7 @@
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
-#include "itkNumberToString.h"
 
-#include "itkGaussianSpatialFunction.h" 
-#include "itkFrequencyImageRegionIteratorWithIndex.h"
 #include "itkTestingMacros.h"
 
 #include <string>
@@ -45,6 +42,7 @@
 // Visualize for dev/debug purposes. Set in cmake file. Requires VTK
 #ifdef ITK_VISUALIZE_TESTS
 #include "itkViewImage.h"
+#include "itkNumberToString.h"
 #endif
 
 
@@ -177,49 +175,6 @@ int runRieszWaveletPhaseAnalysisTest( const std::string& inputImage,
   // The coefficients are now phases, do not apply reconstrucction factors.
   inverseWavelet->ApplyReconstructionFactorsOff();
   inverseWavelet->Update();
-
-  // // Apply a gaussian window of the size of the input.
-  // bool apply_gaussian = false;
-  // if(apply_gaussian == true)
-  //   {
-  //   typedef itk::GaussianSpatialFunction<double, dimension> FunctionType;
-  //   typename FunctionType::Pointer gaussian = FunctionType::New();
-  //   typedef FixedArray< double, Dimension > ArrayType;
-  //   ArrayType m_Mean;
-  //   ArrayType m_Sigma;
-  //   double m_Scale = 1.0;
-  //   bool m_Normalized = true;
-  //   for( unsigned int i = 0; i < Dimension; ++i )
-  //     {
-  //     m_Mean[i] = inverseWavelet->GetOutput()->GetLargestPossibleRegion().GetIndex()[i];
-  //     // 6.0 is equivalent to 3sigmas (border values are close to zero)
-  //     // m_Sigma[i] = outputSize[i]/(2*3.0);
-  //     m_Sigma[i] = inverseWavelet->GetOutput()->GetLargestPossibleRegion().GetSize()[i]/(2.0*2.35);
-  //     }
-  //   gaussian->SetSigma(m_Sigma);
-  //   gaussian->SetMean(m_Mean);
-  //   gaussian->SetScale(m_Scale);
-  //   gaussian->SetNormalized(m_Normalized);
-  //
-  //   // Create an iterator that will walk the output region
-  //   typedef itk::FrequencyImageRegionIteratorWithIndex< ComplexImageType > OutputIterator;
-  //   OutputIterator outIt = OutputIterator( inverseWavelet->GetOutput(),
-  //     inverseWavelet->GetOutput()->GetRequestedRegion() );
-  //   outIt.GoToBegin();
-  //   while( !outIt.IsAtEnd() )
-  //     {
-  //     typename ComplexImageType::IndexType ind = outIt.GetFrequencyBin();
-  //     typename FunctionType::InputType f;
-  //     for (unsigned int i = 0; i<dimension; ++i)
-  //       {
-  //       f[i] = static_cast<typename FunctionType::InputType::ValueType>(ind[i]);
-  //       }
-  //     const double value = gaussian->Evaluate(f);
-  //     // Set the pixel value to the function value
-  //     outIt.Set( outIt.Get() * static_cast<typename ComplexImageType::PixelType::value_type>(value) );
-  //     ++outIt;
-  //     }
-  //   }
 
   typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();
   inverseFFT->SetInput( inverseWavelet->GetOutput() );


### PR DESCRIPTION
Based on: [3D Steerable Wavelets in Practice, Chenouard et al.](https://www.researchgate.net/publication/228103987_3D_Steerable_Wavelets_in_Practice)

N := order of generalized riesz function.
Precondition: N>=1
n = (n1,n2,...nd) := indices vector. d-array, where d is the Dimension of the image.
Precondition: sum(n1,n2,...,nd) = N

R^n = (-j)^N * sqrt(N!/(n1!*n2!...nd!)) * (w1^n1 * w2^n2 * ... wd^nd) *  1.0 / ||w||^N
R^n = complex_component * normalizing_factor * frequency_factor * 1.0/freq_magnitude_factor

The number of output components of the scalar to vector RieszTransform is:
p(N,d) = (N+d - 1)! / (d -1)! N! 
if N = 1 , p(1,d) = d
if N = 2,  p(2,d) = (d+1)*d / 2
For example, d = 3.
N = 1 -> p(1,3) = 3
where the indices would be: (1,0,0) , (0,1,0), (0,0,1)
N = 2 -> p(2,3) = 6
(2,0,0), (0,2,0), (0,0,2) , (1,1,0), (1,0,1), (0,1,1)

EvaluateWithIndices(freq, indices)
m_Order (N)