### PR TITLE
ENH: Increase itk::ExpandWithZerosImageFilter class coverage.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -282,9 +282,9 @@ itk_add_test(NAME itkFrequencyBandImageFilterOddTest
   COMMAND IsotropicWaveletsTestDriver itkFrequencyBandImageFilterTest "Odd")
 ## ExpandWithZeros (in spatial domain)
 itk_add_test(NAME itkExpandWithZerosImageFilterTest2D
-  COMMAND IsotropicWaveletsTestDriver itkExpandWithZerosImageFilterTest 2)
+  COMMAND IsotropicWaveletsTestDriver itkExpandWithZerosImageFilterTest 2 3)
 itk_add_test(NAME itkExpandWithZerosImageFilterTest3D
-  COMMAND IsotropicWaveletsTestDriver itkExpandWithZerosImageFilterTest 3)
+  COMMAND IsotropicWaveletsTestDriver itkExpandWithZerosImageFilterTest 3 3)
 ## ShrinkDecimate (in spatial domain)
 itk_add_test(NAME itkShrinkDecimateImageFilterTest2D
   COMMAND IsotropicWaveletsTestDriver itkShrinkDecimateImageFilterTest 2)

--- a/test/itkExpandWithZerosImageFilterTest.cxx
+++ b/test/itkExpandWithZerosImageFilterTest.cxx
@@ -31,7 +31,7 @@
 
 template< unsigned int VDimension >
 int
-runExpandWithZerosImageFilterTest()
+runExpandWithZerosImageFilterTest( unsigned int expandFactor )
 {
   typedef float                               PixelType;
   typedef itk::Image< PixelType, VDimension > ImageType;
@@ -56,12 +56,14 @@ runExpandWithZerosImageFilterTest()
   typedef itk::ExpandWithZerosImageFilter< ImageType, ImageType > ExpanderType;
   typename ExpanderType::Pointer expander = ExpanderType::New();
 
-  unsigned int expandFactor = 3;
   typename ExpanderType::ExpandFactorsType expandFactors;
   expandFactors.Fill( expandFactor );
-
   expander->SetExpandFactors( expandFactors );
   TEST_SET_GET_VALUE( expandFactors, expander->GetExpandFactors() );
+
+  expander->SetExpandFactors( expandFactor );
+  TEST_SET_GET_VALUE( expandFactors, expander->GetExpandFactors() );
+
   expander->SetInput( input );
   expander->Update();
 
@@ -152,10 +154,11 @@ runExpandWithZerosImageFilterTest()
 int
 itkExpandWithZerosImageFilterTest( int argc, char *argv[] )
 {
-  if ( argc > 2 )
+  if ( argc < 3 )
     {
     std::cerr << "Usage: " << argv[0]
-              << "[dimension]" << std::endl;
+              << "dimension" << std::endl
+              << "expandFactor" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -171,19 +174,18 @@ itkExpandWithZerosImageFilterTest( int argc, char *argv[] )
   EXERCISE_BASIC_OBJECT_METHODS( expander, ExpandWithZerosImageFilter,
     ImageToImageFilter );
 
-  unsigned int dimension = 3;
-  if ( argc == 2 )
-    {
-    dimension = atoi( argv[1] );
-    }
+  // Parse input arguments
+  unsigned int dimension = atoi( argv[1] );
+  unsigned int expandFactor = static_cast< unsigned int >( atoi(argv[2]) );
+
 
   if ( dimension == 2 )
     {
-    return runExpandWithZerosImageFilterTest< 2 >();
+    return runExpandWithZerosImageFilterTest< 2 >( expandFactor );
     }
   else if ( dimension == 3 )
     {
-    return runExpandWithZerosImageFilterTest< 3 >();
+    return runExpandWithZerosImageFilterTest< 3 >( expandFactor );
     }
   else
     {


### PR DESCRIPTION
Exercise the itk::ExpandWithZerosImageFilter::SetExpandFactors( const
unsigned int ) method.

Modify the CMakeLists.txt to accept the new test argument.

Make the arguments be compulsory so that the number of input arguments
check is meaningful.