### PR TITLE
Steerability: Add RieszRotationMatrix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 project(IsotropicWavelets)
 
-# set(IsotropicWavelets_LIBRARIES IsotropicWavelets)
+set(IsotropicWavelets_LIBRARIES IsotropicWavelets)
 
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK REQUIRED)

--- a/include/itkRieszFrequencyFunction.h
+++ b/include/itkRieszFrequencyFunction.h
@@ -23,6 +23,7 @@
 #include <complex>
 #include <numeric>
 #include <functional>
+#include "itkRieszUtilities.h"
 
 namespace itk
 {
@@ -74,7 +75,10 @@ public:
    *
    * @return NumberOfComponents given the order.
    */
-  static unsigned int ComputeNumberOfComponents(unsigned int order);
+  static unsigned int ComputeNumberOfComponents(const unsigned int &order)
+    {
+    return itk::utils::ComputeNumberOfComponents(order, VImageDimension);
+    }
   /**
    * Compute all possible unique indices given the subIndice: (X, 0, ..., 0).
    * Where X can be any number greater than 0, but probably want to use this->m_Order.
@@ -83,12 +87,18 @@ public:
    * @param uniqueIndices Reference to set that store results.
    * @param init position to evaluate  subIndice. Needed for recursion purposes.
    */
-  static void ComputeUniqueIndices(IndicesArrayType subIndice, SetType &uniqueIndices, unsigned int init = 0 );
+  static void ComputeUniqueIndices(IndicesArrayType subIndice, SetType &uniqueIndices, unsigned int init = 0 )
+    {
+    itk::utils::ComputeUniqueIndices<IndicesArrayType, VImageDimension>(subIndice, uniqueIndices, init );
+    }
 
   /**
    * Compute all the permutations from a set of uniqueIndices.
    */
-  static SetType ComputeAllPermutations(const SetType & uniqueIndices);
+  static SetType ComputeAllPermutations(const SetType & uniqueIndices)
+    {
+    return itk::utils::ComputeAllPermutations<IndicesArrayType>(uniqueIndices);
+    }
 
   /** Evaluate the function at a given frequency point. */
   virtual FunctionValueType Evaluate(const TInput &) const ITK_OVERRIDE
@@ -140,14 +150,7 @@ public:
   /// Factorial
   static long Factorial(long n)
     {
-    if (n <= 1)
-      {
-      return 1;
-      }
-    else
-      {
-      return n * Self::Factorial(n-1);
-      }
+    return itk::utils::Factorial(n);
     }
 
   /** Order of the generalized riesz transform. */

--- a/include/itkRieszFrequencyFunction.h
+++ b/include/itkRieszFrequencyFunction.h
@@ -79,6 +79,7 @@ public:
     {
     return itk::utils::ComputeNumberOfComponents(order, VImageDimension);
     }
+
   /**
    * Compute all possible unique indices given the subIndice: (X, 0, ..., 0).
    * Where X can be any number greater than 0, but probably want to use this->m_Order.
@@ -98,6 +99,14 @@ public:
   static SetType ComputeAllPermutations(const SetType & uniqueIndices)
     {
     return itk::utils::ComputeAllPermutations<IndicesArrayType>(uniqueIndices);
+    }
+
+  /**
+   * Compute all the possible indices for a given order.
+   */
+  static SetType ComputeAllPossibleIndices(const unsigned int&order)
+    {
+    return itk::utils::ComputeAllPossibleIndices<IndicesArrayType, VImageDimension>(order);
     }
 
   /** Evaluate the function at a given frequency point. */
@@ -166,12 +175,7 @@ public:
       {
       this->m_Order = inputOrder;
       // Calculate all the possible indices.
-      IndicesArrayType initIndice;
-      initIndice.resize(VImageDimension);
-      initIndice[0] = this->m_Order;
-      SetType uniqueIndices;
-      Self::ComputeUniqueIndices(initIndice, uniqueIndices);
-      this->m_Indices = Self::ComputeAllPermutations(uniqueIndices);
+      this->m_Indices = Self::ComputeAllPossibleIndices(this->m_Order);
       this->Modified();
       }
     }

--- a/include/itkRieszFrequencyFunction.hxx
+++ b/include/itkRieszFrequencyFunction.hxx
@@ -21,10 +21,12 @@
 #include <cmath>
 #include <itkMath.h>
 #include "itkRieszFrequencyFunction.h"
+#include "itkRieszFrequencyFunction.h"
 #include <algorithm>
 
 namespace itk
 {
+
 template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
 RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
 ::RieszFrequencyFunction()
@@ -65,7 +67,6 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
       freqProduct *= frequency_point[dim];
       }
     }
-  
 
   // rieszComponent = (-j)^{m_Order} * sqrt(m_Order!/(n1!n2!...nd!)) * w1^n1...wd^nd / ||w||^m_Order
   return this->ComputeNormalizingFactor(indices)
@@ -73,71 +74,6 @@ RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
     / std::pow(magn, static_cast<double>(this->m_Order)) );
 }
 
