### PR TITLE
Refactor iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ but should work for the default VNL.
 ```
 itkFrequencyImageRegionConstIteratorWithIndex.h
 itkFrequencyImageRegionIteratorWithIndex.h
+itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
+itkFrequencyFFTLayoutImageRegionIteratorWithIndex.h
+itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
+itkFrequencyShiftedFFTLayoutImageRegionIteratorWithIndex.h
 ```
 
 ## FrequencyFunctions

--- a/include/itkFrequencyBandImageFilter.h
+++ b/include/itkFrequencyBandImageFilter.h
@@ -19,7 +19,7 @@
 #define itkFrequencyBandImageFilter_h
 
 #include <itkImageToImageFilter.h>
-#include <itkFrequencyImageRegionIteratorWithIndex.h>
+#include <itkFrequencyFFTLayoutImageRegionIteratorWithIndex.h>
 
 namespace itk
 {
@@ -42,7 +42,8 @@ namespace itk
  *
  * \ingroup IsotropicWavelets
  */
-template<typename TImageType>
+template< typename TImageType,
+  typename TFrequencyIteratorType = FrequencyFFTLayoutImageRegionIteratorWithIndex<TImageType> >
 class FrequencyBandImageFilter:
   public ImageToImageFilter<TImageType, TImageType>
 {
@@ -80,7 +81,7 @@ public:
 #endif
 
   /** Frequency Iterator types */
-  typedef FrequencyImageRegionIteratorWithIndex<TImageType>  FrequencyIteratorType;
+  typedef TFrequencyIteratorType                             FrequencyIteratorType;
   typedef typename FrequencyIteratorType::FrequencyValueType FrequencyValueType;
 
   /****** Frequency Threshold Getters/Setters *****/

--- a/include/itkFrequencyBandImageFilter.hxx
+++ b/include/itkFrequencyBandImageFilter.hxx
@@ -24,8 +24,8 @@
 
 namespace itk
 {
-template<class TImageType>
-FrequencyBandImageFilter< TImageType >
+template<typename TImageType, typename TFrequencyIteratorType >
+FrequencyBandImageFilter<TImageType, TFrequencyIteratorType> 
 ::FrequencyBandImageFilter()
   : m_LowFrequencyThreshold(0),
   m_HighFrequencyThreshold(0.5), // Nyquist in hertz
@@ -38,9 +38,9 @@ FrequencyBandImageFilter< TImageType >
 {
 }
 
-template<class TImageType>
+template<typename TImageType, typename TFrequencyIteratorType >
 void
-FrequencyBandImageFilter< TImageType >
+FrequencyBandImageFilter<TImageType, TFrequencyIteratorType> 
 ::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
@@ -52,9 +52,9 @@ FrequencyBandImageFilter< TImageType >
   os << indent << "   RadialBand? " << (this->m_RadialBand ? "Yes" : "No ") << std::endl;
 }
 
-template<class TImageType>
+template<typename TImageType, typename TFrequencyIteratorType >
 void
-FrequencyBandImageFilter< TImageType >
+FrequencyBandImageFilter<TImageType, TFrequencyIteratorType> 
 ::SetPassBand(const bool pass_low_threshold, const bool pass_high_threshold)
 {
   this->m_PassBand = true;
@@ -63,9 +63,9 @@ FrequencyBandImageFilter< TImageType >
   this->Modified();
 }
 
-template<class TImageType>
+template<typename TImageType, typename TFrequencyIteratorType >
 void
-FrequencyBandImageFilter< TImageType >
+FrequencyBandImageFilter<TImageType, TFrequencyIteratorType> 
 ::SetStopBand(const bool pass_low_threshold, const bool pass_high_threshold)
 {
   this->m_PassBand = false;
@@ -74,9 +74,9 @@ FrequencyBandImageFilter< TImageType >
   this->Modified();
 }
 
-template<class TImageType>
+template<typename TImageType, typename TFrequencyIteratorType >
 void
-FrequencyBandImageFilter< TImageType >
+FrequencyBandImageFilter<TImageType, TFrequencyIteratorType> 
 ::SetFrequencyThresholds( const FrequencyValueType& freq_low,
                           const FrequencyValueType& freq_high)
 {
@@ -86,25 +86,25 @@ FrequencyBandImageFilter< TImageType >
   this->Modified();
 }
 
-template<class TImageType>
+template<typename TImageType, typename TFrequencyIteratorType >
 void
-FrequencyBandImageFilter< TImageType >
+FrequencyBandImageFilter<TImageType, TFrequencyIteratorType> 
 ::SetLowFrequencyThresholdInRadians( const FrequencyValueType& freq_in_radians_low)
 {
   this->SetLowFrequencyThreshold( freq_in_radians_low * 0.5 * itk::Math::one_over_pi);
 }
 
-template<class TImageType>
+template<typename TImageType, typename TFrequencyIteratorType >
 void
-FrequencyBandImageFilter< TImageType >
+FrequencyBandImageFilter<TImageType, TFrequencyIteratorType> 
 ::SetHighFrequencyThresholdInRadians( const FrequencyValueType& freq_in_radians_high)
 {
   this->SetHighFrequencyThreshold( freq_in_radians_high * 0.5 * itk::Math::one_over_pi);
 }
 
-template<class TImageType>
+template<typename TImageType, typename TFrequencyIteratorType >
 void
-FrequencyBandImageFilter< TImageType >
+FrequencyBandImageFilter<TImageType, TFrequencyIteratorType> 
 ::SetFrequencyThresholdsInRadians( const FrequencyValueType& freq_in_radians_low,
                                    const FrequencyValueType& freq_in_radians_high)
 {
@@ -113,9 +113,9 @@ FrequencyBandImageFilter< TImageType >
     freq_in_radians_high * 0.5 * itk::Math::one_over_pi );
 }
 
-template<class TImageType>
+template<typename TImageType, typename TFrequencyIteratorType >
 void
-FrequencyBandImageFilter<TImageType>
+FrequencyBandImageFilter<TImageType, TFrequencyIteratorType> 
 ::BeforeThreadedGenerateData()
 {
   if( this->m_LowFrequencyThreshold > this->m_HighFrequencyThreshold)
@@ -127,9 +127,9 @@ FrequencyBandImageFilter<TImageType>
                        this->GetOutput()->GetLargestPossibleRegion() );
 }
 
-template<class TImageType>
+template<typename TImageType, typename TFrequencyIteratorType >
 void
-FrequencyBandImageFilter<TImageType>
+FrequencyBandImageFilter<TImageType, TFrequencyIteratorType> 
 ::ThreadedGenerateData(
   const ImageRegionType & outputRegionForThread,
   ThreadIdType )

--- a/include/itkFrequencyExpandImageFilter.hxx
+++ b/include/itkFrequencyExpandImageFilter.hxx
@@ -19,14 +19,9 @@
 #define itkFrequencyExpandImageFilter_hxx
 
 #include <itkFrequencyExpandImageFilter.h>
-#include <itkObjectFactory.h>
-#include <itkNumericTraits.h>
 #include <itkProgressReporter.h>
 #include "itkInd2Sub.h"
 #include <itkPasteImageFilter.h>
