### PR TITLE
BUG: Boundary condition was not propagated to FFTPadPositiveIndex

### DIFF
--- a/include/itkFFTPadPositiveIndexImageFilter.h
+++ b/include/itkFFTPadPositiveIndexImageFilter.h
@@ -91,8 +91,17 @@ public:
   itkGetConstMacro(SizeGreatestPrimeFactor, SizeValueType);
   itkSetMacro(SizeGreatestPrimeFactor, SizeValueType);
   /** Set/get the boundary condition. */
-  itkSetMacro(BoundaryCondition, BoundaryConditionPointerType);
   itkGetConstMacro(BoundaryCondition, BoundaryConditionPointerType);
+  virtual void SetBoundaryCondition(const BoundaryConditionPointerType boundaryCondition)
+    {
+    if ( this->m_BoundaryCondition != boundaryCondition )
+      {
+      this->m_BoundaryCondition = boundaryCondition;
+      this->m_FFTPadFilter->SetBoundaryCondition(this->m_BoundaryCondition);
+      this->m_FFTPadFilter->Modified();
+      this->Modified();
+      }
+    }
 
 protected:
   FFTPadPositiveIndexImageFilter();

--- a/include/itkFFTPadPositiveIndexImageFilter.hxx
+++ b/include/itkFFTPadPositiveIndexImageFilter.hxx
@@ -53,6 +53,12 @@ FFTPadPositiveIndexImageFilter< TInputImage, TOutputImage >
   const typename OutputImageType::RegionType & outputRequestedRegion =
     outputPtr->GetRequestedRegion();
 
+  typename OutputImageType::RegionType shiftedOutputRequestedRegion;
+  typename OutputImageType::RegionType::IndexType shiftedRequestedIndex =
+    outputRequestedRegion.GetIndex() - this->m_ChangeInfoFilter->GetOutputOffset();
+  shiftedOutputRequestedRegion.SetIndex(shiftedRequestedIndex);
+  shiftedOutputRequestedRegion.SetSize(outputRequestedRegion.GetSize());
+
   // Ask the boundary condition for the input requested region.
   if ( !m_BoundaryCondition )
     {
@@ -60,7 +66,7 @@ FFTPadPositiveIndexImageFilter< TInputImage, TOutputImage >
     }
   typename InputImageType::RegionType inputRequestedRegion =
     m_BoundaryCondition->GetInputRequestedRegion( inputLargestPossibleRegion,
-      outputRequestedRegion );
+      shiftedOutputRequestedRegion );
 
   inputPtr->SetRequestedRegion( inputRequestedRegion );
 }


### PR DESCRIPTION
Raised by @jhlegarreta at PR InsightSoftwareConsortium/ITKIsotropicWavelets#48 and issue InsightSoftwareConsortium/ITK#6347

The `SetBoundaryCondition` in the class wasn't propagating that boundary to the m_FFTPad which uses it.

Also... I modified GenerateInputRequestedRegion to have into account the shift that we apply to the output (after the regular FFTPad).

@jhlegarreta maybe now the tests produce different outputs?