-template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
-unsigned int
-RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
-::ComputeNumberOfComponents(unsigned int order)
-{
-  return Self::Factorial(order + VImageDimension - 1 )
-    /( Self::Factorial(VImageDimension - 1)*Self::Factorial(order));
-}
-
-template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
-void
-RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
-::ComputeUniqueIndices(IndicesArrayType subIndice,
-  SetType &uniqueIndices, unsigned int init)
-{
-  unsigned int subIndiceSize = subIndice.size();
-  if (init == subIndiceSize - 1)
-    {
-    return;
-    }
-
-  // If OK, store it.
-  if(std::distance(subIndice.begin(), std::max_element(subIndice.begin(), subIndice.end(), std::greater<unsigned int>())) <= VImageDimension - 1)
-    {
-    IndicesArrayType subIndiceCopy = subIndice;
-    std::sort(subIndiceCopy.rbegin(), subIndiceCopy.rend());
-    uniqueIndices.insert(subIndiceCopy);
-    }
-  else
-    {
-    // Process remaining index positions in this branch.
-    Self::ComputeUniqueIndices(subIndice, uniqueIndices, init + 1);
-    return;
-    }
-
-  unsigned int first  = --subIndice[init];
-  ++subIndice[init + 1];
-  //Stop
-  if(first == 0)
-    {
-    return;
-    }
-  // Process modified subIndice.
-  Self::ComputeUniqueIndices(subIndice, uniqueIndices, init);
-  // Process modified init.
-  Self::ComputeUniqueIndices(subIndice, uniqueIndices, init + 1);
-}
-
-template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
-typename RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput>::SetType
-RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >
-::ComputeAllPermutations(const SetType &uniqueIndices)
-{
-  SetType out;
-  for(typename SetType::const_iterator it = uniqueIndices.begin(); it != uniqueIndices.end(); ++it)
-    {
-    out.insert(*it);
-    IndicesArrayType permutation = *it;
-    while(std::prev_permutation(permutation.begin(), permutation.end()) )
-      {
-      out.insert(permutation);
-      }
-    }
-  return out;
-}
 template< typename TFunctionValue, unsigned int VImageDimension, typename TInput >
 typename RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput>::OutputComplexType
 RieszFrequencyFunction< TFunctionValue, VImageDimension, TInput >

--- a/include/itkRieszRotationMatrix.h
+++ b/include/itkRieszRotationMatrix.h
@@ -94,9 +94,16 @@ public:
   RieszRotationMatrix(const SpatialRotationMatrixType & spatialRotationMatrix,
     const unsigned int & order);
 
+  /**
+   * Get/Set the order of the Riesz transform.
+   * The order modifies the number of components and the size of the steerable matrix.
+   *
+   * \sa GetComponents
+   * \sa RieszFrequencyFunction
+   */
   inline const unsigned int & GetOrder() const
     {
-    return m_Order;
+    return this->m_Order;
     }
   inline void SetOrder(const unsigned int & order)
     {
@@ -105,14 +112,23 @@ public:
     this->SetSize(this->m_Components, this->m_Components);
     }
 
+  /**
+   * Get the number of componets M of the steerable matrix.
+   * The size of the steerable matrix is MxM.
+   * The number of components is based on the m_Order of the Riesz
+   * transform and the dimension.
+   *
+   * \sa RieszFrequencyFunction
+   */
   inline const unsigned int & GetComponents() const
     {
-    return m_Components;
+    return this->m_Components;
     }
 
+  /// Get/Set the spatial rotation matrix from which the steerable matrix is composed.
   inline const SpatialRotationMatrixType & GetSpatialRotationMatrix() const
     {
-    return m_SpatialRotationMatrix;
+    return this->m_SpatialRotationMatrix;
     }
 
   inline void SetSpatialRotationMatrix(const SpatialRotationMatrixType & spatialRotationMatrix)
@@ -120,10 +136,58 @@ public:
     this->m_SpatialRotationMatrix = spatialRotationMatrix;
     }
 
+  /**
+   * Round the computed result S[i][j] to zero if it is close enough to zero. How close is controlled by this value.
+   *
+   * Computation requires a quite a few trivial multiplications, generating float errors.
+   * It is specially noticiable because the domain of rotations is in a small interval around zero.
+   * This tries to fix them, but there is no fit for all solution.
+   *
+   * The default in this class: itk::NumericTraits<ValueType>::epsilon()
+   * The default in the function FloatAlmostEqual is : 0.1 * itk::NumericTraits<ValueType>::epsilon()
+   *
+   * \sa itk::Math::FloatAlmostEqual
+   */
+  inline const ValueType & GetMaxAbsoluteDifferenceCloseToZero() const
+    {
+    return this->m_MaxAbsoluteDifferenceCloseToZero;
+    }
+  inline void SetMaxAbsoluteDifferenceCloseToZero(const ValueType & maxAbsoluteDifference)
+    {
+    this->m_MaxAbsoluteDifferenceCloseToZero = maxAbsoluteDifference;
+    }
+  // ------- Debug Macro ------
+  /// Get/Set Debug flag to print extra information.
+  inline const bool & GetDebug() const
+    {
+    return this->m_Debug;
+    }
+  inline void SetDebug(const bool & boolean)
+    {
+    this->m_Debug = boolean;
+    }
+  inline void SetDebugOn()
+    {
+    this->m_Debug = true;
+    }
+  inline void SetDebugOff()
+    {
+    this->m_Debug = false;
+    }
+
+#ifdef ITK_USE_STRICT_CONCEPT_CHECKING
+  // Begin concept checking
+  itkConceptMacro( ValueTypeIsFloatCheck,
+                   ( Concept::IsFloatingPoint< ValueType > ) );
+  // End concept checking
+#endif
+
 private:
   SpatialRotationMatrixType m_SpatialRotationMatrix;
   unsigned int              m_Order;
   unsigned int              m_Components;
+  ValueType                 m_MaxAbsoluteDifferenceCloseToZero;
+  bool                      m_Debug;
 
 }; // end of class
 } // end namespace itk

