### PR TITLE
ENH: Print all member variables.

### DIFF
--- a/include/itkFFTPadPositiveIndexImageFilter.hxx
+++ b/include/itkFFTPadPositiveIndexImageFilter.hxx
@@ -108,7 +108,12 @@ FFTPadPositiveIndexImageFilter< TInputImage, TOutputImage >
 {
   Superclass::PrintSelf(os, indent);
 
-  os << indent << "SizeGreatestPrimeFactor: "  << m_SizeGreatestPrimeFactor << std::endl;
+  itkPrintSelfObjectMacro( FFTPadFilter );
+  itkPrintSelfObjectMacro( ChangeInfoFilter );
+
+  os << indent << "SizeGreatestPrimeFactor: " << m_SizeGreatestPrimeFactor << std::endl;
+
+  m_BoundaryCondition->Print( os, indent );
 }
 
 template< class TInputImage, class TOutputImage >


### PR DESCRIPTION
Print all member variables. Use the itkPrintSelfObject macro to print
objects that can be null pointers.