-#include <itkImageRegionConstIterator.h>
-#include <itkGaussianSpatialFunction.h>
-#include <itkFrequencyImageRegionIteratorWithIndex.h>
 
 namespace itk
 {

--- a/include/itkFrequencyExpandViaInverseFFTImageFilter.hxx
+++ b/include/itkFrequencyExpandViaInverseFFTImageFilter.hxx
@@ -19,14 +19,6 @@
 #define itkFrequencyExpandViaInverseFFTImageFilter_hxx
 
 #include <itkFrequencyExpandViaInverseFFTImageFilter.h>
-#include <itkObjectFactory.h>
-#include <itkNumericTraits.h>
-#include <itkProgressReporter.h>
-#include "itkInd2Sub.h"
-#include <itkPasteImageFilter.h>
-#include <itkImageRegionConstIterator.h>
-#include <itkGaussianSpatialFunction.h>
-#include <itkFrequencyImageRegionIteratorWithIndex.h>
 
 namespace itk
 {
@@ -98,20 +90,6 @@ FrequencyExpandViaInverseFFTImageFilter< TImageType >
     }
 }
 
-/**
- * Implementation Detail:
- * The implementation calculate the number of different regions in an image,
- * depending on the dimension:
- * numberOfRegions = 2^dim (positive and negative frequencies per dim)
- * then uses function to convert a linear array of regions [0, ..., numberOfRegions - 1]
- * to binary subindices (only two options: positive or negative region)
- * In 3D: numberOfRegions = Nr = 2^3 = 8
- * sizeOfSubindices = [2,2,2]
- * Region = 0       -----> Ind2Sub(   0, [2,2,2]) = [0,0,0]
- * Region = 1       -----> Ind2Sub(   1, [2,2,2]) = [1,0,0]
- * Region = Nr - 1  -----> Ind2Sub(Nr-1, [2,2,2]) = [1,1,1]
- * So, if the result of Ind2Sub is 0 we paste the positive frequencies, if 1, negative freq
- */
 template< typename TImageType>
 void
 FrequencyExpandViaInverseFFTImageFilter< TImageType >