--- a/include/itkRieszRotationMatrix.h
+++ b/include/itkRieszRotationMatrix.h
@@ -63,17 +63,6 @@ public:
    * Multi-index notation
    * S[n = (n1,...,nd)][m = (m1,...,md)]
    *
-   * 2D: order:1, components:2
-   * S_{|n| = 1,|m| = 1} = S_{2x2} =:
-         (1,0),(1,0)  (1,0),(0,1)
-         (0,1),(1,0)  (0,1),(0,1)
-
-   * 3D: order:1, components:3
-   * S_{|n| = 1,|m| = 1} = S_{3x3} =:
-         (1,0,0),(1,0,0)  (1,0,0),(0,1,0)  (1,0,0),(0,0,1)
-         (0,1,0),(1,0,0)  (0,1,0),(0,1,0)  (0,1,0),(0,0,1)
-         (0,0,1),(1,0,0)  (0,0,1),(0,1,0)  (0,0,1),(0,0,1)
-
    * S[n = (n1,...,nd)][m = (m1,...,md)] =
    *  sqrt(\frac{m!}{n!}) \sum_{|k1| = n1} \cdots \sum_{|kd| = nd}
    *  \delta_{k1 + k2 + k3, m} x
@@ -85,6 +74,38 @@ public:
 
    */
   const InternalMatrixType & ComputeSteerableMatrix();
+
+  /// Typedefs for IndicesMatrix
+  typedef std::vector<unsigned int>     IndicesArrayType;
+  typedef std::vector<IndicesArrayType> IndicesVector;
+  typedef std::vector<IndicesVector>    IndicesMatrixRow;
+  typedef std::vector<IndicesMatrixRow> IndicesMatrix;
+
+  /**
+   * Generate a matrix-like structure of the same size than the
+   * steering matrix containing a pair of indices n,m.
+   *
+   * Examples:
+   * 2D: order:1, components:2
+   * S_{|n| = 1,|m| = 1} = S_{2x2} =:
+   *     (1,0),(1,0)  (1,0),(0,1)
+   *     (0,1),(1,0)  (0,1),(0,1)
+   *
+   * 3D: order:1, components:3
+   * S_{|n| = 1,|m| = 1} = S_{3x3} =:
+   *      (1,0,0),(1,0,0)  (1,0,0),(0,1,0)  (1,0,0),(0,0,1)
+   *      (0,1,0),(1,0,0)  (0,1,0),(0,1,0)  (0,1,0),(0,0,1)
+   *      (0,0,1),(1,0,0)  (0,0,1),(0,1,0)  (0,0,1),(0,0,1)
+   *
+   * 2D: order:2, components:3
+   * S_{|n| = 2,|m| = 2} = S_{3x3} =:
+   *      (2, 0),(2, 0)   (2, 0),(1, 1)   (2, 0),(0, 2)
+   *      (1, 1),(2, 0)   (1, 1),(1, 1)   (1, 1),(0, 2)
+   *      (0, 2),(2, 0)   (0, 2),(1, 1)   (0, 2),(0, 2)
+   *
+   * @return the matrix with the n,m multiindex
+   */
+  IndicesMatrix GenerateIndicesMatrix();
 
   /** Default constructor. */
   RieszRotationMatrix();

--- a/include/itkRieszRotationMatrix.h
+++ b/include/itkRieszRotationMatrix.h
@@ -1,0 +1,110 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkRieszRotationMatrix_h
+#define itkRieszRotationMatrix_h
+#include "itkVariableSizeMatrix.h"
+#include <vector>
+
+namespace itk
+{
+/** \class RieszRotationMatrix
+ * Get a steerable matrix for the Riesz transform: S_r
+ * from a rotation matrix R in the spatial domain,
+ * and the order of the Riesz transform (T)
+ * T f( R*x ) = T_{S_r} f(x)
+ *
+ * S_r is a MxM matrix, where M = p(N,d) is the number of
+ * components of a riesz transform of order N and dimension d.
+ * M := p(N,d) = \frac{(N+d-1)!}{(d-1)! N!}
+ *
+ * The rotation matrix is a dxd matrix.
+ *
+ * \sa RieszFrequencyFunction
+ * \sa RieszFrequencyFilterBankGenerator
+ *
+ * \ingroup IsotropicWavelets
+ */
+
+template<typename T, unsigned int VImageDimension = 3>
+class RieszRotationMatrix:
+  public itk::VariableSizeMatrix< T >
+{
+public:
+  /** Standard typedefs */
+  typedef RieszRotationMatrix          Self;
+  typedef itk::VariableSizeMatrix< T > Superclass;
+
+  /** Component value type */
+  typedef typename Superclass::ValueType          ValueType;
+  typedef typename Superclass::InternalMatrixType InternalMatrixType;
+  typedef itk::Matrix< T, VImageDimension >       SpatialRotationMatrixType;
+
+  /** Matrix by std::vector multiplication.  */
+  std::vector< T > operator *(const std::vector< T > & vector) const;
+
+  void ComputeSteerableMatrix();
+
+  /** Default constructor. */
+  RieszRotationMatrix();
+  /** Copy constructor. */
+  RieszRotationMatrix(const Self & matrix);
+  /** Compute constructor. */
+  RieszRotationMatrix(const SpatialRotationMatrixType & spatialRotationMatrix,
+    const unsigned int & order);
+
+  inline const unsigned int & GetOrder() const
+    {
+    return m_Order;
+    }
+  inline void SetOrder(const unsigned int & order)
+    {
+    this->m_Order = order;
+    }
+
+  inline const unsigned int & GetComponents() const
+    {
+    return m_Components;
+    }
+  inline void SetComponents(const unsigned int & components)
+    {
+    this->m_Components = components;
+    }
+
+  inline const SpatialRotationMatrixType & GetSpatialRotationMatrix() const
+    {
+    return m_SpatialRotationMatrix;
+    }
+
+  inline void SetSpatialRotationMatrix(const SpatialRotationMatrixType & spatialRotationMatrix)
+    {
+    this->m_SpatialRotationMatrix = spatialRotationMatrix;
+    }
+
+
+private:
+  InternalMatrixType m_SpatialRotationMatrix;
+  unsigned int m_Order;
+  unsigned int m_Components;
+
+}; // end of class
+} // end namespace itk
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkRieszRotationMatrix.hxx"
+#endif
+
+#endif

