### PR TITLE
BUG: Fix const casting compiler errors.

### DIFF
--- a/include/itkFFTPadPositiveIndexImageFilter.hxx
+++ b/include/itkFFTPadPositiveIndexImageFilter.hxx
@@ -45,8 +45,12 @@ FFTPadPositiveIndexImageFilter< TInputImage, TOutputImage >
 ::GenerateInputRequestedRegion()
 {
   // Get pointers to the input and output.
-  InputImageType * inputPtr  = const_cast< TInputImage * >( this->GetInput() );
-  OutputImageType * outputPtr = this->GetOutput();
+  InputImageType * inputPtr =
+    const_cast< InputImageType * >( this->GetInput() );
+  const OutputImageType * outputPtr = this->GetOutput();
+
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr );
 
   const typename InputImageType::RegionType & inputLargestPossibleRegion =
     inputPtr->GetLargestPossibleRegion();
@@ -79,10 +83,13 @@ FFTPadPositiveIndexImageFilter< TInputImage, TOutputImage >
   // call the superclass' implementation of this method
   Superclass::GenerateOutputInformation();
 
-  const InputImageType * input0  = this->GetInput();
-  OutputImageType * output0 = this->GetOutput();
+  const InputImageType * inputPtr = this->GetInput();
+  OutputImageType * outputPtr = this->GetOutput();
 
-  RegionType region0 = input0->GetLargestPossibleRegion();
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr );
+  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
+
+  RegionType inputRegion = inputPtr->GetLargestPossibleRegion();
   SizeType size;
   IndexType index;
   for ( unsigned int i = 0; i < ImageDimension; ++i )
@@ -90,7 +97,7 @@ FFTPadPositiveIndexImageFilter< TInputImage, TOutputImage >
     SizeValueType padSize = 0;
     if ( m_SizeGreatestPrimeFactor > 1 )
       {
-      while ( Math::GreatestPrimeFactor( region0.GetSize()[i] + padSize ) > m_SizeGreatestPrimeFactor )
+      while ( Math::GreatestPrimeFactor( inputRegion.GetSize()[i] + padSize ) > m_SizeGreatestPrimeFactor )
         {
         ++padSize;
         }
@@ -98,13 +105,13 @@ FFTPadPositiveIndexImageFilter< TInputImage, TOutputImage >
     else if ( m_SizeGreatestPrimeFactor == 1 )
       {
       // make sure the total size is even
-      padSize += ( region0.GetSize()[i] + padSize ) % 2;
+      padSize += ( inputRegion.GetSize()[i] + padSize ) % 2;
       }
-    index[i] = region0.GetIndex()[i];
-    size[i]  = region0.GetSize()[i] + padSize;
+    index[i] = inputRegion.GetIndex()[i];
+    size[i]  = inputRegion.GetSize()[i] + padSize;
     }
   RegionType region( index, size );
-  output0->SetLargestPossibleRegion( region );
+  outputPtr->SetLargestPossibleRegion( region );
 }
 
 template< class TInputImage, class TOutputImage >

--- a/include/itkFrequencyExpandImageFilter.hxx
+++ b/include/itkFrequencyExpandImageFilter.hxx
@@ -198,12 +198,11 @@ FrequencyExpandImageFilter< TImageType >
   Superclass::GenerateInputRequestedRegion();
 
   // Get pointers to the input and output
-  ImagePointer inputPtr =
-    const_cast< TImageType * >( this->GetInput() );
-  ImagePointer outputPtr = this->GetOutput();
+  TImageType * inputPtr = const_cast< TImageType * >( this->GetInput() );
+  const TImageType * outputPtr = this->GetOutput();
 
   itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
-  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr );
 
   // We need to compute the input requested region (size and start index)
   unsigned int i;
@@ -252,11 +251,10 @@ FrequencyExpandImageFilter< TImageType >
   Superclass::GenerateOutputInformation();
 
   // Get pointers to the input and output
-  ImagePointer inputPtr =
-    const_cast< TImageType * >( this->GetInput() );
-  ImagePointer outputPtr = this->GetOutput();
+  const TImageType * inputPtr = this->GetInput();
+  TImageType * outputPtr = this->GetOutput();
 
-  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr );
   itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
 
   // We need to compute the output spacing, the output image size, and the

--- a/include/itkFrequencyExpandViaInverseFFTImageFilter.hxx
+++ b/include/itkFrequencyExpandViaInverseFFTImageFilter.hxx
@@ -135,12 +135,11 @@ FrequencyExpandViaInverseFFTImageFilter< TImageType >
   Superclass::GenerateInputRequestedRegion();
 
   // Get pointers to the input and output
-  ImagePointer inputPtr =
-    const_cast< TImageType * >( this->GetInput() );
-  ImagePointer outputPtr = this->GetOutput();
+  TImageType * inputPtr = const_cast< TImageType * >( this->GetInput() );
+  const TImageType * outputPtr = this->GetOutput();
 
   itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
-  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr );
 
   // We need to compute the input requested region (size and start index)
   unsigned int i;