--- a/include/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/include/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -1,0 +1,289 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex_h
+#define itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex_h
+
+#include "itkImageRegionConstIteratorWithIndex.h"
+
+namespace itk
+{
+/** \class FrequencyFFTLayoutImageRegionConstIteratorWithIndex
+ * \brief A multi-dimensional iterator templated over image type that walks
+ * pixels within a region and is specialized to keep track of its image index
+ * location.
+ *
+ * This class is a specialization of ImageRegionConstIteratorWithIndex,
+ * adding method GetFrequencyBins to give the frequency bins corresponding to image indices, and GetFrequency to get the frequency of the bin.
+ * The frequency bins depends on the image size. The default assumes that the image to iterate over is
+ * the output of a forward FFT filter, where the first index corresponds to 0 frequency, and Nyquist Frequencies are
+ * in the middle, between positive and negative frequencies.
+ *
+ * This class can be specialized further to iterate over other frequency
+ * layouts, for example shifted images (where 0 frequency is in the middle of the image, and Nyquist are in the border).
+ * For different layout, use other frequency iterator.
+ *
+ * This iterator is for the frequency layout that results from applying a FFT (vnl or fftw) to an image.
+ * The default ImageInformation is: Origin = {{0}}, Spacing = {{1}}.
+ * In this case the frequency values will be in the range: [-1/2, 1/2] Hz
+ * Or [-pi, pi] rad/s
+ * To modify those ranges:
+ * a) Avoid modifying the origin. The origin index always corresponds to zero frequency after a FFT.
+ *    The range should be always centered around zero.
+ * b) The spacing control the range of frequencies (always around zero).
+ *    If the spacing is = {{0.5}} we get a frequency range of [-1/4, 1/4] or [-pi/2, pi/2].
+ *
+ * The frequency layout is assumed to be: where fs is frequency sampling, or frequency spacing (1.0 by default).
+ * If N is even:
+ * Nyquist frequency at index=N/2 is shared between + and - regions.
+ * <------------positive f ---------------><------------negative f-------------->
+ * 0(DC) fs/N 2*fs/N  ... (N/2 -1)*fs/N  fs/2   -(N/2-1)*fs/N  ...  -2*fs/N  -fs/N
+ *
+ * Example: Size 6:
+ * +    |     -
+ * ------------
+ *      0       <-- DC Component (0 freq)
+ * 1    |     5
+ * 2    |     4
+ *      3       <-- Shared between regions, unique Nyquist.
+ *
+ * If N is odd:
+ * Nyquist frequency is not represented but there are simmetric largest frequencies at index=N/2, N/2 +1
+ * <----------positive f ---------------><------------negative f----------------->
+ * 0(DC) fs/N 2*fs/N  ...... fs/2*(N-1)/N    -fs/2*(N-1)/N  ...    -2*fs/N  -fs/N
+ *
+ * Example: Size 5:
+ * +    |     -
+ * ------------
+ *      0       <-- DC Component (0 freq)
+ * 1    |     4
+ * 2    |     3 <-- Absolute Largest Frequency bins (+, -)
+ *
+ * Please see ImageRegionConstIteratorWithIndex for more information.
+ * \sa ForwardFFTImageFilter
+ *
+ * \par MORE INFORMATION
+ * For a complete description of the ITK Image Iterators and their API, please
+ * see the Iterators chapter in the ITK Software Guide.  The ITK Software Guide
+ * is available in print and as a free .pdf download from https://www.itk.org.
+ *
+ * \ingroup ImageIterators
+ *
+ * \sa ImageRegionIteratorWithIndex
+ * \sa ImageConstIterator \sa ConditionalConstIterator
+ * \sa ConstNeighborhoodIterator \sa ConstShapedNeighborhoodIterator
+ * \sa ConstSliceIterator  \sa CorrespondenceDataStructureIterator
+ * \sa FloodFilledFunctionConditionalConstIterator
+ * \sa FloodFilledImageFunctionConditionalConstIterator
+ * \sa FloodFilledImageFunctionConditionalIterator
+ * \sa FloodFilledSpatialFunctionConditionalConstIterator
+ * \sa FloodFilledSpatialFunctionConditionalIterator
+ * \sa ImageConstIterator \sa ImageConstIteratorWithIndex
+ * \sa ImageIterator \sa ImageIteratorWithIndex
+ * \sa ImageLinearConstIteratorWithIndex  \sa ImageLinearIteratorWithIndex
+ * \sa ImageRandomConstIteratorWithIndex  \sa ImageRandomIteratorWithIndex
+ * \sa ImageRegionConstIterator \sa ImageRegionConstIteratorWithIndex
+ * \sa ImageRegionExclusionConstIteratorWithIndex
+ * \sa ImageRegionExclusionIteratorWithIndex
+ * \sa ImageRegionIterator  \sa ImageRegionIteratorWithIndex
+ * \sa ImageRegionReverseConstIterator  \sa ImageRegionReverseIterator
+ * \sa ImageReverseConstIterator  \sa ImageReverseIterator
+ * \sa ImageSliceConstIteratorWithIndex  \sa ImageSliceIteratorWithIndex
+ * \sa NeighborhoodIterator \sa PathConstIterator  \sa PathIterator
+ * \sa ShapedNeighborhoodIterator  \sa SliceIterator
+ * \sa ImageConstIteratorWithIndex
+ *
+ * \ingroup IsotropicWavelets
+ *
+ */
+template< typename TImage >
+class FrequencyFFTLayoutImageRegionConstIteratorWithIndex:
+  public ImageRegionConstIteratorWithIndex< TImage >
+{
+public:
+  /** Standard class typedefs. */
+  typedef FrequencyFFTLayoutImageRegionConstIteratorWithIndex  Self;
+  typedef ImageRegionConstIteratorWithIndex< TImage > Superclass;
+
+  /** Types inherited from the Superclass */
+  typedef typename Superclass::IndexType             IndexType;
+  typedef typename Superclass::SizeType              SizeType;
+  typedef typename Superclass::OffsetType            OffsetType;
+  typedef typename Superclass::RegionType            RegionType;
+  typedef typename Superclass::ImageType             ImageType;
+  typedef typename Superclass::PixelContainer        PixelContainer;
+  typedef typename Superclass::PixelContainerPointer PixelContainerPointer;
+  typedef typename Superclass::InternalPixelType     InternalPixelType;
+  typedef typename Superclass::PixelType             PixelType;
+  typedef typename Superclass::AccessorType          AccessorType;
+
+  typedef typename ImageType::SpacingType      FrequencyType;
+  typedef typename ImageType::SpacingValueType FrequencyValueType;
+  /** Default constructor. Needed since we provide a cast constructor. */
+  FrequencyFFTLayoutImageRegionConstIteratorWithIndex() :
+    ImageRegionConstIteratorWithIndex< TImage >()
+  {
+    this->InitIndices();
+  };
+
+  /** Constructor establishes an iterator to walk a particular image and a
+   * particular region of that image. */
+  FrequencyFFTLayoutImageRegionConstIteratorWithIndex(const TImage *ptr, const RegionType & region) :
+    ImageRegionConstIteratorWithIndex< TImage >(ptr, region)
+  {
+    this->InitIndices();
+  };
+
+  /** Constructor that can be used to cast from an ImageIterator to an
+   * ImageRegionIteratorWithIndex. Many routines return an ImageIterator, but for a
+   * particular task, you may want an ImageRegionIteratorWithIndex.  Rather than
+   * provide overloaded APIs that return different types of Iterators, itk
+   * returns ImageIterators and uses constructors to cast from an
+   * ImageIterator to a ImageRegionIteratorWithIndex. */
+  explicit FrequencyFFTLayoutImageRegionConstIteratorWithIndex(const Superclass & it) :
+    ImageRegionConstIteratorWithIndex< TImage >(it)
+  {
+    this->InitIndices();
+  };
+
+  /*
+   * Image Index [0, N] returns [0 to N/2] (positive) union [-N/2 + 1, -1] (negative). So index N/2 + 1 returns the bin -N/2 + 1.
+   * If first index of the image is not zero, it stills returns values in the same range.
+   */
+  IndexType GetFrequencyBin() const
+  {
+    IndexType freqInd;
+
+    freqInd.Fill(0);
+    for (unsigned int dim = 0; dim < TImage::ImageDimension; dim++)
+      {
+      if (this->m_PositionIndex[dim] <= m_HalfIndex[dim])
+        {
+        freqInd[dim] = this->m_PositionIndex[dim] - this->m_MinIndex[dim];
+        }
+      else //  -. From -N/2 + 1 (Nyquist if even) to -1 (-df in frequency)
+        {
+        freqInd[dim] = this->m_PositionIndex[dim] - (this->m_MaxIndex[dim] + 1);
+        }
+      }
+    return freqInd;
+  }
+
+  /** Note that this method is independent of the region in the constructor.
+   * It takes into account the ImageInformation of the Image in the frequency domain.
+   * This iterator is for the frequency layout that results from applying a FFT (vnl or fftw) to an image.
+   * If your image has a different layout, use other frequency iterator.
+   * The default ImageInformation is: Origin = {{0}}, Spacing = {{1}}.
+   * In this case the frequency values will be in the range: [-1/2, 1/2] Hz
+   * Or [-pi, pi] rad/s
+   * To modify those ranges:
+   * a) Avoid modifying the origin. The origin index always corresponds to zero frequency after a FFT.
+   *    The range should be always centered around zero.
+   * b) The spacing control the range of frequencies (always around zero).
+   *    If the spacing is = {{0.5}} we get a frequency range of [-1/4, 1/4] or [-pi/2, pi/2].
+   */
+  FrequencyType GetFrequency() const
+  {
+    FrequencyType freq;
+    IndexType     freqInd = this->GetFrequencyBin();
+
+    for (unsigned int dim = 0; dim < TImage::ImageDimension; dim++)
+      {
+      freq[dim] = this->m_FrequencyOrigin[dim]
+        + this->m_FrequencySpacing[dim] * freqInd[dim];
+      }
+    return freq;
+  }
+
+  FrequencyValueType GetFrequencyModuloSquare() const
+  {
+    FrequencyValueType w2(0);
+    FrequencyType      w( this->GetFrequency() );
+
+    for (unsigned int dim = 0; dim < TImage::ImageDimension; dim++)
+      {
+      w2 += w[dim] * w[dim];
+      }
+    return w2;
+  }
+
+  /**
+   * Index corresponding to the first highest frequency (Nyquist) after a FFT transform.
+   * If the size of the image is even, the Nyquist frequency = fs/2 is unique and shared
+   * between positive and negative frequencies.
+   * If odd, Nyquist frequency is not represented, but there is still a largest frequency at this index
+   * = fs/2 * (N-1)/N.
+   */
+  itkGetConstReferenceMacro(HalfIndex, IndexType);
+  void SetHalfIndex(const IndexType halfIndex)
+    {
+    this->m_HalfIndex = halfIndex;
+    };
+  /** Default to first index of the largest possible Region. */
+  itkGetConstReferenceMacro(MinIndex, IndexType);
+  /** Default to UpperIndex of the largest possible Region. */
+  itkGetConstReferenceMacro(MaxIndex, IndexType);
+
+  /** Origin of frequencies is zero for FFT output. */
+  itkGetConstReferenceMacro(FrequencyOrigin, FrequencyType);
+  void SetFrequencyOrigin(const FrequencyType frequencyOrigin)
+    {
+    this->m_FrequencyOrigin = frequencyOrigin;
+    };
+
+  /** This is the pixel width, or the bin size of the frequency.
+   * FrequencySpacing  = SamplingFrequency / ImageSize */
+  itkGetConstReferenceMacro(FrequencySpacing, FrequencyType);
+  void SetFrequencySpacing(const FrequencyType frequencySpacing)
+    {
+    this->m_FrequencySpacing = frequencySpacing;
+    };
+
+private:
+  /** Calculate Nyquist frequency index (m_HalfIndex), and Min/Max indices from LargestPossibleRegion.
+   * Called at constructors.  */
+  void InitIndices()
+  {
+    this->m_MinIndex =
+      this->m_Image->GetLargestPossibleRegion().GetIndex();
+    this->m_MaxIndex =
+      this->m_Image->GetLargestPossibleRegion().GetUpperIndex();
+    FrequencyType samplingFrequency;
+    for (unsigned int dim = 0; dim < ImageType::ImageDimension; dim++)
+      {
+      this->m_HalfIndex[dim] = static_cast<FrequencyValueType>(
+          this->m_MinIndex[dim] + std::ceil( (this->m_MaxIndex[dim] - this->m_MinIndex[dim] ) / 2.0 )
+          );
+      // Set frequency metadata.
+      // Origin of frequencies is zero in the standard layout of a FFT output.
+      this->m_FrequencyOrigin[dim] = 0.0; 
+      // SamplingFrequency = 1.0 / SpatialSpacing
+      samplingFrequency[dim] = 1.0 / this->m_Image->GetSpacing()[dim];
+      // Freq_BinSize = SamplingFrequency / Size
+      this->m_FrequencySpacing[dim] = samplingFrequency[dim]
+        / this->m_Image->GetLargestPossibleRegion().GetSize()[dim];
+      }
+  }
+
+  IndexType     m_HalfIndex;
+  IndexType     m_MinIndex;
+  IndexType     m_MaxIndex;
+  FrequencyType m_FrequencyOrigin;
+  FrequencyType m_FrequencySpacing;
+};
+} // end namespace itk
+#endif