--- a/include/itkRieszRotationMatrix.h
+++ b/include/itkRieszRotationMatrix.h
@@ -19,6 +19,8 @@
 #define itkRieszRotationMatrix_h
 #include "itkVariableSizeMatrix.h"
 #include <vector>
+#include "itkMatrix.h"
+#include "itkRieszUtilities.h"
 
 namespace itk
 {
@@ -40,7 +42,7 @@ namespace itk
  * \ingroup IsotropicWavelets
  */
 
-template<typename T, unsigned int VImageDimension = 3>
+template<typename T = double, unsigned int VImageDimension = 3>
 class RieszRotationMatrix:
   public itk::VariableSizeMatrix< T >
 {
@@ -50,14 +52,39 @@ public:
   typedef itk::VariableSizeMatrix< T > Superclass;
 
   /** Component value type */
-  typedef typename Superclass::ValueType          ValueType;
-  typedef typename Superclass::InternalMatrixType InternalMatrixType;
-  typedef itk::Matrix< T, VImageDimension >       SpatialRotationMatrixType;
+  typedef typename Superclass::ValueType                     ValueType;
+  typedef typename Superclass::InternalMatrixType            InternalMatrixType;
+  typedef itk::Matrix< T, VImageDimension, VImageDimension > SpatialRotationMatrixType;
 
   /** Matrix by std::vector multiplication.  */
   std::vector< T > operator *(const std::vector< T > & vector) const;
 
-  void ComputeSteerableMatrix();
+  /**
+   * Multi-index notation
+   * S[n = (n1,...,nd)][m = (m1,...,md)]
+   *
+   * 2D: order:1, components:2
+   * S_{|n| = 1,|m| = 1} = S_{2x2} =:
+         (1,0),(1,0)  (1,0),(0,1)
+         (0,1),(1,0)  (0,1),(0,1)
+
+   * 3D: order:1, components:3
+   * S_{|n| = 1,|m| = 1} = S_{3x3} =:
+         (1,0,0),(1,0,0)  (1,0,0),(0,1,0)  (1,0,0),(0,0,1)
+         (0,1,0),(1,0,0)  (0,1,0),(0,1,0)  (0,1,0),(0,0,1)
+         (0,0,1),(1,0,0)  (0,0,1),(0,1,0)  (0,0,1),(0,0,1)
+
+   * S[n = (n1,...,nd)][m = (m1,...,md)] =
+   *  sqrt(\frac{m!}{n!}) \sum_{|k1| = n1} \cdots \sum_{|kd| = nd}
+   *  \delta_{k1 + k2 + k3, m} x
+   *  \\frac{n!}{k1! \cdots kd!} r_1^{k_1} \cdots r_d^{k_d}
+   * 
+   * The indices are ordered in descending order:
+   * For example, for order = 2:
+   * ( 2, 0, 0, )( 1, 1, 0, )( 1, 0, 1, )( 0, 2, 0, )( 0, 1, 1, )( 0, 0, 2, )
+
+   */
+  const InternalMatrixType & ComputeSteerableMatrix();
 
   /** Default constructor. */
   RieszRotationMatrix();
@@ -74,15 +101,13 @@ public:
   inline void SetOrder(const unsigned int & order)
     {
     this->m_Order = order;
+    this->m_Components = itk::utils::ComputeNumberOfComponents(this->m_Order, VImageDimension);
+    this->SetSize(this->m_Components, this->m_Components);
     }
 
   inline const unsigned int & GetComponents() const
     {
     return m_Components;
-    }
-  inline void SetComponents(const unsigned int & components)
-    {
-    this->m_Components = components;
     }
 
   inline const SpatialRotationMatrixType & GetSpatialRotationMatrix() const
@@ -95,11 +120,10 @@ public:
     this->m_SpatialRotationMatrix = spatialRotationMatrix;
     }
 
-
 private:
-  InternalMatrixType m_SpatialRotationMatrix;
-  unsigned int m_Order;
-  unsigned int m_Components;
+  SpatialRotationMatrixType m_SpatialRotationMatrix;
+  unsigned int              m_Order;
+  unsigned int              m_Components;
 
 }; // end of class
 } // end namespace itk

