### PR TITLE
ENH: Check for input/output objects with assertion.

### DIFF
--- a/include/itkFrequencyExpandImageFilter.hxx
+++ b/include/itkFrequencyExpandImageFilter.hxx
@@ -202,10 +202,8 @@ FrequencyExpandImageFilter< TImageType >
     const_cast< TImageType * >( this->GetInput() );
   ImagePointer outputPtr = this->GetOutput();
 
-  if ( !inputPtr || !outputPtr )
-    {
-    return;
-    }
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
 
   // We need to compute the input requested region (size and start index)
   unsigned int i;
@@ -258,10 +256,8 @@ FrequencyExpandImageFilter< TImageType >
     const_cast< TImageType * >( this->GetInput() );
   ImagePointer outputPtr = this->GetOutput();
 
-  if ( !inputPtr || !outputPtr )
-    {
-    return;
-    }
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
 
   // We need to compute the output spacing, the output image size, and the
   // output image start index

--- a/include/itkFrequencyExpandViaInverseFFTImageFilter.hxx
+++ b/include/itkFrequencyExpandViaInverseFFTImageFilter.hxx
@@ -139,10 +139,8 @@ FrequencyExpandViaInverseFFTImageFilter< TImageType >
     const_cast< TImageType * >( this->GetInput() );
   ImagePointer outputPtr = this->GetOutput();
 
-  if ( !inputPtr || !outputPtr )
-    {
-    return;
-    }
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
 
   // We need to compute the input requested region (size and start index)
   unsigned int i;
@@ -197,10 +195,8 @@ FrequencyExpandViaInverseFFTImageFilter< TImageType >
     const_cast< TImageType * >( this->GetInput() );
   ImagePointer outputPtr = this->GetOutput();
 
-  if ( !inputPtr || !outputPtr )
-    {
-    return;
-    }
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
 
   // We need to compute the output spacing, the output image size, and the
   // output image start index

--- a/include/itkFrequencyShrinkImageFilter.hxx
+++ b/include/itkFrequencyShrinkImageFilter.hxx
@@ -345,10 +345,8 @@ FrequencyShrinkImageFilter< TImageType >
   ImageConstPointer inputPtr  = this->GetInput();
   ImagePointer outputPtr = this->GetOutput();
 
-  if ( !inputPtr || !outputPtr )
-    {
-    return;
-    }
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
 
   // Compute the output spacing, the output image size, and the
   // output image start index

--- a/include/itkFrequencyShrinkViaInverseFFTImageFilter.hxx
+++ b/include/itkFrequencyShrinkViaInverseFFTImageFilter.hxx
@@ -151,10 +151,8 @@ FrequencyShrinkViaInverseFFTImageFilter< TImageType >
   ImageConstPointer inputPtr  = this->GetInput();
   ImagePointer outputPtr = this->GetOutput();
 
-  if ( !inputPtr || !outputPtr )
-    {
-    return;
-    }
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
 
   // Compute the output spacing, the output image size, and the
   // output image start index

--- a/include/itkShrinkDecimateImageFilter.hxx
+++ b/include/itkShrinkDecimateImageFilter.hxx
@@ -161,10 +161,8 @@ ShrinkDecimateImageFilter< TInputImage, TOutputImage >
   InputImagePointer inputPtr = const_cast< TInputImage * >( this->GetInput() );
   OutputImagePointer outputPtr = this->GetOutput();
 
-  if ( !inputPtr || !outputPtr )
-    {
-    return;
-    }
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
 
   // Compute the input requested region (size and start index)
   // Use the image transformations to insure an input requested region
@@ -239,10 +237,8 @@ ShrinkDecimateImageFilter< TInputImage, TOutputImage >
   InputImageConstPointer inputPtr  = this->GetInput();
   OutputImagePointer outputPtr = this->GetOutput();
 
-  if ( !inputPtr || !outputPtr )
-    {
-    return;
-    }
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
 
   // Compute the output spacing, the output image size, and the
   // output image start index


### PR DESCRIPTION
Rather than simply returning when the input/output objects are not set,
check they exist with an assert statement.

Since the processing framework should handle this situation, and throw
the appropriate exception when the input/output objects are not set,
the assertion is preferred over throwing an exception.

Use the itkAssertInDebugAndIgnoreInRelease macro for such purpose.

See the related topic
http://review.source.kitware.com/#/c/22423