--- a/include/itkFrequencyFFTLayoutImageRegionIteratorWithIndex.h
+++ b/include/itkFrequencyFFTLayoutImageRegionIteratorWithIndex.h
@@ -15,35 +15,23 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#ifndef itkFrequencyImageRegionConstIteratorWithIndex_h
-#define itkFrequencyImageRegionConstIteratorWithIndex_h
+#ifndef itkFrequencyFFTLayoutImageRegionIteratorWithIndex_h
+#define itkFrequencyFFTLayoutImageRegionIteratorWithIndex_h
 
-#include "itkImageRegionConstIteratorWithIndex.h"
+#include "itkImageRegionIteratorWithIndex.h"
+#include "itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h"
 
 namespace itk
 {
-/** \class FrequencyImageRegionConstIteratorWithIndex
- * \brief A multi-dimensional iterator templated over image type that walks
- * pixels within a region and is specialized to keep track of its image index
- * location.
- *
- * This class is a specialization of ImageRegionConstIteratorWithIndex,
- * adding method GetFrequencyBins to give the frequency bins corresponding to image indices, and GetFrequency to get the frequency of the bin.
- * 
- * This iterator assumes that the image is already in the frequency domain, so GetFrequencyBin is a wrap around GetIndex(), and GetFrequency is a wrap around Get().
- *
- * For a different layout, use other frequency iterator.
- *
- * Please see ImageRegionConstIteratorWithIndex for more information.
- * \sa ForwardFFTImageFilter
- *
- * \par MORE INFORMATION
- * For a complete description of the ITK Image Iterators and their API, please
- * see the Iterators chapter in the ITK Software Guide.  The ITK Software Guide
- * is available in print and as a free .pdf download from https://www.itk.org.
+/** \class FrequencyFFTLayoutImageRegionIteratorWithIndex
+
+ * Iterator providing method GetFrequency() to retrieve the frequency associated to an index.
+ * This value is related to the specific layout of frequencies from an image in the dual (frequency) space.
+ * In this case, the layout corresponds to the output of a FastFourierTransform from FFTW library.
+ * This class is a non-const version of FrequencyFFTLayoutImageRegionConstIteratorWithIndex.
  *
  * \ingroup ImageIterators
- *
+ * \sa FrequencyFFTLayoutImageRegionConstIteratorWithIndex
  * \sa ImageRegionIteratorWithIndex
  * \sa ImageConstIterator \sa ConditionalConstIterator
  * \sa ConstNeighborhoodIterator \sa ConstShapedNeighborhoodIterator
@@ -72,13 +60,13 @@ namespace itk
  *
  */
 template< typename TImage >
-class FrequencyImageRegionConstIteratorWithIndex:
-  public ImageRegionConstIteratorWithIndex< TImage >
+class FrequencyFFTLayoutImageRegionIteratorWithIndex:
+  public FrequencyFFTLayoutImageRegionConstIteratorWithIndex< TImage >
 {
 public:
   /** Standard class typedefs. */
-  typedef FrequencyImageRegionConstIteratorWithIndex  Self;
-  typedef ImageRegionConstIteratorWithIndex< TImage > Superclass;
+  typedef FrequencyFFTLayoutImageRegionIteratorWithIndex  Self;
+  typedef ImageRegionIteratorWithIndex< TImage > Superclass;
 
   /** Types inherited from the Superclass */
   typedef typename Superclass::IndexType             IndexType;
@@ -95,19 +83,17 @@ public:
   typedef typename ImageType::SpacingType      FrequencyType;
   typedef typename ImageType::SpacingValueType FrequencyValueType;
   /** Default constructor. Needed since we provide a cast constructor. */
-  FrequencyImageRegionConstIteratorWithIndex() :
-    ImageRegionConstIteratorWithIndex< TImage >()
+  FrequencyFFTLayoutImageRegionIteratorWithIndex() :
+    FrequencyFFTLayoutImageRegionConstIteratorWithIndex< TImage >()
   {
-    this->InitIndices();
-  };
+  }
 
   /** Constructor establishes an iterator to walk a particular image and a
    * particular region of that image. */
-  FrequencyImageRegionConstIteratorWithIndex(const TImage *ptr, const RegionType & region) :
-    ImageRegionConstIteratorWithIndex< TImage >(ptr, region)
+  FrequencyFFTLayoutImageRegionIteratorWithIndex(TImage *ptr, const RegionType & region) :
+    FrequencyFFTLayoutImageRegionConstIteratorWithIndex< TImage >(ptr, region)
   {
-    this->InitIndices();
-  };
+  }
 
   /** Constructor that can be used to cast from an ImageIterator to an
    * ImageRegionIteratorWithIndex. Many routines return an ImageIterator, but for a
@@ -115,66 +101,38 @@ public:
    * provide overloaded APIs that return different types of Iterators, itk
    * returns ImageIterators and uses constructors to cast from an
    * ImageIterator to a ImageRegionIteratorWithIndex. */
-  explicit FrequencyImageRegionConstIteratorWithIndex(const Superclass & it) :
-    ImageRegionConstIteratorWithIndex< TImage >(it)
+  FrequencyFFTLayoutImageRegionIteratorWithIndex(const ImageIteratorWithIndex< TImage > & it) :
+    FrequencyFFTLayoutImageRegionConstIteratorWithIndex< TImage >(it)
   {
-    this->InitIndices();
-  };
-
-  /*
-   * The image is in the frequency domain already, return the index.
-   */
-  IndexType GetFrequencyBin() const
-  {
-    return this->GetIndex();
   }
 
-  /* Equivalent to Get(), but the result is cast to FrequencyType.
-   */
-  FrequencyType GetFrequency() const
+  /** Set the pixel value */
+  void Set(const PixelType & value) const
   {
-    // FrequencyType freq;
-    return static_cast<FrequencyType>(this->Get());
+    this->m_PixelAccessorFunctor.Set(*( const_cast< InternalPixelType * >( this->m_Position ) ), value);
   }
 
-  FrequencyValueType GetFrequencyModuloSquare() const
+  /** Return a reference to the pixel.
+   * This method will provide the fastest access to pixel
+   * data, but it will NOT support ImageAdaptors. */
+  PixelType & Value(void)
   {
-    FrequencyValueType w2(0);
-    FrequencyType      w( this->GetFrequency() );
-
-    for (unsigned int dim = 0; dim < TImage::ImageDimension; dim++)
-      {
-      w2 += w[dim] * w[dim];
-      }
-    return w2;
+    return *( const_cast< InternalPixelType * >( this->m_Position ) );
   }
 
