### PR TITLE
ENH: Increase itk::PhaseAnalysisSoftThresholdImageFilter class coverage.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -148,7 +148,7 @@ itk_add_test(NAME itkMonogenicSignalFrequencyImageFilterTest
 itk_add_test(NAME itkPhaseAnalysisSoftThresholdImageFilterTest
   COMMAND IsotropicWaveletsTestDriver
   itkPhaseAnalysisSoftThresholdImageFilterTest DATA{Input/collagen_32x32x16.tiff}
-  ${ITK_TEST_OUTPUT_DIR}/itkPhaseAnalysisSoftThresholdImageFilterTest.tiff
+  ${ITK_TEST_OUTPUT_DIR}/itkPhaseAnalysisSoftThresholdImageFilterTest.tiff 1 2.0 10044.513 5020.3013 20085.115
   )
 # StructureTensor
 itk_add_test(NAME itkStructureTensorTest


### PR DESCRIPTION
Exercise the Set/Get NumOfSigmas methods, and perform regression tests
for the m_MeanAmp, m_SigmaAmp, and m_Threshold ivars to make exercising
their Get macros relevant.

Modify the CMakeLists.txt to accept the new test input values and the
expected values for the class regression tests.