--- a/include/itkRieszRotationMatrix.hxx
+++ b/include/itkRieszRotationMatrix.hxx
@@ -1,0 +1,102 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkRieszRotationMatrix_hxx
+#define itkRieszRotationMatrix_hxx
+
+#include "itkRieszRotationMatrix.h"
+#include "itkNumericTraits.h"
+#include "itkRieszUtilities.h"
+
+namespace itk
+{
+template<typename T, unsigned int VImageDimension>
+RieszRotationMatrix< T, VImageDimension >
+::RieszRotationMatrix()
+: Superclass(),
+  m_SpatialRotationMatrix(),
+  m_Order(0),
+  m_Components(0)
+{
+}
+
+template<typename T, unsigned int VImageDimension>
+RieszRotationMatrix< T, VImageDimension >
+::RieszRotationMatrix( const Self & rieszMatrix )
+: Superclass(rieszMatrix)
+{
+  this->m_SpatialRotationMatrix =
+    rieszMatrix.GetRotationMatrix;
+  this->m_Order = rieszMatrix.GetOrder();
+  this->m_Components = rieszMatrix.GetComponents();
+}
+
+template<typename T, unsigned int VImageDimension>
+RieszRotationMatrix< T, VImageDimension >
+::RieszRotationMatrix(
+  const SpatialRotationMatrixType & spatialRotationMatrix,
+  const unsigned int &order )
+:
+  Superclass(),
+  m_SpatialRotationMatrix(spatialRotationMatrix),
+  m_Order(order)
+{
+  this->m_Components = itk::utils::ComputeNumberOfComponents(this->m_Order, VImageDimension);
+  this->SetSize(m_Components, m_Components);
+  this->ComputeSteerableMatrix();
+}
+
+/**
+ *  Product by a std::vector
+ */
+template<typename T, unsigned int VImageDimension>
+std::vector< T >
+RieszRotationMatrix< T, VImageDimension >
+::operator*(const std::vector< T > & vect) const
+{
+  unsigned int rows = this->Rows();
+  unsigned int cols = this->Cols();
+
+  if ( vect.size() != cols )
+    {
+    itkGenericExceptionMacro( << "Matrix with " << this->Cols() << " columns cannot be "
+                              << "multiplied with vector of length: " << vect.size() );
+    }
+
+  std::vector< T > result(rows);
+  for ( unsigned int r = 0; r < rows; r++ )
+    {
+    T sum = NumericTraits< T >::ZeroValue();
+    for ( unsigned int c = 0; c < cols; c++ )
+      {
+      sum += this->m_Matrix(r, c) * vect[c];
+      }
+    result[r] = sum;
+    }
+  return result;
+}
+
+template<typename T, unsigned int VImageDimension>
+void
+RieszRotationMatrix< T, VImageDimension >
+::ComputeSteerableMatrix()
+{
+}
+
+} // end namespace itk
+
+#endif

--- a/include/itkRieszUtilities.h
+++ b/include/itkRieszUtilities.h
@@ -1,0 +1,117 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkRieszUtilities_h
+#define itkRieszUtilities_h
+
+#include <set>
+#include <vector>
+#include <functional>
+#include <algorithm>
+
+namespace itk
+{
+namespace utils
+{
+  /// Factorial
+  long Factorial(long n);
+
+  /**
+   * Compute number of components p(N, d), where N = Order, d = Dimension.
+   * p(N,d) = (N + d - 1)!/( (d-1)! N! )
+   *
+   * @param order N of the Riesz transform
+   * @param dimension d of the image
+   *
+   * @return NumberOfComponents given the order for the ImageDimension.
+   */
+  unsigned int ComputeNumberOfComponents( const unsigned int &order, const unsigned int &dimension );
+
+  /**
+   * Compute all possible unique indices given the subIndice: (X, 0, ..., 0).
+   * Where X can be any number greater than 0, but probably want to use this->m_Order.
+   *
+   * TIndicesArrayType = std::vector<unsigned int>
+   * or any std array type with begin(), end() methods.
+   *
+   * @param subIndice Indice (X,0,...,0) where X > 0.
+   * @param uniqueIndices Reference to set that store results.
+   * @param init position to evaluate  subIndice. Needed for recursion purposes.
+   */
+  template< typename TIndicesArrayType, unsigned int VImageDimension >
+  void ComputeUniqueIndices( TIndicesArrayType subIndice,
+    std::set< TIndicesArrayType, std::greater<TIndicesArrayType> > &uniqueIndices,
+    unsigned int init = 0 )
+  {
+  unsigned int subIndiceSize = subIndice.size();
+  if (init == subIndiceSize - 1)
+    {
+    return;
+    }
+
+  // If OK, store it.
+  if(std::distance(subIndice.begin(), std::max_element(subIndice.begin(), subIndice.end(), std::greater<unsigned int>())) <= VImageDimension - 1)
+    {
+    TIndicesArrayType subIndiceCopy = subIndice;
+    std::sort(subIndiceCopy.rbegin(), subIndiceCopy.rend());
+    uniqueIndices.insert(subIndiceCopy);
+    }
+  else
+    {
+    // Process remaining index positions in this branch.
+    itk::utils::ComputeUniqueIndices<TIndicesArrayType, VImageDimension>(subIndice, uniqueIndices, init + 1);
+    return;
+    }
+
+  unsigned int first  = --subIndice[init];
+  ++subIndice[init + 1];
+  //Stop
+  if(first == 0)
+    {
+    return;
+    }
+  // Process modified subIndice.
+  itk::utils::ComputeUniqueIndices<TIndicesArrayType, VImageDimension>(subIndice, uniqueIndices, init);
+  // Process modified init.
+  itk::utils::ComputeUniqueIndices<TIndicesArrayType, VImageDimension>(subIndice, uniqueIndices, init + 1);
+  }
+
+  /**
+   * Compute all the permutations from a set of uniqueIndices.
+   */
+  template< typename TIndicesArrayType >
+  std::set< TIndicesArrayType, std::greater<TIndicesArrayType> > ComputeAllPermutations(
+    const std::set< TIndicesArrayType, std::greater<TIndicesArrayType> > & uniqueIndices)
+  {
+  typedef std::set< TIndicesArrayType, std::greater<TIndicesArrayType> > SetType;
+  SetType out;
+  for(typename SetType::const_iterator it = uniqueIndices.begin(); it != uniqueIndices.end(); ++it)
+    {
+    out.insert(*it);
+    TIndicesArrayType permutation = *it;
+    while(std::prev_permutation(permutation.begin(), permutation.end()) )
+      {
+      out.insert(permutation);
+      }
+    }
+  return out;
+  }
+
+} // end namespace utils
+} // end namespace itk
+
+#endif

