### PR TITLE
ENH: Increase itk::FFTPadPositiveIndexImageFilter class coverage.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -330,11 +330,23 @@ itk_add_test(NAME itkFrequencyShrinkEvenTest
     2
     )
 ##FFTPad
-itk_add_test(NAME itkFFTPadPositiveIndexImageFilterTest
+itk_add_test(NAME itkFFTPadPositiveIndexImageFilterTestZeroFluxNeumann
   COMMAND IsotropicWaveletsTestDriver
   itkFFTPadPositiveIndexImageFilterTest
     DATA{Input/checkershadow_Lch_512x512.tiff}
-    ${ITK_TEST_OUTPUT_DIR}/itkFFTPadPositiveIndexImageFilterTest.tiff
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTPadPositiveIndexImageFilterTestZeroFluxNeumann.tiff 2 ZEROFLUXNEUMANN
+    )
+itk_add_test(NAME itkFFTPadPositiveIndexImageFilterTestConstant
+  COMMAND IsotropicWaveletsTestDriver
+  itkFFTPadPositiveIndexImageFilterTest
+    DATA{Input/checkershadow_Lch_512x512.tiff}
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTPadPositiveIndexImageFilterTestConstant.tiff 2 CONSTANT
+    )
+ itk_add_test(NAME itkFFTPadPositiveIndexImageFilterTestPeriodic
+  COMMAND IsotropicWaveletsTestDriver
+  itkFFTPadPositiveIndexImageFilterTest
+    DATA{Input/checkershadow_Lch_512x512.tiff}
+    ${ITK_TEST_OUTPUT_DIR}/itkFFTPadPositiveIndexImageFilterTestPeriodic.tiff 2 PERIODIC
     )
 ## ZeroDC
 itk_add_test(NAME itkZeroDCImageFilterTest

--- a/test/itkFFTPadPositiveIndexImageFilterTest.cxx
+++ b/test/itkFFTPadPositiveIndexImageFilterTest.cxx
@@ -24,13 +24,15 @@
 #include "itkConstantBoundaryCondition.h"
 #include "itkTestingMacros.h"
 
-int
-itkFFTPadPositiveIndexImageFilterTest( int argc, char * argv[] )
+int itkFFTPadPositiveIndexImageFilterTest( int argc, char * argv[] )
 {
-  if ( argc < 3 )
+  if ( argc < 5 )
     {
-    std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " inputImageFile outputImageFile" << std::endl;
+    std::cerr << "Usage: " << argv[0]
+      << " inputImageFile"
+      << " outputImageFile"
+      << " sizeGreatestPrimeFactor"
+      << " boundarycondition (ZEROFLUXNEUMANN; CONSTANT; PERIODIC)" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -52,13 +54,39 @@ itkFFTPadPositiveIndexImageFilterTest( int argc, char * argv[] )
   EXERCISE_BASIC_OBJECT_METHODS( fftpad, FFTPadPositiveIndexImageFilter,
     ImageToImageFilter );
 
-  /*itk::SizeValueType sizeGreatestPrimeFactor;
-  fftpad->SetSizeGreatestPrimeFactor( sizeGreatestPrimeFactor );
-  TEST_SET_GET_VALUE( sizeGreatestPrimeFactor, fftpad->GetSizeGreatestPrimeFactor() );*/
 
-  /*FFTPadType::BoundaryConditionPointerType boundaryCondition;
-  fftpad->SetBoundaryCondition( boundaryCondition );
-  TEST_SET_GET_VALUE( boundaryCondition, fftpad->GetBoundaryCondition() );*/
+  FFTPadType::SizeType::SizeValueType sizeGreatestPrimeFactor =
+    static_cast< FFTPadType::SizeType::SizeValueType >( atoi( argv[3] ) );
+  fftpad->SetSizeGreatestPrimeFactor( sizeGreatestPrimeFactor );
+  TEST_SET_GET_VALUE( sizeGreatestPrimeFactor, fftpad->GetSizeGreatestPrimeFactor() );
+
+  itk::ConstantBoundaryCondition< ImageType > constantBoundaryCondition;
+  itk::PeriodicBoundaryCondition< ImageType > periodicBoundaryCondition;
+  itk::ZeroFluxNeumannBoundaryCondition< ImageType > zeroFluxNeumannBoundaryCondition;
+
+  std::string boundaryCondition( argv[4] );
+  if ( boundaryCondition == "CONSTANT" )
+    {
+    fftpad->SetBoundaryCondition( &constantBoundaryCondition );
+    TEST_SET_GET_VALUE( &constantBoundaryCondition, fftpad->GetBoundaryCondition() );
+    }
+  else if ( boundaryCondition == "PERIODIC" )
+    {
+    fftpad->SetBoundaryCondition( &periodicBoundaryCondition );
+    TEST_SET_GET_VALUE( &periodicBoundaryCondition, fftpad->GetBoundaryCondition() );
+    }
+  else if ( boundaryCondition == "ZEROFLUXNEUMANN" )
+    {
+    fftpad->SetBoundaryCondition( &zeroFluxNeumannBoundaryCondition );
+    TEST_SET_GET_VALUE( &zeroFluxNeumannBoundaryCondition, fftpad->GetBoundaryCondition() );
+    }
+  else
+    {
+    std::cerr << "Invalid BoundaryCondition '" << boundaryCondition << "'" << std::endl;
+    std::cerr << "Valid values are CONSTANT, PERIODIC or ZEROFLUXNEUMANN." << std::endl;
+    return EXIT_FAILURE;
+    }
+
 
   fftpad->SetInput( reader->GetOutput() );
 


### PR DESCRIPTION
Exercise all Set/Get methods.

Add test cases to use different boundary conditions.