@@ -191,11 +190,10 @@ FrequencyExpandViaInverseFFTImageFilter< TImageType >
   Superclass::GenerateOutputInformation();
 
   // Get pointers to the input and output
-  ImagePointer inputPtr =
-    const_cast< TImageType * >( this->GetInput() );
-  ImagePointer outputPtr = this->GetOutput();
+  const TImageType * inputPtr = this->GetInput();
+  TImageType * outputPtr = this->GetOutput();
 
-  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr );
   itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
 
   // We need to compute the output spacing, the output image size, and the

--- a/include/itkFrequencyShrinkImageFilter.hxx
+++ b/include/itkFrequencyShrinkImageFilter.hxx
@@ -325,8 +325,9 @@ FrequencyShrinkImageFilter< TImageType >
   Superclass::GenerateInputRequestedRegion();
 
   // get pointers to the input and output
-  ImagePointer inputPtr  = const_cast< TImageType * >(this->GetInput() );
-  ImagePointer outputPtr = this->GetOutput();
+  TImageType * inputPtr = const_cast< TImageType * >(this->GetInput() );
+
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
 
   // The filter chops high frequencys [0 1...H,H-1 H-2...1].
   // We need the whole input image, indepently of the RequestedRegion.
@@ -342,10 +343,10 @@ FrequencyShrinkImageFilter< TImageType >
   Superclass::GenerateOutputInformation();
 
   // Get pointers to the input and output
-  ImageConstPointer inputPtr  = this->GetInput();
-  ImagePointer outputPtr = this->GetOutput();
+  const TImageType * inputPtr = this->GetInput();
+  TImageType * outputPtr = this->GetOutput();
 
-  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr );
   itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
 
   // Compute the output spacing, the output image size, and the

--- a/include/itkFrequencyShrinkViaInverseFFTImageFilter.hxx
+++ b/include/itkFrequencyShrinkViaInverseFFTImageFilter.hxx
@@ -131,8 +131,9 @@ FrequencyShrinkViaInverseFFTImageFilter< TImageType >
   Superclass::GenerateInputRequestedRegion();
 
   // get pointers to the input and output
-  ImagePointer inputPtr  = const_cast< TImageType * >(this->GetInput() );
-  ImagePointer outputPtr = this->GetOutput();
+  TImageType * inputPtr = const_cast< TImageType * >(this->GetInput() );
+
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
 
   // The filter chops high frequencys [0 1...H,H-1 H-2...1].
   // We need the whole input image, indepently of the RequestedRegion.
@@ -148,10 +149,10 @@ FrequencyShrinkViaInverseFFTImageFilter< TImageType >
   Superclass::GenerateOutputInformation();
 
   // Get pointers to the input and output
-  ImageConstPointer inputPtr  = this->GetInput();
-  ImagePointer outputPtr = this->GetOutput();
+  const TImageType * inputPtr = this->GetInput();
+  TImageType * outputPtr = this->GetOutput();
 
-  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr );
   itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
 
   // Compute the output spacing, the output image size, and the

--- a/include/itkShrinkDecimateImageFilter.hxx
+++ b/include/itkShrinkDecimateImageFilter.hxx
@@ -158,11 +158,11 @@ ShrinkDecimateImageFilter< TInputImage, TOutputImage >
   Superclass::GenerateInputRequestedRegion();
 
   // Get pointers to the input and output
-  InputImagePointer inputPtr = const_cast< TInputImage * >( this->GetInput() );
-  OutputImagePointer outputPtr = this->GetOutput();
+  TInputImage * inputPtr = const_cast< TInputImage * >( this->GetInput() );
+  const TOutputImage * outputPtr = this->GetOutput();
 
   itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
-  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr );
 
   // Compute the input requested region (size and start index)
   // Use the image transformations to insure an input requested region
@@ -234,10 +234,10 @@ ShrinkDecimateImageFilter< TInputImage, TOutputImage >
   Superclass::GenerateOutputInformation();
 
   // Get pointers to the input and output
-  InputImageConstPointer inputPtr  = this->GetInput();
-  OutputImagePointer outputPtr = this->GetOutput();
+  const TInputImage * inputPtr = this->GetInput();
+  TOutputImage * outputPtr = this->GetOutput();
 
-  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr != ITK_NULLPTR );
+  itkAssertInDebugAndIgnoreInReleaseMacro( inputPtr );
   itkAssertInDebugAndIgnoreInReleaseMacro( outputPtr != ITK_NULLPTR );
 
   // Compute the output spacing, the output image size, and the


### PR DESCRIPTION
Address potential compiler errors related to const pointers trying to be
caste to int types.

The errors were originally reported to the ITK dashboards after Change Id
22423 had been merged:
https://open.cdash.org/viewBuildError.php?buildid=4954347

These were fixed in ITK by Change Id 22467,

Add the itkAssertInDebugAndIgnoreInReleaseMacro macro call where
appropriate for the sake of completeness.

Remove unnecessary calls to GetOutput().

Made the variable naming uniform for the sake of consistency.