### PR TITLE
ENH: Throw an exception when input/output objects not set.

### DIFF
--- a/include/itkFrequencyExpandImageFilter.hxx
+++ b/include/itkFrequencyExpandImageFilter.hxx
@@ -204,7 +204,7 @@ FrequencyExpandImageFilter< TImageType >
 
   if ( !inputPtr || !outputPtr )
     {
-    return;
+    itkExceptionMacro(<< "Input and/or output not set");
     }
 
   // We need to compute the input requested region (size and start index)
@@ -260,7 +260,7 @@ FrequencyExpandImageFilter< TImageType >
 
   if ( !inputPtr || !outputPtr )
     {
-    return;
+    itkExceptionMacro(<< "Input and/or output not set");
     }
 
   // We need to compute the output spacing, the output image size, and the

--- a/include/itkFrequencyExpandViaInverseFFTImageFilter.hxx
+++ b/include/itkFrequencyExpandViaInverseFFTImageFilter.hxx
@@ -141,7 +141,7 @@ FrequencyExpandViaInverseFFTImageFilter< TImageType >
 
   if ( !inputPtr || !outputPtr )
     {
-    return;
+    itkExceptionMacro(<< "Input and/or output not set");
     }
 
   // We need to compute the input requested region (size and start index)
@@ -199,7 +199,7 @@ FrequencyExpandViaInverseFFTImageFilter< TImageType >
 
   if ( !inputPtr || !outputPtr )
     {
-    return;
+    itkExceptionMacro(<< "Input and/or output not set");
     }
 
   // We need to compute the output spacing, the output image size, and the

--- a/include/itkFrequencyShrinkImageFilter.hxx
+++ b/include/itkFrequencyShrinkImageFilter.hxx
@@ -347,7 +347,7 @@ FrequencyShrinkImageFilter< TImageType >
 
   if ( !inputPtr || !outputPtr )
     {
-    return;
+    itkExceptionMacro(<< "Input and/or output not set");
     }
 
   // Compute the output spacing, the output image size, and the

--- a/include/itkFrequencyShrinkViaInverseFFTImageFilter.hxx
+++ b/include/itkFrequencyShrinkViaInverseFFTImageFilter.hxx
@@ -153,7 +153,7 @@ FrequencyShrinkViaInverseFFTImageFilter< TImageType >
 
   if ( !inputPtr || !outputPtr )
     {
-    return;
+    itkExceptionMacro(<< "Input and/or output not set");
     }
 
   // Compute the output spacing, the output image size, and the

--- a/include/itkShrinkDecimateImageFilter.hxx
+++ b/include/itkShrinkDecimateImageFilter.hxx
@@ -163,7 +163,7 @@ ShrinkDecimateImageFilter< TInputImage, TOutputImage >
 
   if ( !inputPtr || !outputPtr )
     {
-    return;
+    itkExceptionMacro(<< "Input and/or output not set");
     }
 
   // Compute the input requested region (size and start index)
@@ -241,7 +241,7 @@ ShrinkDecimateImageFilter< TInputImage, TOutputImage >
 
   if ( !inputPtr || !outputPtr )
     {
-    return;
+    itkExceptionMacro(<< "Input and/or output not set");
     }
 
   // Compute the output spacing, the output image size, and the