--- a/include/itkRieszUtilities.h
+++ b/include/itkRieszUtilities.h
@@ -111,6 +111,37 @@ namespace utils
   return out;
   }
 
+  /**
+   * Compute all possible indices given an order.
+   * The order imposes the constain:
+   * \sum_{i}^{ImageDimension} indice[i] = order
+   * where indice[i]>=0
+   */
+  template< typename TIndicesArrayType, unsigned int VImageDimension >
+  std::set< TIndicesArrayType, std::greater<TIndicesArrayType> > ComputeAllPossibleIndices(const unsigned int &order) 
+  {
+  typedef std::set<TIndicesArrayType, std::greater<TIndicesArrayType> > SetType;
+  SetType uniqueIndices;
+  TIndicesArrayType indice(VImageDimension);
+  indice[0] = order;
+  itk::utils::ComputeUniqueIndices<TIndicesArrayType, VImageDimension>(
+      indice, uniqueIndices);
+  return itk::utils::ComputeAllPermutations<TIndicesArrayType>(uniqueIndices);
+  }
+
+template<typename TIndicesArrayType, unsigned int VImageDimension>
+bool
+LessOrEqualIndiceComparisson(
+  const TIndicesArrayType& rhs,
+  const TIndicesArrayType& lhs)
+{
+  for (unsigned int i = 0; i<VImageDimension; ++i)
+    {
+    if(rhs[i] > lhs[i])
+      return false;
+    }
+  return true;
+}
 } // end namespace utils
 } // end namespace itk
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(IsotropicWavelets_SRCS
+  itkRieszUtilities.cxx
+  )
+### generating libraries
+itk_module_add_library( IsotropicWavelets ${IsotropicWavelets_SRCS})

--- a/src/itkRieszUtilities.cxx
+++ b/src/itkRieszUtilities.cxx
@@ -40,5 +40,24 @@ ComputeNumberOfComponents(const unsigned int &order, const unsigned int &dimensi
     /( itk::utils::Factorial(dimension - 1)*itk::utils::Factorial(order));
 }
 
+// explicit instantiation of template functions with std::vector<unsigned int>
+template
+void
+ComputeUniqueIndices<std::vector<unsigned int>, 3>(
+  std::vector<unsigned int> subIndice,
+  std::set< std::vector<unsigned int>, std::greater<std::vector<unsigned int> > > &uniqueIndices,
+  unsigned int init = 0 );
+
+template
+void
+ComputeUniqueIndices<std::vector<unsigned int>, 2>(
+  std::vector<unsigned int> subIndice,
+  std::set< std::vector<unsigned int>, std::greater<std::vector<unsigned int> > > &uniqueIndices,
+  unsigned int init = 0 );
+
+template
+std::set< std::vector<unsigned int>, std::greater<std::vector<unsigned int> > >
+ComputeAllPermutations<std::vector<unsigned int> >( 
+    const std::set< std::vector<unsigned int>, std::greater<std::vector<unsigned int> > > & uniqueIndices);
 } // end namespace utils
 } // end namespace itk

--- a/src/itkRieszUtilities.cxx
+++ b/src/itkRieszUtilities.cxx
@@ -1,0 +1,44 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkRieszUtilities.h"
+
+namespace itk
+{
+namespace utils
+{
+
+long
+Factorial(const long n)
+{
+  if ( n < 1 )
+    {
+    return 1;
+    }
+  return n * itk::utils::Factorial(n - 1);
+}
+
+unsigned int
+ComputeNumberOfComponents(const unsigned int &order, const unsigned int &dimension )
+{
+  return itk::utils::Factorial(order + dimension - 1 )
+    /( itk::utils::Factorial(dimension - 1)*itk::utils::Factorial(order));
+}
+
+} // end namespace utils
+} // end namespace itk

--- a/src/itkRieszUtilities.cxx
+++ b/src/itkRieszUtilities.cxx
@@ -59,5 +59,23 @@ template
 std::set< std::vector<unsigned int>, std::greater<std::vector<unsigned int> > >
 ComputeAllPermutations<std::vector<unsigned int> >( 
     const std::set< std::vector<unsigned int>, std::greater<std::vector<unsigned int> > > & uniqueIndices);
+
+template
+std::set< std::vector<unsigned int>, std::greater<std::vector<unsigned int> > >
+ComputeAllPossibleIndices<std::vector<unsigned int>, 3>(
+  const unsigned int &order);
+
+template
+std::set< std::vector<unsigned int>, std::greater<std::vector<unsigned int> > >
+ComputeAllPossibleIndices<std::vector<unsigned int>, 2>(
+  const unsigned int &order);
+
+template
+bool
+LessOrEqualIndiceComparisson<std::vector<unsigned int>, 3>(const std::vector<unsigned int> & rhs, const std::vector<unsigned int> & lhs);
+
+template
+bool
+LessOrEqualIndiceComparisson<std::vector<unsigned int>, 2>(const std::vector<unsigned int> & rhs, const std::vector<unsigned int> & lhs);
 } // end namespace utils
 } // end namespace itk

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,7 @@ set(IsotropicWaveletsTests
     itkRieszWaveletPhaseAnalysisTest.cxx
     itkStructureTensorWithGeneralizedRieszTest.cxx
     # TODO add Steerable framework?
+    itkRieszRotationMatrixTest.cxx
   )
 
 if(ITKVtkGlue_ENABLED)