-  /** Origin of frequencies is set to be equal to m_Image->GetOrigin(). */
-  itkGetConstReferenceMacro(FrequencyOrigin, FrequencyType);
-  void SetFrequencyOrigin(const FrequencyType frequencyOrigin)
-    {
-    this->m_FrequencyOrigin = frequencyOrigin;
-    };
-
-  /** This is the pixel width, or the bin size of the frequency.
-   * FrequencySpacing  = SamplingFrequency / ImageSize */
-  itkGetConstReferenceMacro(FrequencySpacing, FrequencyType);
-  void SetFrequencySpacing(const FrequencyType frequencySpacing)
-    {
-    this->m_FrequencySpacing = frequencySpacing;
-    };
-
-private:
-  /** Calculate Nyquist frequency index (m_HalfIndex), and Min/Max indices from LargestPossibleRegion.
-   * Called at constructors.  */
-  void InitIndices()
+protected:
+  /** The construction from a const iterator is declared protected
+      in order to enforce const correctness. */
+  FrequencyFFTLayoutImageRegionIteratorWithIndex(const FrequencyFFTLayoutImageRegionConstIteratorWithIndex< TImage > & it) :
+    FrequencyFFTLayoutImageRegionConstIteratorWithIndex< TImage >(it)
   {
-    this->m_FrequencyOrigin = this->m_Image->GetOrigin();
-    this->m_FrequencySpacing = this->m_Image->GetSpacing();
   }
 
-  FrequencyType m_FrequencyOrigin;
-  FrequencyType m_FrequencySpacing;
+  Self & operator=(const FrequencyFFTLayoutImageRegionConstIteratorWithIndex< TImage > & it)
+  {
+    this->FrequencyFFTLayoutImageRegionConstIteratorWithIndex< TImage >::operator=(it);
+    return *this;
+  }
 };
 } // end namespace itk
 #endif

--- a/include/itkFrequencyImageRegionConstIteratorWithIndex.h
+++ b/include/itkFrequencyImageRegionConstIteratorWithIndex.h
@@ -98,7 +98,7 @@ public:
   FrequencyImageRegionConstIteratorWithIndex() :
     ImageRegionConstIteratorWithIndex< TImage >()
   {
-    this->InitIndices();
+    this->Init();
   };
 
   /** Constructor establishes an iterator to walk a particular image and a
@@ -106,7 +106,7 @@ public:
   FrequencyImageRegionConstIteratorWithIndex(const TImage *ptr, const RegionType & region) :
     ImageRegionConstIteratorWithIndex< TImage >(ptr, region)
   {
-    this->InitIndices();
+    this->Init();
   };
 
   /** Constructor that can be used to cast from an ImageIterator to an
@@ -118,7 +118,7 @@ public:
   explicit FrequencyImageRegionConstIteratorWithIndex(const Superclass & it) :
     ImageRegionConstIteratorWithIndex< TImage >(it)
   {
-    this->InitIndices();
+    this->Init();
   };
 
   /*
@@ -165,9 +165,9 @@ public:
     };
 
 private:
-  /** Calculate Nyquist frequency index (m_HalfIndex), and Min/Max indices from LargestPossibleRegion.
+  /** Set the frequency metadata.
    * Called at constructors.  */