--- a/test/itkFrequencyExpandAndShrinkTest.cxx
+++ b/test/itkFrequencyExpandAndShrinkTest.cxx
@@ -80,15 +80,29 @@ runFrequencyExpandAndShrinkTest( const std::string & inputImage, const std::stri
   /*********** EXPAND ***************/
   typedef itk::FrequencyExpandImageFilter< ComplexImageType > ExpandType;
   typename ExpandType::Pointer expandFilter = ExpandType::New();
-  expandFilter->SetInput(fftFilter->GetOutput());
+
   expandFilter->SetExpandFactors(resizeFactor);
-  expandFilter->Update();
+
+  // Test input or output not set exception
+  TRY_EXPECT_EXCEPTION( expandFilter->Update() );
+
+
+  expandFilter->SetInput(fftFilter->GetOutput());
+
+  TRY_EXPECT_NO_EXCEPTION( expandFilter->Update() );
 
   typedef itk::FrequencyExpandViaInverseFFTImageFilter< ComplexImageType > ExpandViaInverseFFTType;
   typename ExpandViaInverseFFTType::Pointer expandViaInverseFFTFilter = ExpandViaInverseFFTType::New();
-  expandViaInverseFFTFilter->SetInput(fftFilter->GetOutput());
+
   expandViaInverseFFTFilter->SetExpandFactors(resizeFactor);
-  expandViaInverseFFTFilter->Update();
+
+  // Test input or output not set exception
+  TRY_EXPECT_EXCEPTION( expandViaInverseFFTFilter->Update() );
+
+
+  expandViaInverseFFTFilter->SetInput(fftFilter->GetOutput());
+
+  TRY_EXPECT_NO_EXCEPTION( expandViaInverseFFTFilter->Update() );
 
 // #ifdef ITK_VISUALIZE_TESTS
 //   typename InverseFFTFilterType::Pointer inverseFFTExpand1 = InverseFFTFilterType::New();
@@ -104,13 +118,24 @@ runFrequencyExpandAndShrinkTest( const std::string & inputImage, const std::stri
   /*********** SHRINK ***************/
   typedef itk::FrequencyShrinkImageFilter< ComplexImageType > ShrinkType;
   typename ShrinkType::Pointer shrinkFilter = ShrinkType::New();
-  shrinkFilter->SetInput(expandFilter->GetOutput());
+
   shrinkFilter->SetShrinkFactors(resizeFactor);
+
+  // Test input or output not set exception
+  TRY_EXPECT_EXCEPTION( expandFilter->Update() );
+
+
+  shrinkFilter->SetInput(expandFilter->GetOutput());
 
   TRY_EXPECT_NO_EXCEPTION( shrinkFilter->Update() );
 
   typedef itk::FrequencyShrinkViaInverseFFTImageFilter< ComplexImageType > ShrinkViaInverseFFTType;
   typename ShrinkViaInverseFFTType::Pointer shrinkViaInverseFFTFilter = ShrinkViaInverseFFTType::New();
+
+  // Test input or output not set exception
+  TRY_EXPECT_NO_EXCEPTION( shrinkViaInverseFFTFilter->Update() );
+
+
   shrinkViaInverseFFTFilter->SetInput(expandViaInverseFFTFilter->GetOutput());
 
   typename ShrinkViaInverseFFTType::ShrinkFactorsType shrinkFactors;

--- a/test/itkFrequencyExpandTest.cxx
+++ b/test/itkFrequencyExpandTest.cxx
@@ -72,6 +72,11 @@ runFrequencyExpandTest(const std::string & inputImage, const std::string & outpu
   // ExpandFrequency
   typedef itk::FrequencyExpandImageFilter< ComplexImageType > ExpandType;
   typename ExpandType::Pointer expandFilter = ExpandType::New();
+
+  // Test input or output not set exception
+  TRY_EXPECT_EXCEPTION( expandFilter->Update() );
+
+
   expandFilter->SetInput( fftFilter->GetOutput() );
 
   unsigned int expandFactor = 2;
@@ -79,7 +84,8 @@ runFrequencyExpandTest(const std::string & inputImage, const std::string & outpu
   expandFactors.Fill( expandFactor );
   expandFilter->SetExpandFactors( expandFactors );
   TEST_SET_GET_VALUE( expandFactors, expandFilter->GetExpandFactors() );
-  expandFilter->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( expandFilter->Update() );
 
   // Test size and metadata
   typename ComplexImageType::PointType fftOrigin     = fftFilter->GetOutput()->GetOrigin();

--- a/test/itkShrinkDecimateImageFilterTest.cxx
+++ b/test/itkShrinkDecimateImageFilterTest.cxx
@@ -79,6 +79,11 @@ runShrinkDecimateImageFilterTest()
     decimator->SetShrinkFactors( shrinkFactors );
     TEST_SET_GET_VALUE( shrinkFactors, decimator->GetShrinkFactors() );
 
+
+    // Test input or output not set exception
+    TRY_EXPECT_EXCEPTION( decimator->Update() );
+
+
     decimator->SetInput( input );
 
     TRY_EXPECT_NO_EXCEPTION( decimator->Update() );

--- a/test/itkWaveletFrequencyFilterBankGeneratorDownsampleTest.cxx
+++ b/test/itkWaveletFrequencyFilterBankGeneratorDownsampleTest.cxx
@@ -83,10 +83,16 @@ runWaveletFrequencyFilterBankGeneratorDownsampleTest( const std::string& inputIm
   // typedef itk::FrequencyShrinkViaInverseFFTImageFilter<ComplexImageType> ShrinkFilterType;
   typedef itk::FrequencyShrinkImageFilter< ComplexImageType > ShrinkFilterType;
   typename ShrinkFilterType::Pointer shrinkFilter = ShrinkFilterType::New();
+
+  // Test input or output not set exception
+  TRY_EXPECT_EXCEPTION( shrinkFilter->Update() );
+
+
   // shrinkFilter->SetInput(forwardFilterBank->GetOutputHighPass());
   shrinkFilter->SetInput(forwardFilterBank->GetOutputLowPass());
   shrinkFilter->SetShrinkFactors(shrinkFactor);
-  shrinkFilter->Update();
+
+  TRY_EXPECT_NO_EXCEPTION( shrinkFilter->Update() );
 
   typename WaveletFilterBankType::Pointer forwardFilterBankDown = WaveletFilterBankType::New();
   forwardFilterBankDown->SetHighPassSubBands( highSubBands );


### PR DESCRIPTION
Throw an itkException when methods requiring input/output objects find
that these have not been set. Prefer to throw an exception over simply
returning.

Exercise/test the exception.