@@ -119,6 +120,13 @@ itk_add_test(NAME itkRieszFrequencyFilterBankGeneratorTest2
   ${ITK_TEST_OUTPUT_DIR}/itkRieszFrequencyFilterBankGeneratorTest2.tiff
   2
   )
+# Riesz Steerable framework
+itk_add_test(NAME itkRieszRotationMatrixTest2D
+  COMMAND IsotropicWaveletsTestDriver
+  itkRieszRotationMatrixTest 2)
+itk_add_test(NAME itkRieszRotationMatrixTest3D
+  COMMAND IsotropicWaveletsTestDriver
+  itkRieszRotationMatrixTest 3)
 # Monogenic Analysis
 itk_add_test(NAME itkMonogenicSignalFrequencyImageFilterTest
   COMMAND IsotropicWaveletsTestDriver

--- a/test/itkRieszRotationMatrixTest.cxx
+++ b/test/itkRieszRotationMatrixTest.cxx
@@ -25,8 +25,8 @@ int runRieszRotationMatrixTest()
 {
   bool testPassed = true;
   const unsigned int Dimension = VDimension;
-  typedef double ValueType;
-  typedef itk::RieszRotationMatrix<ValueType, Dimension> SteerableMatrix;
+  typedef double                                              ValueType;
+  typedef itk::RieszRotationMatrix<ValueType, Dimension>      SteerableMatrix;
   typedef typename SteerableMatrix::SpatialRotationMatrixType SpatialRotationMatrix;
 
   // Define a spatial rotation matrix.

--- a/test/itkRieszRotationMatrixTest.cxx
+++ b/test/itkRieszRotationMatrixTest.cxx
@@ -23,6 +23,7 @@
 template< unsigned int VDimension >
 int runRieszRotationMatrixTest()
 {
+  bool testPassed = true;
   const unsigned int Dimension = VDimension;
   typedef double ValueType;
   typedef itk::RieszRotationMatrix<ValueType, Dimension> SteerableMatrix;
@@ -30,7 +31,8 @@ int runRieszRotationMatrixTest()
 
   // Define a spatial rotation matrix.
   SpatialRotationMatrix R;
-  double angle = itk::Math::pi_over_4;
+  // double angle = itk::Math::pi_over_4;
+  double angle = itk::Math::pi_over_2;
   double cosA = cos(angle);
   double sinA = sin(angle);
   double C = 1 - cosA;
@@ -68,14 +70,93 @@ int runRieszRotationMatrixTest()
   Sdefault.SetOrder(order1);
   Sdefault.SetSpatialRotationMatrix(R);
   // compute
-  SteerableMatrix S(R, 1);
+  SteerableMatrix S(R, order1);
   // copy
   SteerableMatrix Scopy(S);
   Scopy.SetOrder(2);
+  Scopy.SetDebugOn();
   Scopy.ComputeSteerableMatrix();
+
+  std::cout << "Rotation Matrix:" << std::endl;
+  std::cout << R << std::endl;
+
+  std::cout << "Matrix: Order 2" << std::endl;
   std::cout << Scopy << std::endl;
-    
-  return EXIT_SUCCESS;
+
+  typename SteerableMatrix::InternalMatrixType transposeMatrix = Scopy.GetTranspose();
+  typename SteerableMatrix::InternalMatrixType identityMatrix = Scopy.GetVnlMatrix();
+  identityMatrix.set_identity();
+  typename SteerableMatrix::InternalMatrixType SmultST =
+    Scopy.GetVnlMatrix() * transposeMatrix;
+  
+  if( SmultST != identityMatrix )
+    {
+    testPassed = false;
+    std::cout << "test failed!" << std::endl;
+    std::cerr << "S * S_transpose != identity" << std::endl;
+    std::cout << "Matrix: S*S_transpose" << std::endl;
+    std::cout << SmultST << std::endl;
+    }
+
+  // For angle = pi/2
+  if(itk::Math::AlmostEquals(angle,itk::Math::pi_over_2) )
+    {
+    if(Dimension == 2)
+      {
+      // f: order 2 dim 2:
+      typename SteerableMatrix::InternalMatrixType g(3,3);
+      g(0,0)=0; g(0,1)=0;  g(0,2)=1;
+      g(1,0)=0; g(1,1)=-1; g(1,2)=0;
+      g(2,0)=1; g(2,1)=0;  g(2,2)=0;
+      if( Scopy.GetVnlMatrix() != g )
+        {
+        testPassed = false;
+        std::cout << "test failed!" << std::endl;
+        std::cerr << "expected result:" << std::endl;
+        std::cerr << g << std::endl;
+        std::cerr << "but got:" << std::endl;
+        std::cerr << Scopy.GetVnlMatrix() << std::endl;
+        }
+      }
+    if(Dimension == 3)
+      {
+      // f: order 2 dim 3:
+      typename SteerableMatrix::InternalMatrixType f(6,6);
+      f(0,0)=0; f(0,1)=0;  f(0,2)=0; f(0,3)=1; f(0,4)=0;  f(0,5)=0;
+      f(1,0)=0; f(1,1)=-1; f(1,2)=0; f(1,3)=0; f(1,4)=0;  f(1,5)=0;
+      f(2,0)=0; f(2,1)=0;  f(2,2)=0; f(2,3)=0; f(2,4)=-1; f(2,5)=0;
+      f(3,0)=1; f(3,1)=0;  f(3,2)=0; f(3,3)=0; f(3,4)=0;  f(3,5)=0;
+      f(4,0)=0; f(4,1)=0;  f(4,2)=1; f(4,3)=0; f(4,4)=0;  f(4,5)=0;
+      f(5,0)=0; f(5,1)=0;  f(5,2)=0; f(5,3)=0; f(5,4)=0;  f(5,5)=1;
+      if( Scopy.GetVnlMatrix() != f )
+        {
+        testPassed = false;
+        std::cout << "test failed!" << std::endl;
+        std::cerr << "expected result:" << std::endl;
+        std::cerr << f << std::endl;
+        std::cerr << "but got:" << std::endl;
+        std::cerr << Scopy.GetVnlMatrix() << std::endl;
+        }
+      }
+    }
+  std::cout << "Matrix: Order 1" << std::endl;
+  std::cout << S << std::endl;
+
+  // unsigned int highOrder = 10;
+  // Sdefault.SetOrder(highOrder);
+  // Sdefault.ComputeSteerableMatrix();
+  // std::cout << "Matrix: Order " << highOrder << std::endl;
+  // std::cout << "Matrix: size " << Sdefault.Rows() << std::endl;
+  // std::cout << Sdefault << std::endl;
+
+  if(testPassed)
+    {
+    return EXIT_SUCCESS;
+    }
+  else
+    {
+    return EXIT_FAILURE;
+    }
 }
 
 int itkRieszRotationMatrixTest(int argc, char* argv[])

--- a/test/itkRieszRotationMatrixTest.cxx
+++ b/test/itkRieszRotationMatrixTest.cxx
@@ -1,0 +1,105 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkRieszRotationMatrix.h"
+#include <complex>
+#include "itkMath.h"
+
+template< unsigned int VDimension >
+int runRieszRotationMatrixTest()
+{
+  const unsigned int Dimension = VDimension;
+  typedef double ValueType;
+  typedef itk::RieszRotationMatrix<ValueType, Dimension> SteerableMatrix;
+  typedef typename SteerableMatrix::SpatialRotationMatrixType SpatialRotationMatrix;
+
+  // Define a spatial rotation matrix.
+  SpatialRotationMatrix R;
+  double angle = itk::Math::pi_over_4;
+  double cosA = cos(angle);
+  double sinA = sin(angle);
+  double C = 1 - cosA;
+  if(Dimension == 2)
+    {
+    R[0][0] =  cosA;
+    R[0][1] =  -sinA;
+    R[1][0] =  sinA;
+    R[1][1] =  cosA;
+    }
+
+  itk::FixedArray<double, Dimension> dir;
+  dir.Fill(0);
+  if(Dimension == 3)
+    {
+    double x = dir[0] = 0;
+    double y = dir[1] = 0;
+    double z = dir[2] = 1;
+    R[0][0] =  x*x*C + cosA;
+    R[0][1] =  x*y*C - z*sinA;
+    R[0][2] =  x*z*C + y*sinA;
+
+    R[1][0] =  y*x*C + z*sinA;
+    R[1][1] =  y*y*C + cosA;
+    R[1][2] =  y*z*C - x*sinA;
+
+    R[2][0] =  z*x*C - y*sinA;
+    R[2][1] =  z*y*C + x*sinA;
+    R[2][2] =  z*z*C + cosA;
+    }
+  // Check constructors of SteerableMatrix.
+  // default
+  SteerableMatrix Sdefault;
+  const unsigned int order1 = 1;
+  Sdefault.SetOrder(order1);
+  Sdefault.SetSpatialRotationMatrix(R);
+  // compute
+  SteerableMatrix S(R, 1);
+  // copy
+  SteerableMatrix Scopy(S);
+  Scopy.SetOrder(2);
+  Scopy.ComputeSteerableMatrix();
+  std::cout << Scopy << std::endl;
+    
+  return EXIT_SUCCESS;
+}
+
+int itkRieszRotationMatrixTest(int argc, char* argv[])
+{
+  if(argc != 2)
+    {
+    std::cerr << "Usage: " << argv[0]
+              << "dimension" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  const unsigned int dimension = atoi(argv[1]);
+  if(dimension == 2)
+    {
+    return runRieszRotationMatrixTest<2>();
+    }
+  else if(dimension == 3)
+    {
+    return runRieszRotationMatrixTest<3>();
+    }
+  else
+    {
+    std::cerr << "dimension = " << dimension 
+      <<" . But test only work for 2 or 3 dimension."<< std::endl;
+    return EXIT_FAILURE;
+    }
+}


### PR DESCRIPTION
Add S_r, rotation matrix, that steers the generalized riesz function.

Get a steerable matrix for the Riesz transform: S_r
from a rotation matrix R in the spatial domain,
and the order of the Riesz transform (T)
T f( R*x ) = T_{S_r} f(x)

S_r is a MxM matrix, where M = p(N,d) is the number of
components of a riesz transform of order N and dimension d.
M := p(N,d) = \frac{(N+d-1)!}{(d-1)! N!}

The rotation matrix is a dxd matrix.