-  void InitIndices()
+  void Init()
   {
     this->m_FrequencyOrigin = this->m_Image->GetOrigin();
     this->m_FrequencySpacing = this->m_Image->GetSpacing();

--- a/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -1,0 +1,285 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex_h
+#define itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex_h
+
+#include "itkImageRegionConstIteratorWithIndex.h"
+
+namespace itk
+{
+/** \class FrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex
+ * \brief A multi-dimensional iterator templated over image type that walks
+ * pixels within a region and is specialized to keep track of its image index
+ * location.
+ *
+ * This class is a specialization of ImageRegionConstIteratorWithIndex,
+ * adding method GetFrequencyBins to give the frequency bins corresponding to image indices, and GetFrequency to get the frequency of the bin.
+ * The frequency bins depends on the image size. The default assumes that the image to iterate over is
+ * the output of a forward FFT filter, where the first index corresponds to 0 frequency, and Nyquist Frequencies are
+ * in the middle, between positive and negative frequencies.
+ *
+ * This class can be specialized further to iterate over other frequency
+ * layouts, for example shifted images (where 0 frequency is in the middle of the image, and Nyquist are in the border).
+ * For different layout, use other frequency iterator.
+ *
+ * This iterator is for the frequency layout that results from applying a FFT (vnl or fftw) to an image.
+ * The default ImageInformation is: Origin = {{0}}, Spacing = {{1}}.
+ * In this case the frequency values will be in the range: [-1/2, 1/2] Hz
+ * Or [-pi, pi] rad/s
+ * To modify those ranges:
+ * a) Avoid modifying the origin. The origin index always corresponds to zero frequency after a FFT.
+ *    The range should be always centered around zero.
+ * b) The spacing control the range of frequencies (always around zero).
+ *    If the spacing is = {{0.5}} we get a frequency range of [-1/4, 1/4] or [-pi/2, pi/2].
+ *
+ * The frequency layout is assumed to be: where fs is frequency sampling, or frequency spacing (1.0 by default).
+ * If N is even:
+ * Nyquist frequency at index=N/2 is shared between + and - regions.
+ * <------------positive f ---------------><------------negative f-------------->
+ * 0(DC) fs/N 2*fs/N  ... (N/2 -1)*fs/N  fs/2   -(N/2-1)*fs/N  ...  -2*fs/N  -fs/N
+ *
+ * Example: Size 6:
+ * +    |     -
+ * ------------
+ *      0       <-- DC Component (0 freq)
+ * 1    |     5
+ * 2    |     4
+ *      3       <-- Shared between regions, unique Nyquist.
+ *
+ * If N is odd:
+ * Nyquist frequency is not represented but there are simmetric largest frequencies at index=N/2, N/2 +1
+ * <----------positive f ---------------><------------negative f----------------->
+ * 0(DC) fs/N 2*fs/N  ...... fs/2*(N-1)/N    -fs/2*(N-1)/N  ...    -2*fs/N  -fs/N
+ *
+ * Example: Size 5:
+ * +    |     -
+ * ------------
+ *      0       <-- DC Component (0 freq)
+ * 1    |     4
+ * 2    |     3 <-- Absolute Largest Frequency bins (+, -)
+ *
+ * Please see ImageRegionConstIteratorWithIndex for more information.
+ * \sa ForwardFFTImageFilter
+ *
+ * \par MORE INFORMATION
+ * For a complete description of the ITK Image Iterators and their API, please
+ * see the Iterators chapter in the ITK Software Guide.  The ITK Software Guide
+ * is available in print and as a free .pdf download from https://www.itk.org.
+ *
+ * \ingroup ImageIterators
+ *
+ * \sa ImageRegionIteratorWithIndex
+ * \sa ImageConstIterator \sa ConditionalConstIterator
+ * \sa ConstNeighborhoodIterator \sa ConstShapedNeighborhoodIterator
+ * \sa ConstSliceIterator  \sa CorrespondenceDataStructureIterator
+ * \sa FloodFilledFunctionConditionalConstIterator
+ * \sa FloodFilledImageFunctionConditionalConstIterator
+ * \sa FloodFilledImageFunctionConditionalIterator
+ * \sa FloodFilledSpatialFunctionConditionalConstIterator
+ * \sa FloodFilledSpatialFunctionConditionalIterator
+ * \sa ImageConstIterator \sa ImageConstIteratorWithIndex
+ * \sa ImageIterator \sa ImageIteratorWithIndex
+ * \sa ImageLinearConstIteratorWithIndex  \sa ImageLinearIteratorWithIndex
+ * \sa ImageRandomConstIteratorWithIndex  \sa ImageRandomIteratorWithIndex
+ * \sa ImageRegionConstIterator \sa ImageRegionConstIteratorWithIndex
+ * \sa ImageRegionExclusionConstIteratorWithIndex
+ * \sa ImageRegionExclusionIteratorWithIndex
+ * \sa ImageRegionIterator  \sa ImageRegionIteratorWithIndex
+ * \sa ImageRegionReverseConstIterator  \sa ImageRegionReverseIterator
+ * \sa ImageReverseConstIterator  \sa ImageReverseIterator
+ * \sa ImageSliceConstIteratorWithIndex  \sa ImageSliceIteratorWithIndex
+ * \sa NeighborhoodIterator \sa PathConstIterator  \sa PathIterator
+ * \sa ShapedNeighborhoodIterator  \sa SliceIterator
+ * \sa ImageConstIteratorWithIndex
+ *
+ * \ingroup IsotropicWavelets
+ *
+ */
+template< typename TImage >
+class FrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex:
+  public ImageRegionConstIteratorWithIndex< TImage >
+{
+public:
+  /** Standard class typedefs. */
+  typedef FrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex  Self;
+  typedef ImageRegionConstIteratorWithIndex< TImage > Superclass;
+
+  /** Types inherited from the Superclass */
+  typedef typename Superclass::IndexType             IndexType;
+  typedef typename Superclass::SizeType              SizeType;
+  typedef typename Superclass::OffsetType            OffsetType;
+  typedef typename Superclass::RegionType            RegionType;
+  typedef typename Superclass::ImageType             ImageType;
+  typedef typename Superclass::PixelContainer        PixelContainer;
+  typedef typename Superclass::PixelContainerPointer PixelContainerPointer;
+  typedef typename Superclass::InternalPixelType     InternalPixelType;
+  typedef typename Superclass::PixelType             PixelType;
+  typedef typename Superclass::AccessorType          AccessorType;
+
+  typedef typename ImageType::SpacingType      FrequencyType;
+  typedef typename ImageType::SpacingValueType FrequencyValueType;
+  /** Default constructor. Needed since we provide a cast constructor. */
+  FrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex() :
+    ImageRegionConstIteratorWithIndex< TImage >()
+  {
+    this->InitIndices();
+  };
+
+  /** Constructor establishes an iterator to walk a particular image and a
+   * particular region of that image. */
+  FrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex(const TImage *ptr, const RegionType & region) :
+    ImageRegionConstIteratorWithIndex< TImage >(ptr, region)
+  {
+    this->InitIndices();
+  };
+
+  /** Constructor that can be used to cast from an ImageIterator to an
+   * ImageRegionIteratorWithIndex. Many routines return an ImageIterator, but for a
+   * particular task, you may want an ImageRegionIteratorWithIndex.  Rather than
+   * provide overloaded APIs that return different types of Iterators, itk
+   * returns ImageIterators and uses constructors to cast from an
+   * ImageIterator to a ImageRegionIteratorWithIndex. */
+  explicit FrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex(const Superclass & it) :
+    ImageRegionConstIteratorWithIndex< TImage >(it)
+  {
+    this->InitIndices();
+  };
+
+  /*
+   * Image Index [0, N - 1] returns [-N/2 + 1, -1] (negative) union [0 to N/2] (positive). So index N/2 + 1 returns the bin 0.
+   * It is a shift by -N/2 + 1, from [0, N-1] to [-N/2 + 1, N/2]
+   * If first index of the image is not zero, it stills returns values in the same range.
+   */
+  IndexType GetFrequencyBin() const
+  {
+    IndexType freqInd;
+
+    freqInd.Fill(0);
+    for (unsigned int dim = 0; dim < TImage::ImageDimension; dim++)
+      {
+        freqInd[dim] = this->m_PositionIndex[dim] - this->m_HalfIndex[dim] + 1;
+      }
+    return freqInd;
+  }
+
+  /** Note that this method is independent of the region in the constructor.
+   * It takes into account the ImageInformation of the Image in the frequency domain.
+   * This iterator is for the frequency layout that results from applying a FFT and then ShiftFFT to center the zero frequency component.
+   * If your image has a different layout, use other frequency iterator.
+   * The default ImageInformation is: Origin = {{0}}, Spacing = {{1}}.
+   * In this case the frequency values will be in the range: [-1/2, 1/2] Hz
+   * Or [-pi, pi] rad/s
+   * To modify those ranges:
+   * a) Avoid modifying the origin. The origin index always corresponds to zero frequency after a FFT.
+   *    The range should be always centered around zero.
+   * b) The spacing control the range of frequencies (always around zero).
+   *    If the spacing is = {{0.5}} we get a frequency range of [-1/4, 1/4] or [-pi/2, pi/2].
+   */
+  FrequencyType GetFrequency() const
+  {
+    FrequencyType freq;
+    IndexType     freqInd = this->GetFrequencyBin();
+
+    for (unsigned int dim = 0; dim < TImage::ImageDimension; dim++)
+      {
+      freq[dim] = this->m_FrequencyOrigin[dim]
+        + this->m_FrequencySpacing[dim] * freqInd[dim];
+      }
+    return freq;
+  }
+
+  FrequencyValueType GetFrequencyModuloSquare() const
+  {
+    FrequencyValueType w2(0);
+    FrequencyType      w( this->GetFrequency() );
+
+    for (unsigned int dim = 0; dim < TImage::ImageDimension; dim++)
+      {
+      w2 += w[dim] * w[dim];
+      }
+    return w2;
+  }
+
+  /**
+   * Index corresponding to the first highest frequency (Nyquist) after a FFT transform.
+   * If the size of the image is even, the Nyquist frequency = fs/2 is unique and shared
+   * between positive and negative frequencies.
+   * If odd, Nyquist frequency is not represented, but there is still a largest frequency at this index
+   * = fs/2 * (N-1)/N.
+   * If the FFTLayout is Shifted, this correponds to the index where the zero component is minus 1.
+   * ZeroFrequencyIndex = HalfIndex + 1;
+   */
+  itkGetConstReferenceMacro(HalfIndex, IndexType);
+  void SetHalfIndex(const IndexType halfIndex)
+    {
+    this->m_HalfIndex = halfIndex;
+    };
+  /** Default to first index of the largest possible Region. */
+  itkGetConstReferenceMacro(MinIndex, IndexType);
+  /** Default to UpperIndex of the largest possible Region. */
+  itkGetConstReferenceMacro(MaxIndex, IndexType);
+
+  /** Origin of frequencies is zero for FFT output. */
+  itkGetConstReferenceMacro(FrequencyOrigin, FrequencyType);
+  void SetFrequencyOrigin(const FrequencyType frequencyOrigin)
+    {
+    this->m_FrequencyOrigin = frequencyOrigin;
+    };
+
+  /** This is the pixel width, or the bin size of the frequency.
+   * FrequencySpacing  = SamplingFrequency / ImageSize */
+  itkGetConstReferenceMacro(FrequencySpacing, FrequencyType);
+  void SetFrequencySpacing(const FrequencyType frequencySpacing)
+    {
+    this->m_FrequencySpacing = frequencySpacing;
+    };
+
+private:
+  /** Calculate Nyquist frequency index (m_HalfIndex), and Min/Max indices from LargestPossibleRegion.
+   * Called at constructors.  */
+  void InitIndices()
+  {
+    this->m_MinIndex =
+      this->m_Image->GetLargestPossibleRegion().GetIndex();
+    this->m_MaxIndex =
+      this->m_Image->GetLargestPossibleRegion().GetUpperIndex();
+    FrequencyType samplingFrequency;
+    for (unsigned int dim = 0; dim < ImageType::ImageDimension; dim++)
+      {
+      this->m_HalfIndex[dim] = static_cast<FrequencyValueType>(
+          this->m_MinIndex[dim] + std::ceil( (this->m_MaxIndex[dim] - this->m_MinIndex[dim] ) / 2.0 )
+          );
+      // Set frequency metadata.
+      // Origin of frequencies is zero in the standard layout of a FFT output.
+      this->m_FrequencyOrigin[dim] = 0.0; 
+      // SamplingFrequency = 1.0 / SpatialSpacing
+      samplingFrequency[dim] = 1.0 / this->m_Image->GetSpacing()[dim];
+      // Freq_BinSize = SamplingFrequency / Size
+      this->m_FrequencySpacing[dim] = samplingFrequency[dim]
+        / this->m_Image->GetLargestPossibleRegion().GetSize()[dim];
+      }
+  }
+
+  IndexType     m_HalfIndex;
+  IndexType     m_MinIndex;
+  IndexType     m_MaxIndex;
+  FrequencyType m_FrequencyOrigin;
+  FrequencyType m_FrequencySpacing;
+};
+} // end namespace itk
+#endif

--- a/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
+++ b/include/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.h
@@ -137,7 +137,7 @@ public:
   FrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex() :
     ImageRegionConstIteratorWithIndex< TImage >()
   {
-    this->InitIndices();
+    this->Init();
   };
 
   /** Constructor establishes an iterator to walk a particular image and a
@@ -145,7 +145,7 @@ public:
   FrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex(const TImage *ptr, const RegionType & region) :
     ImageRegionConstIteratorWithIndex< TImage >(ptr, region)
   {
-    this->InitIndices();
+    this->Init();
   };
 
   /** Constructor that can be used to cast from an ImageIterator to an
@@ -157,7 +157,7 @@ public:
   explicit FrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex(const Superclass & it) :
     ImageRegionConstIteratorWithIndex< TImage >(it)
   {
-    this->InitIndices();
+    this->Init();
   };
 
   /*
@@ -244,7 +244,7 @@ public:
 private:
   /** Calculate m_ZeroFrequencyIndex, and frequency spacing/origin.
    * Called at constructors.  */
-  void InitIndices()
+  void Init()
   {
     IndexType minIndex =
       this->m_Image->GetLargestPossibleRegion().GetIndex();

--- a/include/itkFrequencyShrinkImageFilter.hxx
+++ b/include/itkFrequencyShrinkImageFilter.hxx
@@ -19,16 +19,15 @@
 #define itkFrequencyShrinkImageFilter_hxx
 
 #include <itkFrequencyShrinkImageFilter.h>
-#include <itkImageScanlineIterator.h>
 #include <itkProgressReporter.h>
 #include <numeric>
 #include <functional>
 #include "itkInd2Sub.h"
 #include <itkPasteImageFilter.h>
-#include <itkGaussianSpatialFunction.h>
-#include <itkFrequencyImageRegionIteratorWithIndex.h>
 #include <itkAddImageFilter.h>
 #include <itkMultiplyImageFilter.h>
+// #include <itkGaussianSpatialFunction.h>
+// #include <itkFrequencyImageRegionIteratorWithIndex.h>
 
 namespace itk
 {

--- a/include/itkMonogenicSignalFrequencyImageFilter.h
+++ b/include/itkMonogenicSignalFrequencyImageFilter.h
@@ -20,7 +20,7 @@
 
 #include <itkImageToImageFilter.h>
 #include <itkVectorImage.h>
-#include <itkFrequencyImageRegionConstIteratorWithIndex.h>
+#include <itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.h>
 #include "itkRieszFrequencyFunction.h"
 namespace itk
 {
@@ -40,7 +40,7 @@ namespace itk
  */
 template< typename TInputImage,
   typename TFrequencyImageRegionConstIterator =
-    FrequencyImageRegionConstIteratorWithIndex< TInputImage> >
+    FrequencyFFTLayoutImageRegionConstIteratorWithIndex< TInputImage> >
 class MonogenicSignalFrequencyImageFilter:
   public ImageToImageFilter<
     TInputImage,

--- a/include/itkRieszFrequencyFilterBankGenerator.h
+++ b/include/itkRieszFrequencyFilterBankGenerator.h
@@ -22,7 +22,7 @@
 #include <itkGenerateImageSource.h>
 #include <complex>
 #include "itkRieszFrequencyFunction.h"
-#include <itkFrequencyImageRegionIteratorWithIndex.h>
+#include <itkFrequencyFFTLayoutImageRegionIteratorWithIndex.h>
 
 namespace itk
 {
@@ -48,7 +48,7 @@ namespace itk
  */
 template<typename TOutputImage,
   typename TRieszFunction = itk::RieszFrequencyFunction<std::complex<double>, TOutputImage::ImageDimension>,
-  typename TFrequencyRegionIterator = FrequencyImageRegionIteratorWithIndex< TOutputImage> >
+  typename TFrequencyRegionIterator = FrequencyFFTLayoutImageRegionIteratorWithIndex< TOutputImage> >
 class RieszFrequencyFilterBankGenerator:
   public itk::GenerateImageSource< TOutputImage >
 {

--- a/include/itkWaveletFrequencyFilterBankGenerator.h
+++ b/include/itkWaveletFrequencyFilterBankGenerator.h
@@ -21,7 +21,7 @@
 #include <itkImageRegionIterator.h>
 #include <complex>
 #include <itkGenerateImageSource.h>
-#include <itkFrequencyImageRegionIteratorWithIndex.h>
+#include <itkFrequencyFFTLayoutImageRegionIteratorWithIndex.h>
 
 namespace itk
 {
@@ -45,7 +45,7 @@ namespace itk
  */
 template<typename TOutputImage,
   typename TWaveletFunction,
-  typename TFrequencyRegionIterator = FrequencyImageRegionIteratorWithIndex< TOutputImage> >
+  typename TFrequencyRegionIterator = FrequencyFFTLayoutImageRegionIteratorWithIndex< TOutputImage> >
 class WaveletFrequencyFilterBankGenerator:
   public itk::GenerateImageSource< TOutputImage >
 {
@@ -66,12 +66,11 @@ public:
   typedef typename Superclass::OutputImageType    OutputImageType;
   typedef typename Superclass::OutputImagePointer OutputImagePointer;
   /** Basic typedefs */
-  // typedef typename itk::ImageRegionIterator<OutputImageType> OutputRegionIterator;
   typedef TFrequencyRegionIterator             OutputRegionIterator;
   typedef typename OutputImageType::RegionType OutputImageRegionType;
   /** WaveletFunction types */
   typedef TWaveletFunction                                WaveletFunctionType;
-  typedef typename WaveletFunctionType::Pointer WaveletFunctionPointer;
+  typedef typename WaveletFunctionType::Pointer           WaveletFunctionPointer;
   typedef typename WaveletFunctionType::FunctionValueType FunctionValueType;
 
   itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -249,8 +249,10 @@ itk_add_test(NAME itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest
 itk_add_test(NAME itkInd2SubTest
   COMMAND IsotropicWaveletsTestDriver itkInd2SubTest)
 ## BandPass
-itk_add_test(NAME itkFrequencyBandImageFilterTest
-  COMMAND IsotropicWaveletsTestDriver itkFrequencyBandImageFilterTest)
+itk_add_test(NAME itkFrequencyBandImageFilterEvenTest
+  COMMAND IsotropicWaveletsTestDriver itkFrequencyBandImageFilterTest "Even")
+itk_add_test(NAME itkFrequencyBandImageFilterOddTest
+  COMMAND IsotropicWaveletsTestDriver itkFrequencyBandImageFilterTest "Odd")
 ## ExpandWithZeros (in spatial domain)
 itk_add_test(NAME itkExpandWithZerosImageFilterTest2D
   COMMAND IsotropicWaveletsTestDriver itkExpandWithZerosImageFilterTest 2)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ set(Libraries
 set(IsotropicWaveletsTests
     #### Frequency Manipulation ###
     # Iterator with Index.
-    itkFrequencyImageRegionIteratorWithIndexTest.cxx
+    itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
     # BandPass Filter
     itkFrequencyBandImageFilterTest.cxx
     # Resize
@@ -243,8 +243,8 @@ itk_add_test(NAME itkIsotropicWaveletFrequencyFunctionTest
   2
   )
 # FrequencyIterator
-itk_add_test(NAME itkFrequencyImageRegionIteratorWithIndexTest
-  COMMAND IsotropicWaveletsTestDriver itkFrequencyImageRegionIteratorWithIndexTest)
+itk_add_test(NAME itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest
+  COMMAND IsotropicWaveletsTestDriver itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest)
 ##Ind2Sub
 itk_add_test(NAME itkInd2SubTest
   COMMAND IsotropicWaveletsTestDriver itkInd2SubTest)

--- a/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
+++ b/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
@@ -150,9 +150,9 @@ public:
     IndexType halfIndexPlusOne;
     for (unsigned int dim = 0; dim < ImageType::ImageDimension; dim++)
       {
-      halfIndexPlusOne[dim] = it.GetHalfIndex()[dim] + 1;
+      halfIndexPlusOne[dim] = it.GetLargestPositiveFrequencyIndex()[dim] + 1;
       }
-    IndexType firstNegativeIndex = m_ImageIsOdd ? halfIndexPlusOne : it.GetHalfIndex();
+    IndexType firstNegativeIndex = m_ImageIsOdd ? halfIndexPlusOne : it.GetLargestPositiveFrequencyIndex();
     IndexType smallestNegativeFreqIndex;
     for (unsigned int dim = 0; dim < ImageType::ImageDimension; dim++)
       {
@@ -195,12 +195,12 @@ public:
       truthHalfIndex[dim] =
         m_Image->GetLargestPossibleRegion().GetIndex()[dim]
         + m_Image->GetLargestPossibleRegion().GetSize()[dim] / 2;
-      if( it.GetHalfIndex()[dim] != truthHalfIndex[dim] )
+      if( it.GetLargestPositiveFrequencyIndex()[dim] != truthHalfIndex[dim] )
         {
         std::cerr << "Test failed! " << std::endl;
-        std::cerr << "Error in GetHalfIndex()" << std::endl;
+        std::cerr << "Error in GetLargestPositiveFrequencyIndex()" << std::endl;
         std::cerr << "Expected: " << truthHalfIndex << ", but got "
-          << it.GetHalfIndex() << std::endl;
+          << it.GetLargestPositiveFrequencyIndex() << std::endl;
         return false;
         }
       }
@@ -236,9 +236,9 @@ public:
         return false;
         }
 
-      if( index == it.GetHalfIndex() &&
+      if( index == it.GetLargestPositiveFrequencyIndex() &&
           it.GetFrequency() != m_LargestFrequency &&
-          it.GetFrequencyBin() != it.GetHalfIndex() )
+          it.GetFrequencyBin() != it.GetLargestPositiveFrequencyIndex() )
         {
         std::cerr << "Test failed! " << std::endl;
         std::cerr << "Error in largest frequency bin" << std::endl;

--- a/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
+++ b/test/itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest.cxx
@@ -16,7 +16,7 @@
  *
  *=========================================================================*/
 
-#include "itkFrequencyImageRegionIteratorWithIndex.h"
+#include "itkFrequencyFFTLayoutImageRegionIteratorWithIndex.h"
 #include "itkTestingMacros.h"
 
 #include <iostream>
@@ -25,16 +25,16 @@
 
 
 template< typename TImage >
-class itkFrequencyImageRegionIteratorWithIndexTester
+class itkFrequencyFFTLayoutImageRegionIteratorWithIndexTester
 {
 public:
   typedef TImage                          ImageType;
   typedef typename ImageType::IndexType   IndexType;
   typedef typename ImageType::SpacingType FrequencyType;
 
-  typedef itk::FrequencyImageRegionIteratorWithIndex<ImageType > IteratorType;
+  typedef itk::FrequencyFFTLayoutImageRegionIteratorWithIndex<ImageType > IteratorType;
 
-  explicit itkFrequencyImageRegionIteratorWithIndexTester( size_t inputImageSize )
+  explicit itkFrequencyFFTLayoutImageRegionIteratorWithIndexTester( size_t inputImageSize )
   {
     m_Image = ImageType::New();
 
@@ -260,7 +260,7 @@ private:
   bool                           m_ImageIsOdd;
 };
 
-int itkFrequencyImageRegionIteratorWithIndexTest( int, char* [] )
+int itkFrequencyFFTLayoutImageRegionIteratorWithIndexTest( int, char* [] )
 {
   bool testPassed = true; // let's be optimistic
 
@@ -273,7 +273,7 @@ int itkFrequencyImageRegionIteratorWithIndexTest( int, char* [] )
     size_t inputImageSize( 8 );
     std::cout << "Testing with EVEN Image< std::complex<float>, 3 > with size: "
       << inputImageSize << std::endl;
-    itkFrequencyImageRegionIteratorWithIndexTester<
+    itkFrequencyFFTLayoutImageRegionIteratorWithIndexTester<
       itk::Image< std::complex< FloatPixelType >, Dimension > > Tester( inputImageSize );
     if( Tester.TestIterator() == false )
       {
@@ -286,7 +286,7 @@ int itkFrequencyImageRegionIteratorWithIndexTest( int, char* [] )
     size_t inputImageSize( 10 );
     std::cout << "Testing with EVEN Image< char, 3 > with size: " <<
       inputImageSize << std::endl;
-    itkFrequencyImageRegionIteratorWithIndexTester<
+    itkFrequencyFFTLayoutImageRegionIteratorWithIndexTester<
       itk::Image< CharPixelType, Dimension > > Tester( inputImageSize );
     if( Tester.TestIterator() == false )
       {
@@ -299,7 +299,7 @@ int itkFrequencyImageRegionIteratorWithIndexTest( int, char* [] )
     size_t inputImageSize(9);
     std::cout << "Testing with ODD Image< char, 3 > with size: "
       << inputImageSize << std::endl;
-    itkFrequencyImageRegionIteratorWithIndexTester<
+    itkFrequencyFFTLayoutImageRegionIteratorWithIndexTester<
       itk::Image< CharPixelType, Dimension > > Tester( inputImageSize );
     if( Tester.TestIterator() == false )
       {


### PR DESCRIPTION
- Rename existing FrequencyImageRegionIterator to FrequencyFFTLayoutImageRegionIterator.
- Add ShiftedFFTLayout Iterator
- Add a frequency iterator that is just a wrap around a regular one with GetFrequency, GetFrequencyBin, in case input images are gathered experimentally in the frequency domain.
