### PR TITLE
ENH: Increase the itk::FrequencyShrinkImageFilter class coverage.

### DIFF
--- a/test/itkFrequencyShrinkTest.cxx
+++ b/test/itkFrequencyShrinkTest.cxx
@@ -74,7 +74,7 @@ runFrequencyShrinkTest( const std::string & inputImage, const std::string & outp
   fftFilter->SetInput( zeroDCFilter->GetOutput() );
   typedef typename FFTFilterType::OutputImageType ComplexImageType;
 
-  // ShinkFrequency
+  // ShrinkFrequency
   typedef itk::FrequencyShrinkImageFilter< ComplexImageType > ShrinkType;
   typename ShrinkType::Pointer shrinkFilter = ShrinkType::New();
 
@@ -117,7 +117,7 @@ runFrequencyShrinkTest( const std::string & inputImage, const std::string & outp
     }
   std::cout << "Image Even? " << imageIsEven << std::endl;
 
-  // Test hermitian properties for even Images. Odd real images are not even hermitian after FFTw.
+  // Test Hermitian properties for even Images. Odd real images are not even hermitian after FFTw.
   if ( imageIsEven )
     {
     bool fftIsHermitian    = itk::Testing::ComplexImageIsHermitian( fftFilter->GetOutput() );
@@ -135,9 +135,9 @@ runFrequencyShrinkTest( const std::string & inputImage, const std::string & outp
       testPassed = false;
       }
 
-    // Hermitian Test:
-    // Simmetry and Hermitian test: ComplexInverseFFT will generate output with zero imaginary part.
-    // Check that complex part is almost 0 after FFT and complex inverse FFT.
+      // Hermitian Test:
+      // Simmetry and Hermitian test: ComplexInverseFFT will generate output with zero imaginary part.
+      // Check that complex part is almost 0 after FFT and complex inverse FFT.
       {
       typedef itk::ComplexToComplexFFTImageFilter< ComplexImageType > ComplexFFTType;
       typename ComplexFFTType::Pointer complexInverseFFT = ComplexFFTType::New();
@@ -174,7 +174,7 @@ runFrequencyShrinkTest( const std::string & inputImage, const std::string & outp
                   << std::endl;
         }
       }
-    // Check that complex part is almost 0 filter is correct after shrink
+      // Check that complex part is almost 0 filter is correct after shrink
       {
       typedef itk::ComplexToComplexFFTImageFilter< ComplexImageType > ComplexFFTType;
       typename ComplexFFTType::Pointer complexInverseFFT = ComplexFFTType::New();
@@ -213,9 +213,9 @@ runFrequencyShrinkTest( const std::string & inputImage, const std::string & outp
     }
 
   // Test size and metadata
-  typename ComplexImageType::PointType fftOrigin     = fftFilter->GetOutput()->GetOrigin();
-  typename ComplexImageType::SpacingType fftSpacing    = fftFilter->GetOutput()->GetSpacing();
-  typename ComplexImageType::PointType shrinkOrigin  = shrinkFilter->GetOutput()->GetOrigin();
+  typename ComplexImageType::PointType fftOrigin = fftFilter->GetOutput()->GetOrigin();
+  typename ComplexImageType::SpacingType fftSpacing = fftFilter->GetOutput()->GetSpacing();
+  typename ComplexImageType::PointType shrinkOrigin = shrinkFilter->GetOutput()->GetOrigin();
   typename ComplexImageType::SpacingType shrinkSpacing = shrinkFilter->GetOutput()->GetSpacing();
 
   std::cout << "ShrinkOrigin = " << shrinkOrigin << std::endl;
@@ -259,21 +259,22 @@ runFrequencyShrinkTest( const std::string & inputImage, const std::string & outp
   changeInputInfoFilter->Update();
 
   typename ShrinkType::Pointer shrinkBandFilter = ShrinkType::New();
-  shrinkBandFilter->SetApplyBandFilter(true);
+  bool applyBandFilter = true;
+  TEST_SET_GET_BOOLEAN( shrinkBandFilter, ApplyBandFilter, applyBandFilter );
   shrinkBandFilter->SetInput( changeInputInfoFilter->GetOutput());
   bool lowFreqThresholdPassing  = true;
   bool highFreqThresholdPassing = true;
   shrinkBandFilter->GetFrequencyBandFilter()->SetPassBand(lowFreqThresholdPassing, highFreqThresholdPassing);
 
   typename ShrinkType::Pointer shrinkNoIntersectionFilter = ShrinkType::New();
-  shrinkNoIntersectionFilter->SetApplyBandFilter(true);
+  TEST_SET_GET_BOOLEAN( shrinkNoIntersectionFilter, ApplyBandFilter, applyBandFilter );
   shrinkNoIntersectionFilter->SetInput( changeInputInfoFilter->GetOutput());
   lowFreqThresholdPassing  = true;
   highFreqThresholdPassing = false;
   shrinkNoIntersectionFilter->GetFrequencyBandFilter()->SetPassBand(lowFreqThresholdPassing, highFreqThresholdPassing);
 
   typename ShrinkType::Pointer shrinkIntersectionPassFilter = ShrinkType::New();
-  shrinkIntersectionPassFilter->SetApplyBandFilter(true);
+  TEST_SET_GET_BOOLEAN( shrinkIntersectionPassFilter, ApplyBandFilter, applyBandFilter );
   shrinkIntersectionPassFilter->SetInput( changeInputInfoFilter->GetOutput() );
   lowFreqThresholdPassing  = true;
   highFreqThresholdPassing = true;


### PR DESCRIPTION
Exercise the boolean Set/Get macros for the m_ApplyBandFilter ivar using
the TEST_SET_GET_BOOLEAN macro.

Minor indentation and comment changes to improve readability.