### PR TITLE
ENH: Add undecimated wavelet steerable pyramid.

### DIFF
--- a/include/itkWaveletFrequencyFilterBankGenerator.h
+++ b/include/itkWaveletFrequencyFilterBankGenerator.h
@@ -88,6 +88,17 @@ public:
   itkSetMacro(InverseBank, bool);
   itkBooleanMacro( InverseBank );
 
+  /** Level to scale the wavelet function. Used in undecimated wavelet.
+   * /sa WaveletFrequencyForwardUndecimated
+   */
+  itkGetMacro(Level, unsigned int);
+  virtual void SetLevel(const unsigned int & level)
+  {
+    this->m_Level = level;
+    this->m_LevelFactor = std::pow(static_cast<double>(this->m_ScaleFactor),level);
+    this->Modified();
+  }
+
   /** Get pointer to the instance of the wavelet function in order to access and change wavelet parameters */
   itkGetModifiableObjectMacro(WaveletFunction, WaveletFunctionType);
 
@@ -123,6 +134,11 @@ private:
   unsigned int           m_HighPassSubBands;
   bool                   m_InverseBank;
   WaveletFunctionPointer m_WaveletFunction;
+  unsigned int           m_Level;
+  /** Default to 2 (Dyadic). No modifiable, but allow future extensions */
+  unsigned int           m_ScaleFactor;
+  /** m_ScaleFactor^m_Level */
+  double                 m_LevelFactor;
 }; // end of class
 } // end namespace itk
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/include/itkWaveletFrequencyFilterBankGenerator.hxx
+++ b/include/itkWaveletFrequencyFilterBankGenerator.hxx
@@ -26,7 +26,10 @@ template< typename TOutputImage, typename TWaveletFunction, typename TFrequencyR
 WaveletFrequencyFilterBankGenerator< TOutputImage, TWaveletFunction, TFrequencyRegionIterator >
 ::WaveletFrequencyFilterBankGenerator()
   : m_HighPassSubBands(0),
-  m_InverseBank(false)
+  m_InverseBank(false),
+  m_Level(0),
+  m_ScaleFactor(2),
+  m_LevelFactor(1)
 {
   this->SetHighPassSubBands(1);
   m_WaveletFunction = TWaveletFunction::New();
@@ -60,6 +63,8 @@ WaveletFrequencyFilterBankGenerator< TOutputImage, TWaveletFunction, TFrequencyR
 
   os << indent << "HighPassSubBands: " << this->m_HighPassSubBands
      << indent << "InverseBank: " << (this->m_InverseBank ? "true" : "false")
+     << indent << "Level: " << this->m_Level
+     << indent << "LevelFactor: " << this->m_LevelFactor
      << std::endl;
 }
 
@@ -168,8 +173,8 @@ WaveletFrequencyFilterBankGenerator< TOutputImage, TWaveletFunction, TFrequencyR
     for ( unsigned int l = 0; l < m_HighPassSubBands + 1; ++l )
       {
       evaluatedSubBand = this->m_InverseBank ?
-        this->m_WaveletFunction->EvaluateInverseSubBand(w, l) :
-        this->m_WaveletFunction->EvaluateForwardSubBand(w, l);
+        this->m_WaveletFunction->EvaluateInverseSubBand(this->m_LevelFactor * w, l) :
+        this->m_WaveletFunction->EvaluateForwardSubBand(this->m_LevelFactor * w, l);
 
       outputItList[l].Set( outputItList[l].Get()
         + static_cast< typename OutputImageType::PixelType::value_type >(evaluatedSubBand));

--- a/include/itkWaveletFrequencyForward.h
+++ b/include/itkWaveletFrequencyForward.h
@@ -122,7 +122,7 @@ public:
    * Return J: $ J = \text{min_element}\{J_0,\ldots, J_d\} $;
    * where each $J_i$ is the  number of integer divisions that can be done with the $i$ size and the scale factor.
    */
-  static unsigned int ComputeMaxNumberOfLevels(typename InputImageType::SizeType& input_size, unsigned int scaleFactor = 2);
+  static unsigned int ComputeMaxNumberOfLevels(const typename InputImageType::SizeType & input_size, const unsigned int scaleFactor = 2);
 
   /** (Level, band) pair.
    * Level from: [0, m_Levels), and equal to m_Levels only for the low_pass image.

--- a/include/itkWaveletFrequencyForward.hxx
+++ b/include/itkWaveletFrequencyForward.hxx
@@ -55,7 +55,7 @@ WaveletFrequencyForward< TInputImage, TOutputImage,
 ::OutputIndexToLevelBand(unsigned int linear_index)
 {
   return itk::utils::IndexToLevelBandSteerablePyramid(linear_index,
-      this->m_TotalOutputs, this->m_Levels, this->m_HighPassSubBands);
+      this->m_Levels, this->m_HighPassSubBands);
 };
 
 template< typename TInputImage,

--- a/include/itkWaveletFrequencyForward.hxx
+++ b/include/itkWaveletFrequencyForward.hxx
@@ -24,6 +24,7 @@
 #include <itkMultiplyImageFilter.h>
 #include <itkShrinkDecimateImageFilter.h>
 #include <itkChangeInformationImageFilter.h>
+#include <itkWaveletUtilities.h>
 
 namespace itk
 {
@@ -53,20 +54,8 @@ WaveletFrequencyForward< TInputImage, TOutputImage,
   TWaveletFilterBank, TFrequencyShrinkFilterType >
 ::OutputIndexToLevelBand(unsigned int linear_index)
 {
-  if ( linear_index > this->m_TotalOutputs - 1 || linear_index < 0 )
-    {
-    itkExceptionMacro(<< "Failed converting liner index " << linear_index
-                      << " to Level,Band pair : out of bounds");
-    }
-  // Low pass (band = 0).
-  // if (linear_index == this->m_TotalOutputs - 1 )
-  //   return std::make_pair(this->m_Levels, 0);
-
-  unsigned int band = (linear_index ) % this->m_HighPassSubBands;
-  // note integer division ahead.
-  unsigned int level = (linear_index ) / this->m_HighPassSubBands;
-  itkAssertInDebugAndIgnoreInReleaseMacro( level >= 0 );
-  return std::make_pair(level, band);
+  return itk::utils::IndexToLevelBandSteerablePyramid(linear_index,
+      this->m_TotalOutputs, this->m_Levels, this->m_HighPassSubBands);
 };
 
 template< typename TInputImage,
@@ -149,44 +138,10 @@ template< typename TInputImage,
 unsigned int
 WaveletFrequencyForward< TInputImage, TOutputImage,
   TWaveletFilterBank, TFrequencyShrinkFilterType >
-::ComputeMaxNumberOfLevels(typename InputImageType::SizeType& inputSize, unsigned int scaleFactor)
+::ComputeMaxNumberOfLevels(const typename InputImageType::SizeType & inputSize,
+    const unsigned int scaleFactor)
 {
-  FixedArray< unsigned int, ImageDimension > exponentPerAxis;
-  exponentPerAxis.Fill(1);
-  for ( unsigned int axis = 0; axis < ImageDimension; ++axis )
-    {
-    size_t sizeAxis = inputSize[axis];
-    double exponent = std::log(sizeAxis) / std::log(static_cast< double >(scaleFactor));
-    // check that exponent is integer: the fractional part is 0
-    double exponentIntPart;
-    double exponentFractionPart = std::modf(exponent, &exponentIntPart );
-    if ( exponentFractionPart == 0 )
-      {
-      exponentPerAxis[axis] = static_cast< unsigned int >(exponent);
-      }
-    else
-      {
-      // increase valid levels until the division size/scale_factor gives a non-integer.
-      double sizeAtLevel = static_cast<double>(sizeAxis);
-      for (;;)
-        {
-        double division = sizeAtLevel / static_cast<double>(scaleFactor);
-        double intPartDivision;
-        double fractionPartDivision = std::modf(division, &intPartDivision );
-        if ( fractionPartDivision == 0 )
-          {
-          exponentPerAxis[axis]++;
-          sizeAtLevel = intPartDivision;
-          }
-        else
-          {
-          break;
-          }
-        }
-      }
-    }
-  // return the min_element of array (1 if any size is not power of 2)
-  return *std::min_element(exponentPerAxis.Begin(), exponentPerAxis.End());
+  return itk::utils::ComputeMaxNumberOfLevels(inputSize, scaleFactor);
 }
 
 template< typename TInputImage,

--- a/include/itkWaveletFrequencyForwardUndecimated.h
+++ b/include/itkWaveletFrequencyForwardUndecimated.h
@@ -115,7 +115,7 @@ public:
    * Return J: $ J = \text{min_element}\{J_0,\ldots, J_d\} $;
    * where each $J_i$ is the  number of integer divisions that can be done with the $i$ size and the scale factor.
    */
-  static unsigned int ComputeMaxNumberOfLevels(typename InputImageType::SizeType& input_size, unsigned int scaleFactor = 2);
+  static unsigned int ComputeMaxNumberOfLevels(const typename InputImageType::SizeType & input_size, const unsigned int scaleFactor = 2);
 
   /** (Level, band) pair.
    * Level from: [0, m_Levels), and equal to m_Levels only for the low_pass image.
@@ -153,14 +153,14 @@ protected:
    * below.
    * \sa ProcessObject::GenerateOutputInformaton()
    */
-  // virtual void GenerateOutputInformation() ITK_OVERRIDE;
+  virtual void GenerateOutputInformation() ITK_OVERRIDE;
 
   /** Given one output whose requested region has been set, this method sets
    * the requested region for the remaining output images.  The original
    * documentation of this method is below.
    * \sa ProcessObject::GenerateOutputRequestedRegion()
    */
-  // virtual void GenerateOutputRequestedRegion(DataObject *output) ITK_OVERRIDE;
+  virtual void GenerateOutputRequestedRegion(DataObject *output) ITK_OVERRIDE;
 
   /** WaveletFrequencyForwardUndecimated requires a larger input requested
    * region than the output requested regions to accommodate the shrinkage and
@@ -169,7 +169,7 @@ protected:
    * original documentation of this method is below.
    * \sa ProcessObject::GenerateInputRequestedRegion()
    */
-  // virtual void GenerateInputRequestedRegion() ITK_OVERRIDE;
+  virtual void GenerateInputRequestedRegion() ITK_OVERRIDE;
 
 private:
   ITK_DISALLOW_COPY_AND_ASSIGN(WaveletFrequencyForwardUndecimated);

--- a/include/itkWaveletFrequencyForwardUndecimated.h
+++ b/include/itkWaveletFrequencyForwardUndecimated.h
@@ -49,7 +49,7 @@ class WaveletFrequencyForwardUndecimated:
 {
 public:
   /** Standard typenames typedefs. */
-  typedef WaveletFrequencyForwardUndecimated                         Self;
+  typedef WaveletFrequencyForwardUndecimated              Self;
   typedef ImageToImageFilter< TInputImage, TOutputImage > Superclass;
   typedef SmartPointer< Self >                            Pointer;
   typedef SmartPointer< const Self >                      ConstPointer;

--- a/include/itkWaveletFrequencyForwardUndecimated.h
+++ b/include/itkWaveletFrequencyForwardUndecimated.h
@@ -1,0 +1,190 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkWaveletFrequencyForwardUndecimated_h
+#define itkWaveletFrequencyForwardUndecimated_h
+
+#include <itkImageRegionConstIterator.h>
+#include <itkImageRegionIterator.h>
+#include <itkImageConstIterator.h>
+#include <complex>
+#include <itkFixedArray.h>
+#include <itkImageToImageFilter.h>
+
+namespace itk
+{
+/** \class WaveletFrequencyForwardUndecimated
+ * @brief IsotropicWavelet multiscale analysis where input is an image in the frequency domain.
+ * Output Layout:
+ * Output 0 is the residual low pass filtered of the last level/scale.
+ * [0]: Low pass residual, also called approximation.
+ * [1,..,HighPassBands]: Wavelet coef of first level.
+ * [HighPassBands + 1,..,l*HighPassBands]: Wavelet coef of l level.
+ *
+ * @note The information/metadata of input image is ignored.
+ * It can be restored after reconstruction @sa WaveletFrequencyInverse
+ * with a @sa ChangeInformationFilter using the input image as a reference.
+ *
+ * \ingroup IsotropicWavelets
+ */
+template< typename TInputImage,
+ typename TOutputImage,
+ typename TWaveletFilterBank >
+class WaveletFrequencyForwardUndecimated:
+  public ImageToImageFilter< TInputImage, TOutputImage>
+{
+public:
+  /** Standard typenames typedefs. */
+  typedef WaveletFrequencyForwardUndecimated                         Self;
+  typedef ImageToImageFilter< TInputImage, TOutputImage > Superclass;
+  typedef SmartPointer< Self >                            Pointer;
+  typedef SmartPointer< const Self >                      ConstPointer;
+
+  /** Inherit types from Superclass. */
+  typedef typename Superclass::InputImageType         InputImageType;
+  typedef typename Superclass::OutputImageType        OutputImageType;
+  typedef typename Superclass::InputImagePointer      InputImagePointer;
+  typedef typename Superclass::OutputImagePointer     OutputImagePointer;
+  typedef typename Superclass::InputImageConstPointer InputImageConstPointer;
+
+  typedef typename std::vector<OutputImagePointer> OutputsType;
+
+  typedef typename itk::ImageRegionIterator<OutputImageType>     OutputRegionIterator;
+  typedef typename itk::ImageRegionConstIterator<InputImageType> InputRegionConstIterator;
+  typedef typename OutputImageType::RegionType                   OutputImageRegionType;
+
+  typedef TWaveletFilterBank                                  WaveletFilterBankType;
+  typedef typename WaveletFilterBankType::Pointer             WaveletFilterBankPointer;
+  typedef typename WaveletFilterBankType::WaveletFunctionType WaveletFunctionType;
+  typedef typename WaveletFilterBankType::FunctionValueType   FunctionValueType;
+
+  /** ImageDimension constants */
+  itkStaticConstMacro(ImageDimension, unsigned int,
+                      TInputImage::ImageDimension);
+
+  /** Standard New method. */
+  itkNewMacro(Self);
+
+  /** Runtime information support. */
+  itkTypeMacro(WaveletFrequencyForwardUndecimated,
+               ImageToImageFilter);
+  virtual void SetLevels(unsigned int n);
+
+  itkGetConstReferenceMacro(Levels, unsigned int);
+  virtual void SetHighPassSubBands(unsigned int n);
+
+  itkGetConstReferenceMacro(HighPassSubBands, unsigned int);
+  itkGetConstReferenceMacro(TotalOutputs, unsigned int);
+
+  /** ScaleFactor for each level in the pyramid.
+   * Set to 2 (dyadic) at constructor and not modifiable, but provides future flexibility */
+  itkGetConstReferenceMacro(ScaleFactor, unsigned int);
+  // itkSetMacro(ScaleFactor, unsigned int);
+
+  /** Return modifiable pointer of the wavelet filter bank member. */
+  itkGetModifiableObjectMacro(WaveletFilterBank, WaveletFilterBankType);
+  /** Return modifiable pointer to the wavelet function, which is a member of wavelet filter bank. */
+  virtual WaveletFunctionType * GetModifiableWaveletFunction()
+  {
+    return this->GetModifiableWaveletFilterBank()->GetModifiableWaveletFunction();
+  }
+
+  /** Flag to store the wavelet Filter Bank Pyramid, for all levels and all bands.
+   * Access to it with GetWaveletFilterBankPyramid()*/
+  itkSetMacro(StoreWaveletFilterBankPyramid, bool)
+  itkGetMacro(StoreWaveletFilterBankPyramid, bool)
+  itkBooleanMacro(StoreWaveletFilterBankPyramid);
+
+  itkGetMacro(WaveletFilterBankPyramid, std::vector<OutputImagePointer>);
+
+  /** Compute max number of levels depending on the size of the image.
+   * Return J: $ J = \text{min_element}\{J_0,\ldots, J_d\} $;
+   * where each $J_i$ is the  number of integer divisions that can be done with the $i$ size and the scale factor.
+   */
+  static unsigned int ComputeMaxNumberOfLevels(typename InputImageType::SizeType& input_size, unsigned int scaleFactor = 2);
+
+  /** (Level, band) pair.
+   * Level from: [0, m_Levels), and equal to m_Levels only for the low_pass image.
+   * band from [0, m_HighPassSubbands) */
+  typedef std::pair<unsigned int, unsigned int> IndexPairType;
+  /** Get the (Level,Band) from a linear index output.
+   * The index corresponding to the low-pass image is the last one, corresponding to the IndexPairType(this->GetLevels(), 0).
+   */
+  IndexPairType OutputIndexToLevelBand(unsigned int linear_index);
+
+  /** Retrieve outputs */
+  OutputsType GetOutputs();
+
+  OutputsType GetOutputsHighPass();
+
+  OutputImagePointer GetOutputLowPass();
+
+  OutputsType GetOutputsHighPassByLevel(unsigned int level);
+
+protected:
+  WaveletFrequencyForwardUndecimated();
+  ~WaveletFrequencyForwardUndecimated() {}
+  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
+
+  /** Single-threaded version of GenerateData. */
+  void GenerateData() ITK_OVERRIDE;
+
+  /************ Information *************/
+
+  /** WaveletFrequencyForwardUndecimated produces images which are of
+   * different resolution and different pixel spacing than its input image.
+   * As such, WaveletFrequencyForwardUndecimated needs to provide an
+   * implementation for GenerateOutputInformation() in order to inform the
+   * pipeline execution model.  The original documentation of this method is
+   * below.
+   * \sa ProcessObject::GenerateOutputInformaton()
+   */
+  // virtual void GenerateOutputInformation() ITK_OVERRIDE;
+
+  /** Given one output whose requested region has been set, this method sets
+   * the requested region for the remaining output images.  The original
+   * documentation of this method is below.
+   * \sa ProcessObject::GenerateOutputRequestedRegion()
+   */
+  // virtual void GenerateOutputRequestedRegion(DataObject *output) ITK_OVERRIDE;
+
+  /** WaveletFrequencyForwardUndecimated requires a larger input requested
+   * region than the output requested regions to accommodate the shrinkage and
+   * smoothing operations. As such, WaveletFrequencyForwardUndecimated needs
+   * to provide an implementation for GenerateInputRequestedRegion().  The
+   * original documentation of this method is below.
+   * \sa ProcessObject::GenerateInputRequestedRegion()
+   */
+  // virtual void GenerateInputRequestedRegion() ITK_OVERRIDE;
+
+private:
+  ITK_DISALLOW_COPY_AND_ASSIGN(WaveletFrequencyForwardUndecimated);
+
+  unsigned int                    m_Levels;
+  unsigned int                    m_HighPassSubBands;
+  unsigned int                    m_TotalOutputs;
+  unsigned int                    m_ScaleFactor;
+  WaveletFilterBankPointer        m_WaveletFilterBank;
+  bool                            m_StoreWaveletFilterBankPyramid;
+  std::vector<OutputImagePointer> m_WaveletFilterBankPyramid;
+};
+} // end namespace itk
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkWaveletFrequencyForwardUndecimated.hxx"
+#endif
+
+#endif

--- a/include/itkWaveletFrequencyForwardUndecimated.hxx
+++ b/include/itkWaveletFrequencyForwardUndecimated.hxx
@@ -52,7 +52,7 @@ WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
 ::OutputIndexToLevelBand(unsigned int linear_index)
 {
   return itk::utils::IndexToLevelBandSteerablePyramid(linear_index,
-      this->m_TotalOutputs, this->m_Levels, this->m_HighPassSubBands);
+      this->m_Levels, this->m_HighPassSubBands);
 };
 
 template< typename TInputImage,

--- a/include/itkWaveletFrequencyForwardUndecimated.hxx
+++ b/include/itkWaveletFrequencyForwardUndecimated.hxx
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <itkMultiplyImageFilter.h>
 #include <itkChangeInformationImageFilter.h>
+#include <itkWaveletUtilities.h>
 
 namespace itk
 {
@@ -50,20 +51,8 @@ WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
   TWaveletFilterBank >
 ::OutputIndexToLevelBand(unsigned int linear_index)
 {
-  if ( linear_index > this->m_TotalOutputs - 1 || linear_index < 0 )
-    {
-    itkExceptionMacro(<< "Failed converting liner index " << linear_index
-                      << " to Level,Band pair : out of bounds");
-    }
-  // Low pass (band = 0).
-  // if (linear_index == this->m_TotalOutputs - 1 )
-  //   return std::make_pair(this->m_Levels, 0);
-
-  unsigned int band = (linear_index ) % this->m_HighPassSubBands;
-  // note integer division ahead.
-  unsigned int level = (linear_index ) / this->m_HighPassSubBands;
-  itkAssertInDebugAndIgnoreInReleaseMacro( level >= 0 );
-  return std::make_pair(level, band);
+  return itk::utils::IndexToLevelBandSteerablePyramid(linear_index,
+      this->m_TotalOutputs, this->m_Levels, this->m_HighPassSubBands);
 };
 
 template< typename TInputImage,
@@ -141,44 +130,9 @@ template< typename TInputImage,
 unsigned int
 WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
   TWaveletFilterBank >
-::ComputeMaxNumberOfLevels(typename InputImageType::SizeType& inputSize, unsigned int scaleFactor)
+::ComputeMaxNumberOfLevels(const typename InputImageType::SizeType & inputSize, const unsigned int scaleFactor)
 {
-  FixedArray< unsigned int, ImageDimension > exponentPerAxis;
-  exponentPerAxis.Fill(1);
-  for ( unsigned int axis = 0; axis < ImageDimension; ++axis )
-    {
-    size_t sizeAxis = inputSize[axis];
-    double exponent = std::log(sizeAxis) / std::log(static_cast< double >(scaleFactor));
-    // check that exponent is integer: the fractional part is 0
-    double exponentIntPart;
-    double exponentFractionPart = std::modf(exponent, &exponentIntPart );
-    if ( exponentFractionPart == 0 )
-      {
-      exponentPerAxis[axis] = static_cast< unsigned int >(exponent);
-      }
-    else
-      {
-      // increase valid levels until the division size/scale_factor gives a non-integer.
-      double sizeAtLevel = static_cast<double>(sizeAxis);
-      for (;;)
-        {
-        double division = sizeAtLevel / static_cast<double>(scaleFactor);
-        double intPartDivision;
-        double fractionPartDivision = std::modf(division, &intPartDivision );
-        if ( fractionPartDivision == 0 )
-          {
-          exponentPerAxis[axis]++;
-          sizeAtLevel = intPartDivision;
-          }
-        else
-          {
-          break;
-          }
-        }
-      }
-    }
-  // return the min_element of array (1 if any size is not power of 2)
-  return *std::min_element(exponentPerAxis.Begin(), exponentPerAxis.End());
+  return itk::utils::ComputeMaxNumberOfLevels(inputSize, scaleFactor);
 }
 
 template< typename TInputImage,
@@ -240,257 +194,118 @@ WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
      << std::endl;
 }
 
-// template< typename TInputImage,
-//   typename TOutputImage,
-//   typename TWaveletFilterBank,
-//   typename TFrequencyShrinkFilterType >
-// void
-// WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
-//   TWaveletFilterBank >
-// ::GenerateOutputInformation()
-// {
-//   // call the superclass's implementation of this method
-//   Superclass::GenerateOutputInformation();
-//
-//   // get pointers to the input and output
-//   InputImageConstPointer inputPtr = this->GetInput();
-//
-//   if ( !inputPtr )
-//     {
-//     itkExceptionMacro(<< "Input has not been set");
-//     }
-//
-//   typename InputImageType::SizeType inputSize =
-//     inputPtr->GetLargestPossibleRegion().GetSize();
-//   typename InputImageType::IndexType inputStartIndex =
-//     inputPtr->GetLargestPossibleRegion().GetIndex();
-//   #<{(|* inputOrigin and inputSpacing is lost and should be restored
-//    * at the end of the inverse wavelet transform. |)}>#
-//   typename OutputImageType::PointType inputModifiedOrigin(0);
-//   typename OutputImageType::SpacingType inputModifiedSpacing(1);
-//   // typename OutputImageType::DirectionType outputDirection = inputDirection;
-//
-//   OutputImagePointer outputPtr;
-//   typename OutputImageType::SizeType inputSizePerLevel = inputSize;
-//   typename OutputImageType::IndexType inputStartIndexPerLevel = inputStartIndex;
-//   typename OutputImageType::PointType inputOriginPerLevel = inputModifiedOrigin;
-//   typename OutputImageType::SpacingType inputSpacingPerLevel = inputModifiedSpacing;
-//   // typename OutputImageType::DirectionType inputDirectionPerLevel = inputDirection;
-//   // we need to compute the output spacing, the output image size,
-//   // and the output image start index
-//   for ( unsigned int level = 0; level < this->m_Levels; ++level )
-//     {
-//     // Bands per level . No downsampling in the first level iteration.
-//     for ( unsigned int band = 0; band < this->m_HighPassSubBands; ++band )
-//       {
-//       unsigned int current_output = level * m_HighPassSubBands + band;
-//       outputPtr = this->GetOutput(current_output);
-//       if ( !outputPtr )
-//         {
-//         continue;
-//         }
-//       typename OutputImageType::RegionType largestPossibleRegion;
-//       largestPossibleRegion.SetSize(inputSizePerLevel);
-//       largestPossibleRegion.SetIndex(inputStartIndexPerLevel);
-//       outputPtr->SetLargestPossibleRegion(largestPossibleRegion);
-//       outputPtr->SetOrigin(inputOriginPerLevel);
-//       outputPtr->SetSpacing(inputSpacingPerLevel);
-//       // outputPtr->SetDirection(outputDirection);
-//       }
-//     // Calculate for next levels new Size and Index, per dim.
-//     for ( unsigned int idim = 0; idim < OutputImageType::ImageDimension; idim++ )
-//       {
-//       // Size divided by scale
-//       inputSizePerLevel[idim] = static_cast< SizeValueType >(
-//           std::floor(static_cast< double >(inputSizePerLevel[idim]) / this->m_ScaleFactor));
-//       if ( inputSizePerLevel[idim] < 1 )
-//         {
-//         inputSizePerLevel[idim] = 1;
-//         }
-//       // Index dividided by scale
-//       inputStartIndexPerLevel[idim] = static_cast< IndexValueType >(
-//           std::ceil(static_cast< double >(inputStartIndexPerLevel[idim]) / this->m_ScaleFactor));
-//       // Spacing
-//       inputSpacingPerLevel[idim] = inputSpacingPerLevel[idim] * this->m_ScaleFactor;
-//       // Origin, the same.
-//       // inputOriginPerLevel[idim] = inputOriginPerLevel[idim] ;
-//       // inputOriginPerLevel[idim] = inputOriginPerLevel[idim] / this->m_ScaleFactor;
-//       }
-//
-//     // Set the low pass at the end.
-//     if ( level == this->m_Levels - 1 )
-//       {
-//       outputPtr = this->GetOutput(this->m_TotalOutputs - 1);
-//       if ( !outputPtr )
-//         {
-//         continue;
-//         }
-//       typename OutputImageType::RegionType largestPossibleRegion;
-//       largestPossibleRegion.SetSize(inputSizePerLevel);
-//       largestPossibleRegion.SetIndex(inputStartIndexPerLevel);
-//       outputPtr->SetLargestPossibleRegion(largestPossibleRegion);
-//       outputPtr->SetOrigin(inputOriginPerLevel);
-//       outputPtr->SetSpacing(inputSpacingPerLevel);
-//       // outputPtr->SetDirection(inputDirectionPerLevel);
-//       }
-//     }
-// }
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::GenerateOutputInformation()
+{
+  // call the superclass's implementation of this method
+  Superclass::GenerateOutputInformation();
 
-// template< typename TInputImage,
-//   typename TOutputImage,
-//   typename TWaveletFilterBank,
-//   typename TFrequencyShrinkFilterType >
-// void
-// WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
-//   TWaveletFilterBank >
-// ::GenerateOutputRequestedRegion(DataObject *refOutput)
-// {
-//   // call the superclass's implementation of this method
-//   Superclass::GenerateOutputRequestedRegion(refOutput);
-//
-//   // find the index for this output
-//   unsigned int refIndex =
-//     static_cast< unsigned int >(refOutput->GetSourceOutputIndex());
-//   std::pair< unsigned int, unsigned int > pairRef =
-//     this->OutputIndexToLevelBand(refIndex);
-//   unsigned int refLevel = pairRef.first;
-//   // unsigned int refBand  = pairRef.second;
-//
-//   // compute baseIndex and baseSize
-//   typedef typename OutputImageType::SizeType   SizeType;
-//   typedef typename OutputImageType::IndexType  IndexType;
-//   typedef typename OutputImageType::RegionType RegionType;
-//
-//   TOutputImage *ptr = itkDynamicCastInDebugMode< TOutputImage * >(refOutput);
-//   if ( !ptr )
-//     {
-//     itkExceptionMacro(<< "Could not cast refOutput to TOutputImage*.");
-//     }
-//
-//   if ( ptr->GetRequestedRegion() == ptr->GetLargestPossibleRegion() )
-//     {
-//     // set the requested regions for the other outputs to their largest
-//     for ( unsigned int nout = 0; nout < this->m_TotalOutputs; ++nout )
-//       {
-//       if ( nout == refIndex )
-//         {
-//         continue;
-//         }
-//       if ( !this->GetOutput(nout) )
-//         {
-//         continue;
-//         }
-//       this->GetOutput(nout)->SetRequestedRegionToLargestPossibleRegion();
-//       }
-//     }
-//   else
-//     {
-//     // compute requested regions for the other outputs based on
-//     // the requested region of the reference output
-//     IndexType outputIndex;
-//     SizeType outputSize;
-//     RegionType outputRegion;
-//     RegionType baseRegion = ptr->GetRequestedRegion();
-//     IndexType baseIndex  = baseRegion.GetIndex();
-//     SizeType baseSize   = baseRegion.GetSize();
-//     for ( unsigned int level = 0; level < this->m_Levels + 1; ++level )
-//       {
-//       int distanceToReferenceLevel = static_cast< int >(refLevel) - static_cast< int >(level);
-//       for ( unsigned int idim = 0; idim < TOutputImage::ImageDimension; idim++ )
-//         {
-//         outputIndex[idim] = baseIndex[idim]
-//           * static_cast< IndexValueType >(std::pow(static_cast< double >(this->m_ScaleFactor),
-//                                             distanceToReferenceLevel));
-//         outputSize[idim] = baseSize[idim]
-//           * static_cast< SizeValueType >(std::pow(static_cast< double >(this->m_ScaleFactor),
-//                                            distanceToReferenceLevel));
-//         if ( outputSize[idim] < 1 )
-//           {
-//           itkExceptionMacro( << "Failure at level: " << level
-//                              << " in forward wavelet, going to negative image size. Too many levels for input image size.");
-//           }
-//         }
-//       outputRegion.SetIndex(outputIndex);
-//       outputRegion.SetSize(outputSize);
-//
-//       // Set low pass output
-//       if ( level == this->m_Levels )
-//         {
-//         unsigned int n_output = this->m_TotalOutputs - 1;
-//         if ( n_output == refIndex )
-//           {
-//           continue;
-//           }
-//         if ( !this->GetOutput(n_output) )
-//           {
-//           continue;
-//           }
-//         outputRegion.Crop(this->GetOutput(n_output)->GetLargestPossibleRegion());
-//         this->GetOutput(n_output)->SetRequestedRegion(outputRegion);
-//         }
-//       else // Bands per level
-//         {
-//         for ( unsigned int band = 0; band < this->m_HighPassSubBands; ++band )
-//           {
-//           unsigned int n_output = level * this->m_HighPassSubBands + band;
-//           if ( n_output == refIndex )
-//             {
-//             continue;
-//             }
-//           if ( !this->GetOutput(n_output) )
-//             {
-//             continue;
-//             }
-//           outputRegion.Crop(this->GetOutput(n_output)->GetLargestPossibleRegion());
-//           // set the requested region
-//           this->GetOutput(n_output)->SetRequestedRegion(outputRegion);
-//           }
-//         }
-//       }
-//     }
-// }
+  // get pointers to the input and output
+  InputImageConstPointer inputPtr = this->GetInput();
 
-// template< typename TInputImage,
-//   typename TOutputImage,
-//   typename TWaveletFilterBank,
-//   typename TFrequencyShrinkFilterType >
-// void
-// WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
-//   TWaveletFilterBank >
-// ::GenerateInputRequestedRegion()
-// {
-//   // call the superclass' implementation of this method
-//   Superclass::GenerateInputRequestedRegion();
-//
-//   // get pointers to the input and output
-//   InputImagePointer inputPtr = const_cast< InputImageType * >(this->GetInput());
-//   if ( !inputPtr )
-//     {
-//     itkExceptionMacro(<< "Input has not been set.");
-//     }
-//
-//   // compute baseIndex and baseSize
-//   typedef typename OutputImageType::SizeType   SizeType;
-//   typedef typename OutputImageType::IndexType  IndexType;
-//   typedef typename OutputImageType::RegionType RegionType;
-//
-//   // The first level has the same size than input.
-//   // At least one band is ensured to exist, so use it.
-//   unsigned int refOutput = 0;
-//   SizeType baseSize  = this->GetOutput(refOutput)->GetRequestedRegion().GetSize();
-//   IndexType baseIndex =
-//     this->GetOutput(refOutput)->GetRequestedRegion().GetIndex();
-//   RegionType baseRegion;
-//
-//   baseRegion.SetIndex(baseIndex);
-//   baseRegion.SetSize(baseSize);
-//
-//   // make sure the requested region is within the largest possible
-//   baseRegion.Crop(inputPtr->GetLargestPossibleRegion());
-//
-//   // set the input requested region
-//   inputPtr->SetRequestedRegion(baseRegion);
-// }
+  if ( !inputPtr )
+    {
+    itkExceptionMacro(<< "Input has not been set");
+    }
+
+  /** inputOrigin and inputSpacing is lost and should be restored
+   * at the end of the inverse wavelet transform. */
+  typename OutputImageType::PointType inputModifiedOrigin(0);
+  typename OutputImageType::SpacingType inputModifiedSpacing(1);
+  // typename OutputImageType::DirectionType outputDirection = inputDirection;
+
+  OutputImagePointer outputPtr;
+  for ( unsigned int nOutput = 0; nOutput < this->m_TotalOutputs; ++nOutput )
+    {
+      outputPtr = this->GetOutput(nOutput);
+      if ( !outputPtr )
+        {
+        continue;
+        }
+      outputPtr->SetLargestPossibleRegion(inputPtr->GetLargestPossibleRegion());
+      outputPtr->SetOrigin(inputModifiedOrigin);
+      outputPtr->SetSpacing(inputModifiedSpacing);
+      outputPtr->SetDirection(inputPtr->GetDirection());
+    }
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::GenerateOutputRequestedRegion(DataObject *refOutput)
+{
+  // call the superclass's implementation of this method
+  Superclass::GenerateOutputRequestedRegion(refOutput);
+
+  // find the index for this output
+  unsigned int refIndex =
+    static_cast< unsigned int >(refOutput->GetSourceOutputIndex());
+
+  TOutputImage *ptr = itkDynamicCastInDebugMode< TOutputImage * >(refOutput);
+  if ( !ptr )
+    {
+    itkExceptionMacro(<< "Could not cast refOutput to TOutputImage*.");
+    }
+
+  for ( unsigned int nOutput = 0; nOutput < this->m_TotalOutputs; ++nOutput )
+    {
+    if ( nOutput == refIndex )
+      {
+      continue;
+      }
+    if ( !this->GetOutput(nOutput) )
+      {
+      continue;
+      }
+    this->GetOutput(nOutput)->SetRequestedRegion(ptr->GetRequestedRegion());
+    }
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::GenerateInputRequestedRegion()
+{
+  // call the superclass' implementation of this method
+  Superclass::GenerateInputRequestedRegion();
+
+  // get pointers to the input and output
+  InputImagePointer inputPtr = const_cast< InputImageType * >(this->GetInput());
+  if ( !inputPtr )
+    {
+    itkExceptionMacro(<< "Input has not been set.");
+    }
+
+  // compute baseIndex and baseSize
+  typedef typename OutputImageType::SizeType   SizeType;
+  typedef typename OutputImageType::IndexType  IndexType;
+  typedef typename OutputImageType::RegionType RegionType;
+
+  // All the levels and subbands have the same size.
+  // At least one band is ensured to exist, so use it.
+  unsigned int refOutput = 0;
+  SizeType baseSize  = this->GetOutput(refOutput)->GetRequestedRegion().GetSize();
+  IndexType baseIndex =
+    this->GetOutput(refOutput)->GetRequestedRegion().GetIndex();
+  RegionType baseRegion;
+
+  baseRegion.SetIndex(baseIndex);
+  baseRegion.SetSize(baseSize);
+
+  // set the input requested region
+  inputPtr->SetRequestedRegion(baseRegion);
+}
 
 template< typename TInputImage,
   typename TOutputImage,
@@ -537,6 +352,10 @@ WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
   std::vector< OutputImagePointer > highPassWavelets = this->m_WaveletFilterBank->GetOutputsHighPassBands();
   OutputImagePointer lowPassWavelet = this->m_WaveletFilterBank->GetOutputLowPass();
   lowPassWavelet->DisconnectPipeline();
+  for ( unsigned int band = 0; band < this->m_HighPassSubBands; ++band )
+    {
+    highPassWavelets[band]->DisconnectPipeline();
+    }
 
   if ( this->m_StoreWaveletFilterBankPyramid )
     {
@@ -587,6 +406,7 @@ WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
     multiplyLowFilter->SetInput1(lowPassWavelet);
     multiplyLowFilter->SetInput2(inputPerLevel);
     // multiplyLowFilter->InPlaceOn();
+    multiplyLowFilter->Update();
     if ( level == this->m_Levels - 1 ) // Set low_pass output (index=this->m_TotalOutputs - 1)
       {
       this->GraftNthOutput(this->m_TotalOutputs - 1, multiplyLowFilter->GetOutput());
@@ -596,7 +416,6 @@ WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
       }
     else // update inputPerLevel
       {
-      multiplyLowFilter->Update();
       inputPerLevel = multiplyLowFilter->GetOutput();
       /******* Downsample (scale) wavelets *****/
       m_WaveletFilterBank->SetLevel(level + 1);

--- a/include/itkWaveletFrequencyForwardUndecimated.hxx
+++ b/include/itkWaveletFrequencyForwardUndecimated.hxx
@@ -1,0 +1,624 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkWaveletFrequencyForwardUndecimated_hxx
+#define itkWaveletFrequencyForwardUndecimated_hxx
+#include <itkWaveletFrequencyForwardUndecimated.h>
+#include <itkCastImageFilter.h>
+#include <itkImage.h>
+#include <algorithm>
+#include <itkMultiplyImageFilter.h>
+#include <itkChangeInformationImageFilter.h>
+
+namespace itk
+{
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::WaveletFrequencyForwardUndecimated()
+  : m_Levels(1),
+  m_HighPassSubBands(1),
+  m_TotalOutputs(1),
+  m_ScaleFactor(2),
+  m_StoreWaveletFilterBankPyramid(false)
+{
+  this->SetNumberOfRequiredInputs(1);
+  m_WaveletFilterBank = WaveletFilterBankType::New();
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+std::pair< unsigned int, unsigned int >
+WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::OutputIndexToLevelBand(unsigned int linear_index)
+{
+  if ( linear_index > this->m_TotalOutputs - 1 || linear_index < 0 )
+    {
+    itkExceptionMacro(<< "Failed converting liner index " << linear_index
+                      << " to Level,Band pair : out of bounds");
+    }
+  // Low pass (band = 0).
+  // if (linear_index == this->m_TotalOutputs - 1 )
+  //   return std::make_pair(this->m_Levels, 0);
+
+  unsigned int band = (linear_index ) % this->m_HighPassSubBands;
+  // note integer division ahead.
+  unsigned int level = (linear_index ) / this->m_HighPassSubBands;
+  itkAssertInDebugAndIgnoreInReleaseMacro( level >= 0 );
+  return std::make_pair(level, band);
+};
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+std::vector< typename WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+    TWaveletFilterBank >::OutputImagePointer >
+WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::GetOutputs()
+{
+  std::vector< OutputImagePointer > outputPtrs;
+  for ( unsigned int nout = 0; nout < this->m_TotalOutputs; ++nout )
+    {
+    outputPtrs.push_back(this->GetOutput(nout));
+    }
+  return outputPtrs;
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+std::vector< typename WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+    TWaveletFilterBank >::OutputImagePointer >
+WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::GetOutputsHighPass()
+{
+  std::vector< OutputImagePointer > outputPtrs;
+  for ( unsigned int nout = 1; nout < this->m_TotalOutputs; ++nout )
+    {
+    outputPtrs.push_back(this->GetOutput(nout));
+    }
+  return outputPtrs;
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+typename WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >::OutputImagePointer
+WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::GetOutputLowPass()
+{
+  return this->GetOutput(this->m_TotalOutputs - 1);
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+std::vector< typename WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+    TWaveletFilterBank >::OutputImagePointer >
+WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::GetOutputsHighPassByLevel(unsigned int level)
+{
+  std::vector< OutputImagePointer > outputPtrs;
+  unsigned int nOutput_start =  level * this->m_HighPassSubBands;
+  unsigned int nOutput_end   = (level + 1) * this->m_HighPassSubBands;
+  if ( nOutput_end > this->m_TotalOutputs )
+    {
+    nOutput_end = this->m_TotalOutputs;
+    }
+  for ( unsigned int nOutput = nOutput_start; nOutput < nOutput_end; ++nOutput )
+    {
+    outputPtrs.push_back(this->GetOutput(nOutput));
+    }
+  return outputPtrs;
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+unsigned int
+WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::ComputeMaxNumberOfLevels(typename InputImageType::SizeType& inputSize, unsigned int scaleFactor)
+{
+  FixedArray< unsigned int, ImageDimension > exponentPerAxis;
+  exponentPerAxis.Fill(1);
+  for ( unsigned int axis = 0; axis < ImageDimension; ++axis )
+    {
+    size_t sizeAxis = inputSize[axis];
+    double exponent = std::log(sizeAxis) / std::log(static_cast< double >(scaleFactor));
+    // check that exponent is integer: the fractional part is 0
+    double exponentIntPart;
+    double exponentFractionPart = std::modf(exponent, &exponentIntPart );
+    if ( exponentFractionPart == 0 )
+      {
+      exponentPerAxis[axis] = static_cast< unsigned int >(exponent);
+      }
+    else
+      {
+      // increase valid levels until the division size/scale_factor gives a non-integer.
+      double sizeAtLevel = static_cast<double>(sizeAxis);
+      for (;;)
+        {
+        double division = sizeAtLevel / static_cast<double>(scaleFactor);
+        double intPartDivision;
+        double fractionPartDivision = std::modf(division, &intPartDivision );
+        if ( fractionPartDivision == 0 )
+          {
+          exponentPerAxis[axis]++;
+          sizeAtLevel = intPartDivision;
+          }
+        else
+          {
+          break;
+          }
+        }
+      }
+    }
+  // return the min_element of array (1 if any size is not power of 2)
+  return *std::min_element(exponentPerAxis.Begin(), exponentPerAxis.End());
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::SetLevels(unsigned int inputLevels)
+{
+  unsigned int current_outputs = 1 + this->m_Levels * this->m_HighPassSubBands;
+
+  if ( this->m_TotalOutputs == current_outputs && this->m_Levels == inputLevels )
+    {
+    return;
+    }
+
+  this->m_Levels = inputLevels;
+  this->m_TotalOutputs = 1 + inputLevels * this->m_HighPassSubBands;
+
+  this->SetNumberOfRequiredOutputs( this->m_TotalOutputs );
+  this->Modified();
+  for ( unsigned int n_output = 0; n_output < this->m_TotalOutputs; ++n_output )
+    {
+    this->SetNthOutput(n_output, this->MakeOutput(n_output));
+    }
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::SetHighPassSubBands(unsigned int k)
+{
+  if ( this->m_HighPassSubBands == k )
+    {
+    return;
+    }
+  this->m_HighPassSubBands = k;
+  // Trigger setting new number of outputs avoiding code duplication
+  this->SetLevels(this->m_Levels);
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::PrintSelf(std::ostream & os, Indent indent) const
+{
+  Superclass::PrintSelf(os, indent);
+  os << indent
+     << " Levels: " << this->m_Levels
+     << " HighPassSubBands: " << this->m_HighPassSubBands
+     << " TotalOutputs: " << this->m_TotalOutputs
+     << std::endl;
+}
+
+// template< typename TInputImage,
+//   typename TOutputImage,
+//   typename TWaveletFilterBank,
+//   typename TFrequencyShrinkFilterType >
+// void
+// WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+//   TWaveletFilterBank >
+// ::GenerateOutputInformation()
+// {
+//   // call the superclass's implementation of this method
+//   Superclass::GenerateOutputInformation();
+//
+//   // get pointers to the input and output
+//   InputImageConstPointer inputPtr = this->GetInput();
+//
+//   if ( !inputPtr )
+//     {
+//     itkExceptionMacro(<< "Input has not been set");
+//     }
+//
+//   typename InputImageType::SizeType inputSize =
+//     inputPtr->GetLargestPossibleRegion().GetSize();
+//   typename InputImageType::IndexType inputStartIndex =
+//     inputPtr->GetLargestPossibleRegion().GetIndex();
+//   #<{(|* inputOrigin and inputSpacing is lost and should be restored
+//    * at the end of the inverse wavelet transform. |)}>#
+//   typename OutputImageType::PointType inputModifiedOrigin(0);
+//   typename OutputImageType::SpacingType inputModifiedSpacing(1);
+//   // typename OutputImageType::DirectionType outputDirection = inputDirection;
+//
+//   OutputImagePointer outputPtr;
+//   typename OutputImageType::SizeType inputSizePerLevel = inputSize;
+//   typename OutputImageType::IndexType inputStartIndexPerLevel = inputStartIndex;
+//   typename OutputImageType::PointType inputOriginPerLevel = inputModifiedOrigin;
+//   typename OutputImageType::SpacingType inputSpacingPerLevel = inputModifiedSpacing;
+//   // typename OutputImageType::DirectionType inputDirectionPerLevel = inputDirection;
+//   // we need to compute the output spacing, the output image size,
+//   // and the output image start index
+//   for ( unsigned int level = 0; level < this->m_Levels; ++level )
+//     {
+//     // Bands per level . No downsampling in the first level iteration.
+//     for ( unsigned int band = 0; band < this->m_HighPassSubBands; ++band )
+//       {
+//       unsigned int current_output = level * m_HighPassSubBands + band;
+//       outputPtr = this->GetOutput(current_output);
+//       if ( !outputPtr )
+//         {
+//         continue;
+//         }
+//       typename OutputImageType::RegionType largestPossibleRegion;
+//       largestPossibleRegion.SetSize(inputSizePerLevel);
+//       largestPossibleRegion.SetIndex(inputStartIndexPerLevel);
+//       outputPtr->SetLargestPossibleRegion(largestPossibleRegion);
+//       outputPtr->SetOrigin(inputOriginPerLevel);
+//       outputPtr->SetSpacing(inputSpacingPerLevel);
+//       // outputPtr->SetDirection(outputDirection);
+//       }
+//     // Calculate for next levels new Size and Index, per dim.
+//     for ( unsigned int idim = 0; idim < OutputImageType::ImageDimension; idim++ )
+//       {
+//       // Size divided by scale
+//       inputSizePerLevel[idim] = static_cast< SizeValueType >(
+//           std::floor(static_cast< double >(inputSizePerLevel[idim]) / this->m_ScaleFactor));
+//       if ( inputSizePerLevel[idim] < 1 )
+//         {
+//         inputSizePerLevel[idim] = 1;
+//         }
+//       // Index dividided by scale
+//       inputStartIndexPerLevel[idim] = static_cast< IndexValueType >(
+//           std::ceil(static_cast< double >(inputStartIndexPerLevel[idim]) / this->m_ScaleFactor));
+//       // Spacing
+//       inputSpacingPerLevel[idim] = inputSpacingPerLevel[idim] * this->m_ScaleFactor;
+//       // Origin, the same.
+//       // inputOriginPerLevel[idim] = inputOriginPerLevel[idim] ;
+//       // inputOriginPerLevel[idim] = inputOriginPerLevel[idim] / this->m_ScaleFactor;
+//       }
+//
+//     // Set the low pass at the end.
+//     if ( level == this->m_Levels - 1 )
+//       {
+//       outputPtr = this->GetOutput(this->m_TotalOutputs - 1);
+//       if ( !outputPtr )
+//         {
+//         continue;
+//         }
+//       typename OutputImageType::RegionType largestPossibleRegion;
+//       largestPossibleRegion.SetSize(inputSizePerLevel);
+//       largestPossibleRegion.SetIndex(inputStartIndexPerLevel);
+//       outputPtr->SetLargestPossibleRegion(largestPossibleRegion);
+//       outputPtr->SetOrigin(inputOriginPerLevel);
+//       outputPtr->SetSpacing(inputSpacingPerLevel);
+//       // outputPtr->SetDirection(inputDirectionPerLevel);
+//       }
+//     }
+// }
+
+// template< typename TInputImage,
+//   typename TOutputImage,
+//   typename TWaveletFilterBank,
+//   typename TFrequencyShrinkFilterType >
+// void
+// WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+//   TWaveletFilterBank >
+// ::GenerateOutputRequestedRegion(DataObject *refOutput)
+// {
+//   // call the superclass's implementation of this method
+//   Superclass::GenerateOutputRequestedRegion(refOutput);
+//
+//   // find the index for this output
+//   unsigned int refIndex =
+//     static_cast< unsigned int >(refOutput->GetSourceOutputIndex());
+//   std::pair< unsigned int, unsigned int > pairRef =
+//     this->OutputIndexToLevelBand(refIndex);
+//   unsigned int refLevel = pairRef.first;
+//   // unsigned int refBand  = pairRef.second;
+//
+//   // compute baseIndex and baseSize
+//   typedef typename OutputImageType::SizeType   SizeType;
+//   typedef typename OutputImageType::IndexType  IndexType;
+//   typedef typename OutputImageType::RegionType RegionType;
+//
+//   TOutputImage *ptr = itkDynamicCastInDebugMode< TOutputImage * >(refOutput);
+//   if ( !ptr )
+//     {
+//     itkExceptionMacro(<< "Could not cast refOutput to TOutputImage*.");
+//     }
+//
+//   if ( ptr->GetRequestedRegion() == ptr->GetLargestPossibleRegion() )
+//     {
+//     // set the requested regions for the other outputs to their largest
+//     for ( unsigned int nout = 0; nout < this->m_TotalOutputs; ++nout )
+//       {
+//       if ( nout == refIndex )
+//         {
+//         continue;
+//         }
+//       if ( !this->GetOutput(nout) )
+//         {
+//         continue;
+//         }
+//       this->GetOutput(nout)->SetRequestedRegionToLargestPossibleRegion();
+//       }
+//     }
+//   else
+//     {
+//     // compute requested regions for the other outputs based on
+//     // the requested region of the reference output
+//     IndexType outputIndex;
+//     SizeType outputSize;
+//     RegionType outputRegion;
+//     RegionType baseRegion = ptr->GetRequestedRegion();
+//     IndexType baseIndex  = baseRegion.GetIndex();
+//     SizeType baseSize   = baseRegion.GetSize();
+//     for ( unsigned int level = 0; level < this->m_Levels + 1; ++level )
+//       {
+//       int distanceToReferenceLevel = static_cast< int >(refLevel) - static_cast< int >(level);
+//       for ( unsigned int idim = 0; idim < TOutputImage::ImageDimension; idim++ )
+//         {
+//         outputIndex[idim] = baseIndex[idim]
+//           * static_cast< IndexValueType >(std::pow(static_cast< double >(this->m_ScaleFactor),
+//                                             distanceToReferenceLevel));
+//         outputSize[idim] = baseSize[idim]
+//           * static_cast< SizeValueType >(std::pow(static_cast< double >(this->m_ScaleFactor),
+//                                            distanceToReferenceLevel));
+//         if ( outputSize[idim] < 1 )
+//           {
+//           itkExceptionMacro( << "Failure at level: " << level
+//                              << " in forward wavelet, going to negative image size. Too many levels for input image size.");
+//           }
+//         }
+//       outputRegion.SetIndex(outputIndex);
+//       outputRegion.SetSize(outputSize);
+//
+//       // Set low pass output
+//       if ( level == this->m_Levels )
+//         {
+//         unsigned int n_output = this->m_TotalOutputs - 1;
+//         if ( n_output == refIndex )
+//           {
+//           continue;
+//           }
+//         if ( !this->GetOutput(n_output) )
+//           {
+//           continue;
+//           }
+//         outputRegion.Crop(this->GetOutput(n_output)->GetLargestPossibleRegion());
+//         this->GetOutput(n_output)->SetRequestedRegion(outputRegion);
+//         }
+//       else // Bands per level
+//         {
+//         for ( unsigned int band = 0; band < this->m_HighPassSubBands; ++band )
+//           {
+//           unsigned int n_output = level * this->m_HighPassSubBands + band;
+//           if ( n_output == refIndex )
+//             {
+//             continue;
+//             }
+//           if ( !this->GetOutput(n_output) )
+//             {
+//             continue;
+//             }
+//           outputRegion.Crop(this->GetOutput(n_output)->GetLargestPossibleRegion());
+//           // set the requested region
+//           this->GetOutput(n_output)->SetRequestedRegion(outputRegion);
+//           }
+//         }
+//       }
+//     }
+// }
+
+// template< typename TInputImage,
+//   typename TOutputImage,
+//   typename TWaveletFilterBank,
+//   typename TFrequencyShrinkFilterType >
+// void
+// WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+//   TWaveletFilterBank >
+// ::GenerateInputRequestedRegion()
+// {
+//   // call the superclass' implementation of this method
+//   Superclass::GenerateInputRequestedRegion();
+//
+//   // get pointers to the input and output
+//   InputImagePointer inputPtr = const_cast< InputImageType * >(this->GetInput());
+//   if ( !inputPtr )
+//     {
+//     itkExceptionMacro(<< "Input has not been set.");
+//     }
+//
+//   // compute baseIndex and baseSize
+//   typedef typename OutputImageType::SizeType   SizeType;
+//   typedef typename OutputImageType::IndexType  IndexType;
+//   typedef typename OutputImageType::RegionType RegionType;
+//
+//   // The first level has the same size than input.
+//   // At least one band is ensured to exist, so use it.
+//   unsigned int refOutput = 0;
+//   SizeType baseSize  = this->GetOutput(refOutput)->GetRequestedRegion().GetSize();
+//   IndexType baseIndex =
+//     this->GetOutput(refOutput)->GetRequestedRegion().GetIndex();
+//   RegionType baseRegion;
+//
+//   baseRegion.SetIndex(baseIndex);
+//   baseRegion.SetSize(baseSize);
+//
+//   // make sure the requested region is within the largest possible
+//   baseRegion.Crop(inputPtr->GetLargestPossibleRegion());
+//
+//   // set the input requested region
+//   inputPtr->SetRequestedRegion(baseRegion);
+// }
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyForwardUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::GenerateData()
+{
+  InputImageConstPointer input = this->GetInput();
+
+  this->AllocateOutputs();
+
+  // note: clear reduces size to zero, but doesn't change capacity.
+  m_WaveletFilterBankPyramid.clear();
+
+  typedef itk::CastImageFilter< InputImageType, OutputImageType > CastFilterType;
+  typename CastFilterType::Pointer castFilter = CastFilterType::New();
+  castFilter->SetInput(input);
+  castFilter->Update();
+  OutputImagePointer inputPerLevel = castFilter->GetOutput();
+  typedef itk::ChangeInformationImageFilter< OutputImageType > ChangeInformationFilterType;
+  typename ChangeInformationFilterType::Pointer changeInputInfoFilter = ChangeInformationFilterType::New();
+  typename InputImageType::PointType origin_old  = inputPerLevel->GetOrigin();
+  typename InputImageType::SpacingType spacing_old = inputPerLevel->GetSpacing();
+  typename InputImageType::PointType origin_new  = origin_old;
+  origin_new.Fill(0);
+  typename InputImageType::SpacingType spacing_new = spacing_old;
+  spacing_new.Fill(1);
+  changeInputInfoFilter->SetInput(inputPerLevel);
+  changeInputInfoFilter->ChangeDirectionOff();
+  changeInputInfoFilter->ChangeRegionOff();
+  changeInputInfoFilter->ChangeSpacingOn();
+  changeInputInfoFilter->ChangeOriginOn();
+  changeInputInfoFilter->UseReferenceImageOff();
+  changeInputInfoFilter->SetOutputOrigin(origin_new);
+  changeInputInfoFilter->SetOutputSpacing(spacing_new);
+  changeInputInfoFilter->Update();
+
+  // Generate WaveletFilterBank.
+  this->m_WaveletFilterBank->SetHighPassSubBands(this->m_HighPassSubBands);
+  this->m_WaveletFilterBank->SetSize(changeInputInfoFilter->GetOutput()->GetLargestPossibleRegion().GetSize() );
+  this->m_WaveletFilterBank->Update();
+  std::vector< OutputImagePointer > highPassWavelets = this->m_WaveletFilterBank->GetOutputsHighPassBands();
+  OutputImagePointer lowPassWavelet = this->m_WaveletFilterBank->GetOutputLowPass();
+  lowPassWavelet->DisconnectPipeline();
+
+  if ( this->m_StoreWaveletFilterBankPyramid )
+    {
+    for ( unsigned int bankOutput = 0; bankOutput < this->m_HighPassSubBands + 1; ++bankOutput )
+      {
+      this->m_WaveletFilterBankPyramid.push_back(this->m_WaveletFilterBank->GetOutput(bankOutput));
+      }
+    }
+
+  typedef itk::MultiplyImageFilter< OutputImageType > MultiplyFilterType;
+  inputPerLevel = changeInputInfoFilter->GetOutput();
+  double scaleFactor = static_cast< double >(this->m_ScaleFactor);
+  for ( unsigned int level = 0; level < this->m_Levels; ++level )
+    {
+    /******* Set HighPass bands *****/
+    itkDebugMacro(<< "Number of FilterBank high pass bands: " << highPassWavelets.size() );
+    for ( unsigned int band = 0; band < this->m_HighPassSubBands; ++band )
+      {
+      unsigned int n_output = level * this->m_HighPassSubBands + band;
+      /******* Band dilation factor for HighPass bands *****/
+      //  2^(1/#bands) instead of Dyadic dilations.
+      typename MultiplyFilterType::Pointer multiplyByAnalysisBandFactor = MultiplyFilterType::New();
+      multiplyByAnalysisBandFactor->SetInput1(highPassWavelets[band]);
+      // double expBandFactor = 0;
+      // double expBandFactor = - static_cast<double>(level*ImageDimension)/2.0;
+      double expBandFactor = ( -static_cast< double >(level)
+                               + band / static_cast< double >(this->m_HighPassSubBands) ) * ImageDimension / 2.0;
+      multiplyByAnalysisBandFactor->SetConstant(std::pow(scaleFactor, expBandFactor));
+      // TODO Warning: InPlace here deletes buffered region of input.
+      // http://public.kitware.com/pipermail/community/2015-April/008819.html
+      // multiplyByAnalysisBandFactor->InPlaceOn();
+      multiplyByAnalysisBandFactor->Update();
+
+      typename MultiplyFilterType::Pointer multiplyHighBandFilter = MultiplyFilterType::New();
+      multiplyHighBandFilter->SetInput1(multiplyByAnalysisBandFactor->GetOutput());
+      multiplyHighBandFilter->SetInput2(inputPerLevel);
+      multiplyHighBandFilter->InPlaceOn();
+      multiplyHighBandFilter->GraftOutput(this->GetOutput(n_output));
+      multiplyHighBandFilter->Update();
+
+      this->UpdateProgress( static_cast< float >( n_output - 1 )
+        / static_cast< float >( m_TotalOutputs ) );
+      this->GraftNthOutput(n_output, multiplyHighBandFilter->GetOutput());
+      }
+
+    /******* Calculate LowPass band *****/
+    typename MultiplyFilterType::Pointer multiplyLowFilter = MultiplyFilterType::New();
+    multiplyLowFilter->SetInput1(lowPassWavelet);
+    multiplyLowFilter->SetInput2(inputPerLevel);
+    // multiplyLowFilter->InPlaceOn();
+    if ( level == this->m_Levels - 1 ) // Set low_pass output (index=this->m_TotalOutputs - 1)
+      {
+      this->GraftNthOutput(this->m_TotalOutputs - 1, multiplyLowFilter->GetOutput());
+      this->UpdateProgress( static_cast< float >( this->m_TotalOutputs - 1 )
+        / static_cast< float >( this->m_TotalOutputs ) );
+      continue;
+      }
+    else // update inputPerLevel
+      {
+      multiplyLowFilter->Update();
+      inputPerLevel = multiplyLowFilter->GetOutput();
+      /******* Downsample (scale) wavelets *****/
+      m_WaveletFilterBank->SetLevel(level + 1);
+      m_WaveletFilterBank->Update();
+      lowPassWavelet = m_WaveletFilterBank->GetOutputLowPass();
+      lowPassWavelet->DisconnectPipeline();
+      highPassWavelets = m_WaveletFilterBank->GetOutputsHighPassBands();
+      for ( unsigned int band = 0; band < this->m_HighPassSubBands; ++band )
+        {
+        highPassWavelets[band]->DisconnectPipeline();
+        }
+
+      if ( this->m_StoreWaveletFilterBankPyramid )
+        {
+        m_WaveletFilterBankPyramid.push_back(lowPassWavelet);
+        for ( unsigned int band = 0; band < this->m_HighPassSubBands; ++band )
+          {
+          m_WaveletFilterBankPyramid.push_back(highPassWavelets[band]);
+          }
+        }
+      } // end update inputPerLevel
+    } // end level
+}
+} // end namespace itk
+#endif

--- a/include/itkWaveletFrequencyInverse.hxx
+++ b/include/itkWaveletFrequencyInverse.hxx
@@ -54,22 +54,8 @@ WaveletFrequencyInverse< TInputImage, TOutputImage,
   TWaveletFilterBank, TFrequencyExpandFilterType >
 ::InputIndexToLevelBand(unsigned int linear_index)
 {
-  if ( linear_index > this->m_TotalInputs - 1 || linear_index < 0 )
-    {
-    itkExceptionMacro(<< "Failed converting liner index " << linear_index
-                      << " to Level,Band pair : out of bounds");
-    }
-  // Low pass (band = 0).
-  if ( linear_index == 0 )
-    {
-    return std::make_pair(this->m_Levels, 0);
-    }
-
-  unsigned int band = (linear_index - 1) % this->m_HighPassSubBands;
-  band = band + 1;
-  // note integer division ahead.
-  unsigned int level = (linear_index - band) / this->m_HighPassSubBands + 1;
-  return std::make_pair(level, band);
+  return itk::utils::IndexToLevelBandSteerablePyramid(linear_index,
+      this->m_Levels, this->m_HighPassSubBands);
 };
 
 template< typename TInputImage,

--- a/include/itkWaveletFrequencyInverse.hxx
+++ b/include/itkWaveletFrequencyInverse.hxx
@@ -394,8 +394,8 @@ WaveletFrequencyInverse< TInputImage, TOutputImage,
     else
       {
       waveletLow = this->m_WaveletFilterBankPyramid[level * (1 + this->m_HighPassSubBands)];
-      itkDebugMacro(<< "waveletLow: " << level << " Region:" << waveletLow->GetLargestPossibleRegion() );
       }
+    itkDebugMacro(<< "waveletLow: " << level << " Region:" << waveletLow->GetLargestPossibleRegion() );
 
     typedef itk::ChangeInformationImageFilter< InputImageType > ChangeInformationFilterType;
     typename ChangeInformationFilterType::Pointer changeWaveletInfoFilter = ChangeInformationFilterType::New();

--- a/include/itkWaveletFrequencyInverseUndecimated.h
+++ b/include/itkWaveletFrequencyInverseUndecimated.h
@@ -1,0 +1,176 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkWaveletFrequencyInverseUndecimated_h
+#define itkWaveletFrequencyInverseUndecimated_h
+
+#include <itkImageRegionConstIterator.h>
+#include <itkImageRegionIterator.h>
+#include <itkImageConstIterator.h>
+#include <complex>
+#include <itkFixedArray.h>
+#include <itkImageToImageFilter.h>
+
+namespace itk
+{
+/** \class WaveletFrequencyInverseUndecimated
+ * @brief Wavelet analysis where input is an FFT image.
+ * Aim to be Isotropic.
+ *
+ * \ingroup IsotropicWavelets
+ */
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+  class WaveletFrequencyInverseUndecimated:
+  public ImageToImageFilter< TInputImage, TOutputImage>
+{
+public:
+  /** Standard classs typedefs. */
+  typedef WaveletFrequencyInverseUndecimated              Self;
+  typedef ImageToImageFilter< TInputImage, TOutputImage > Superclass;
+  typedef SmartPointer< Self >                            Pointer;
+  typedef SmartPointer< const Self >                      ConstPointer;
+
+  /** Inherit types from Superclass. */
+  typedef typename Superclass::InputImageType         InputImageType;
+  typedef typename Superclass::OutputImageType        OutputImageType;
+  typedef typename Superclass::InputImagePointer      InputImagePointer;
+  typedef typename Superclass::OutputImagePointer     OutputImagePointer;
+  typedef typename Superclass::InputImageConstPointer InputImageConstPointer;
+
+  typedef TWaveletFilterBank                                  WaveletFilterBankType;
+  typedef typename WaveletFilterBankType::Pointer             WaveletFilterBankPointer;
+  typedef typename WaveletFilterBankType::WaveletFunctionType WaveletFunctionType;
+  typedef typename WaveletFilterBankType::FunctionValueType   FunctionValueType;
+
+  /** ImageDimension constants */
+  itkStaticConstMacro(ImageDimension, unsigned int,
+                      TInputImage::ImageDimension);
+
+  /** Standard New method. */
+  itkNewMacro(Self);
+
+  /** Runtime information support. */
+  itkTypeMacro(WaveletFrequencyInverseUndecimated,
+               ImageToImageFilter);
+
+  /** Number of levels/scales. Maximum depends on size of image */
+  void SetLevels(unsigned int n);
+  itkGetMacro(Levels, unsigned int);
+
+  /** Number of high pass subbands, 1 minimum */
+  void SetHighPassSubBands(unsigned int n);
+  itkGetMacro(HighPassSubBands, unsigned int);
+
+  /** Total number of inputs required: Levels*HighPassSubBands + 1 */
+  itkGetMacro(TotalInputs, unsigned int);
+
+  /** Shrink/Expand factor at each level.
+   * Set to 2 (dyadic), not modifiable, but providing future flexibility */
+  itkGetConstReferenceMacro(ScaleFactor, unsigned int)
+
+  /** 
+   * If On, applies to each input the appropiate Level-Band multiplicative factor. Needed for perfect reconstruction.
+   * It has to be turned off for some applications (phase analysis for example) */
+  itkGetConstReferenceMacro(ApplyReconstructionFactors, bool)
+  itkSetMacro(ApplyReconstructionFactors, bool)
+  itkBooleanMacro(ApplyReconstructionFactors);
+
+  /** Flag to use external WaveletFilterBankPyramid generated in ForwardWavelet.
+   * Requires to use SetWaveletFilterBankPyramid. */
+  itkGetConstReferenceMacro(UseWaveletFilterBankPyramid, bool)
+  itkSetMacro(UseWaveletFilterBankPyramid, bool)
+  itkBooleanMacro(UseWaveletFilterBankPyramid);
+
+  /**
+   * Set vector containing the WaveletFilterBankPyramid.
+   * This vector is generated in the ForwardWavelet when StoreWaveletFilterBankPyramid is On.
+   */
+  void SetWaveletFilterBankPyramid(const std::vector<InputImagePointer> &filterBankPyramid)
+    {
+    this->m_WaveletFilterBankPyramid = filterBankPyramid;
+    }
+
+  typedef std::pair<unsigned int, unsigned int> IndexPairType;
+  /** Get the (Level,Band) from a linear index input */
+  IndexPairType InputIndexToLevelBand(unsigned int linear_index);
+
+  void SetInputs(const std::vector<InputImagePointer> & inputs);
+
+  void SetInputLowPass(const InputImagePointer & input_low_pass);
+
+  void SetInputsHighPass(const std::vector<InputImagePointer> & inputs);
+
+protected:
+  WaveletFrequencyInverseUndecimated();
+  ~WaveletFrequencyInverseUndecimated() {}
+  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
+
+  /** Single-threaded version of GenerateData. */
+  void GenerateData() ITK_OVERRIDE;
+
+  /************ Information *************/
+
+  /** WaveletFrequencyInverseUndecimated produces images which are of
+   * different resolution and different pixel spacing than its input image.
+   * As such, WaveletFrequencyInverseUndecimated needs to provide an
+   * implementation for GenerateOutputInformation() in order to inform the
+   * pipeline execution model.  The original documentation of this method is
+   * below.
+   * \sa ProcessObject::GenerateOutputInformaton()
+   */
+  virtual void GenerateOutputInformation() ITK_OVERRIDE;
+
+  /** Given one output whose requested region has been set, this method sets
+   * the requested region for the remaining output images.  The original
+   * documentation of this method is below.
+   * \sa ProcessObject::GenerateOutputRequestedRegion()
+   */
+  virtual void GenerateOutputRequestedRegion(DataObject *output) ITK_OVERRIDE;
+
+  /** WaveletFrequencyInverseUndecimated requires a larger input requested
+   * region than the output requested regions to accommodate the shrinkage and
+   * smoothing operations. As such, WaveletFrequencyInverseUndecimated needs
+   * to provide an implementation for GenerateInputRequestedRegion().  The
+   * original documentation of this method is below.
+   * \sa ProcessObject::GenerateInputRequestedRegion()
+   */
+  virtual void GenerateInputRequestedRegion() ITK_OVERRIDE;
+
+  /** Input images do not occupy the same physical space.
+   * Remove the check. */
+  virtual void VerifyInputInformation() ITK_OVERRIDE {};
+
+private:
+  ITK_DISALLOW_COPY_AND_ASSIGN(WaveletFrequencyInverseUndecimated);
+
+  unsigned int                   m_Levels;
+  unsigned int                   m_HighPassSubBands;
+  unsigned int                   m_TotalInputs;
+  unsigned int                   m_ScaleFactor;
+  bool                           m_ApplyReconstructionFactors;
+  bool                           m_UseWaveletFilterBankPyramid;
+  WaveletFilterBankPointer       m_WaveletFilterBank;
+  std::vector<InputImagePointer> m_WaveletFilterBankPyramid;
+};
+} // end namespace itk
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkWaveletFrequencyInverseUndecimated.hxx"
+#endif
+
+#endif

--- a/include/itkWaveletFrequencyInverseUndecimated.hxx
+++ b/include/itkWaveletFrequencyInverseUndecimated.hxx
@@ -1,0 +1,423 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkWaveletFrequencyInverseUndecimated_hxx
+#define itkWaveletFrequencyInverseUndecimated_hxx
+#include <itkWaveletFrequencyInverseUndecimated.h>
+#include <itkCastImageFilter.h>
+#include <itkImage.h>
+#include <algorithm>
+#include <itkMultiplyImageFilter.h>
+#include <itkAddImageFilter.h>
+#include <itkImageDuplicator.h>
+#include <itkChangeInformationImageFilter.h>
+#include <itkWaveletUtilities.h>
+namespace itk
+{
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::WaveletFrequencyInverseUndecimated()
+  : m_Levels(1),
+  m_HighPassSubBands(1),
+  m_TotalInputs(0),
+  m_ScaleFactor(2),
+  m_ApplyReconstructionFactors(true),
+  m_UseWaveletFilterBankPyramid(false)
+{
+  this->SetNumberOfRequiredOutputs(1);
+  this->m_WaveletFilterBank = WaveletFilterBankType::New();
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+std::pair< unsigned int, unsigned int >
+WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::InputIndexToLevelBand(unsigned int linear_index)
+{
+  return itk::utils::IndexToLevelBandSteerablePyramid(linear_index,
+      this->m_TotalOutputs, this->m_Levels, this->m_HighPassSubBands);
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::SetLevels(unsigned int n)
+{
+  unsigned int current_inputs = 1 + this->m_Levels * this->m_HighPassSubBands;
+
+  if ( this->m_TotalInputs == current_inputs && this->m_Levels == n )
+    {
+    return;
+    }
+
+  this->m_Levels = n;
+  this->m_TotalInputs = 1 + n * this->m_HighPassSubBands;
+
+  this->SetNumberOfRequiredInputs( this->m_TotalInputs );
+  this->Modified();
+
+  this->SetNthOutput(0, this->MakeOutput(0));
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::SetHighPassSubBands(unsigned int k)
+{
+  if ( this->m_HighPassSubBands == k )
+    {
+    return;
+    }
+  this->m_HighPassSubBands = k;
+  // Trigger setting new number of inputs avoiding code duplication
+  this->SetLevels(this->m_Levels);
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::SetInputs(const std::vector< InputImagePointer > & inputs)
+{
+  if ( inputs.size() != this->m_TotalInputs )
+    {
+    itkExceptionMacro(<< "Error seting inputs in inverse wavelet. Wrong vector size: "
+                      << inputs.size() << " .According to number of levels and bands it should be: " << m_TotalInputs);
+    }
+  for ( unsigned int nin = 0; nin < this->m_TotalInputs; ++nin )
+    {
+    if ( this->GetInput(nin) != inputs[nin] )
+      {
+      this->SetNthInput(nin, inputs[nin]);
+      }
+    }
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::SetInputLowPass(const InputImagePointer & input_low_pass)
+{
+  this->SetNthInput(this->m_TotalInputs - 1, input_low_pass);
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::SetInputsHighPass(const std::vector< InputImagePointer > & inputs)
+{
+  if ( inputs.size() != this->m_TotalInputs - 1 )
+    {
+    itkExceptionMacro(<< "Error seting inputs in inverse wavelet. Wrong vector size: "
+                      << inputs.size() << " .According to number of levels and bands it should be: " << m_TotalInputs
+        - 1);
+    }
+  for ( unsigned int nin = 0; nin < this->m_TotalInputs - 1; ++nin )
+    {
+    this->SetNthInput(nin, inputs[nin]);
+    }
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::PrintSelf(std::ostream & os, Indent indent) const
+{
+  Superclass::PrintSelf(os, indent);
+  os << indent << "Levels: " << this->m_Levels << std::endl;
+  os << indent << "HighPassSubBands: " << this->m_HighPassSubBands << std::endl;
+  os << indent << "TotalInputs: " << this->m_TotalInputs << std::endl;
+  os << indent << "ScaleFactor: " << this->m_ScaleFactor << std::endl;
+  os << indent << "ApplyReconstructionFactors: " << this->m_ApplyReconstructionFactors << std::endl;
+  os << indent << "UseWaveletFilterBankPyramid: " << this->m_UseWaveletFilterBankPyramid << std::endl;
+  itkPrintSelfObjectMacro(WaveletFilterBank);
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::GenerateOutputInformation()
+{
+  // call the superclass's implementation of this method
+  Superclass::GenerateOutputInformation();
+  // Check  all inputs exist.
+  for ( unsigned int nInput = 0; nInput < this->m_TotalInputs; ++nInput )
+    {
+    if ( !this->GetInput(nInput) )
+      {
+      itkExceptionMacro(<< "Input: " << nInput << " has not been set");
+      }
+    }
+
+  // We know inputIndex = 0 has the same size than output. Use it.
+  InputImagePointer inputPtr = const_cast< InputImageType * >(this->GetInput(0));
+  const typename InputImageType::PointType & inputOrigin =
+    inputPtr->GetOrigin();
+  const typename InputImageType::SpacingType & inputSpacing =
+    inputPtr->GetSpacing();
+  const typename InputImageType::DirectionType & inputDirection =
+    inputPtr->GetDirection();
+  const typename InputImageType::SizeType & inputSize =
+    inputPtr->GetLargestPossibleRegion().GetSize();
+  const typename InputImageType::IndexType & inputStartIndex =
+    inputPtr->GetLargestPossibleRegion().GetIndex();
+
+  OutputImagePointer outputPtr;
+  outputPtr = this->GetOutput(0);
+
+  typename OutputImageType::RegionType outputLargestPossibleRegion;
+  outputLargestPossibleRegion.SetSize(inputSize);
+  outputLargestPossibleRegion.SetIndex(inputStartIndex);
+
+  outputPtr->SetLargestPossibleRegion(outputLargestPossibleRegion);
+  outputPtr->SetOrigin(inputOrigin);
+  outputPtr->SetSpacing(inputSpacing);
+  outputPtr->SetDirection(inputDirection);
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::GenerateOutputRequestedRegion(DataObject *refOutput)
+{
+  // call the superclass's implementation of this method
+  Superclass::GenerateOutputRequestedRegion(refOutput);
+}
+
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::GenerateInputRequestedRegion()
+{
+  // call the superclass' implementation of this method
+  Superclass::GenerateInputRequestedRegion();
+
+  // compute baseIndex and baseSize
+  typedef typename OutputImageType::SizeType   SizeType;
+  typedef typename OutputImageType::IndexType  IndexType;
+  typedef typename OutputImageType::RegionType RegionType;
+
+  OutputImagePointer outputPtr = this->GetOutput(0);
+
+  SizeType baseSize  = outputPtr->GetRequestedRegion().GetSize();
+  IndexType baseIndex = outputPtr->GetRequestedRegion().GetIndex();
+  RegionType baseRegion;
+  baseRegion.SetIndex(baseIndex);
+  baseRegion.SetSize(baseSize);
+  for ( unsigned int level = 0; level < this->m_Levels; ++level )
+    {
+    for ( unsigned int band = 0; band < this->m_HighPassSubBands; ++band )
+      {
+      unsigned int nInput = level * this->m_HighPassSubBands + band;
+      if ( !this->GetInput(nInput) )
+        {
+        itkExceptionMacro(<< "Input ptr does not exist: " << nInput );
+        }
+      InputImagePointer inputPtr = const_cast< InputImageType * >(this->GetInput(nInput));
+      // set the requested region
+      inputPtr->SetRequestedRegion(baseRegion);
+      }
+    }
+}
+
+// ITK forward implementation: Freq Domain, no downsampling
+//    - HPs (lv1 wavelet coef)
+// I -         - HPs (lv2 wavelet coef)
+//    - LP  -
+//             - LP
+// Where Down is a downsample.
+template< typename TInputImage,
+  typename TOutputImage,
+  typename TWaveletFilterBank >
+void
+WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
+  TWaveletFilterBank >
+::GenerateData()
+{
+  this->AllocateOutputs();
+  // Start with the approximation image (the smallest).
+  InputImageConstPointer low_pass = this->GetInput(this->m_TotalInputs - 1);
+
+  typedef itk::ImageDuplicator< InputImageType > DuplicatorType;
+  typename DuplicatorType::Pointer duplicator = DuplicatorType::New();
+  duplicator->SetInputImage(low_pass);
+  duplicator->Update();
+  InputImagePointer low_pass_per_level = duplicator->GetModifiableOutput();
+
+  typedef itk::MultiplyImageFilter< InputImageType > MultiplyFilterType;
+
+  double scaleFactor = static_cast< double >(this->m_ScaleFactor);
+  for ( int level = this->m_Levels - 1; level > -1; --level )
+    {
+    itkDebugMacro( << "LEVEL: " << level );
+    itkDebugMacro(<< "Low_pass_per_level: " << level << " Region:" << low_pass_per_level->GetLargestPossibleRegion() );
+
+    /******* Calculate FilterBank with the right size per level. *****/
+    // Save the FilterBank vector created in the forward wavelet and load it here to save compute it again.
+    InputImagePointer waveletLow;
+    if ( !this->m_UseWaveletFilterBankPyramid )
+      {
+      this->m_WaveletFilterBank->SetHighPassSubBands(this->m_HighPassSubBands);
+      this->m_WaveletFilterBank->SetSize(low_pass_per_level->GetLargestPossibleRegion().GetSize() );
+      this->m_WaveletFilterBank->SetInverseBank(true);
+      // this->m_WaveletFilterBank->SetScaleFactor(this->m_ScaleFactor);
+      this->m_WaveletFilterBank->SetLevel(level);
+      this->m_WaveletFilterBank->Modified();
+      this->m_WaveletFilterBank->UpdateLargestPossibleRegion();
+      waveletLow = this->m_WaveletFilterBank->GetOutputLowPass();
+      }
+    else
+      {
+      waveletLow = this->m_WaveletFilterBankPyramid[level * (1 + this->m_HighPassSubBands)];
+      }
+    itkDebugMacro(<< "waveletLow: " << level << " Region:" << waveletLow->GetLargestPossibleRegion() );
+    typedef itk::ChangeInformationImageFilter< InputImageType > ChangeInformationFilterType;
+
+    /******* LowPass band *****/
+    typename MultiplyFilterType::Pointer multiplyLowPass = MultiplyFilterType::New();
+    multiplyLowPass->SetInput1(waveletLow);
+    multiplyLowPass->SetInput2(low_pass_per_level);
+    multiplyLowPass->Update();
+    low_pass_per_level = multiplyLowPass->GetOutput();
+
+    /******* HighPass sub-bands *****/
+    std::vector< InputImagePointer > highPassMasks;
+    if ( !this->m_UseWaveletFilterBankPyramid )
+      {
+      highPassMasks = this->m_WaveletFilterBank->GetOutputsHighPassBands();
+      }
+    else
+      {
+      highPassMasks.insert(highPassMasks.begin(),
+        this->m_WaveletFilterBankPyramid.begin()
+        + 1 + level * (1 + this->m_HighPassSubBands),
+        this->m_WaveletFilterBankPyramid.begin()
+        + this->m_HighPassSubBands + 1 + level * (1 + this->m_HighPassSubBands) );
+      }
+    // Store HighBands steps into high_pass_reconstruction image:
+    InputImagePointer reconstructed = InputImageType::New();
+    reconstructed->SetRegions(low_pass_per_level->GetLargestPossibleRegion());
+    reconstructed->Allocate();
+    reconstructed->FillBuffer(0);
+    InputImagePointer bandInputImage;
+    for ( unsigned int band = 0; band < this->m_HighPassSubBands; ++band )
+      {
+      unsigned int nInput = level * this->m_HighPassSubBands + band;
+      bandInputImage = const_cast< InputImageType * >(this->GetInput(nInput));
+      reconstructed->SetSpacing(bandInputImage->GetSpacing());
+      reconstructed->SetOrigin(bandInputImage->GetOrigin());
+
+      typename ChangeInformationFilterType::Pointer changeWaveletHighInfoFilter = ChangeInformationFilterType::New();
+      changeWaveletHighInfoFilter->SetInput(highPassMasks[band]);
+      changeWaveletHighInfoFilter->UseReferenceImageOn();
+      changeWaveletHighInfoFilter->SetReferenceImage( bandInputImage );
+      changeWaveletHighInfoFilter->ChangeDirectionOff();
+      changeWaveletHighInfoFilter->ChangeRegionOff();
+      changeWaveletHighInfoFilter->ChangeSpacingOn();
+      changeWaveletHighInfoFilter->ChangeOriginOn();
+      changeWaveletHighInfoFilter->UpdateLargestPossibleRegion();
+      highPassMasks[band] = changeWaveletHighInfoFilter->GetOutput();
+      highPassMasks[band]->DisconnectPipeline();
+
+      typename MultiplyFilterType::Pointer multiplyHighBandFilter = MultiplyFilterType::New();
+      multiplyHighBandFilter->SetInput1(highPassMasks[band]);
+      multiplyHighBandFilter->SetInput2(bandInputImage);
+      multiplyHighBandFilter->UpdateLargestPossibleRegion();
+
+      /******* Band dilation factor for HighPass bands *****/
+      //  2^(1/#bands) instead of Dyadic dilations.
+      typename MultiplyFilterType::Pointer multiplyByReconstructionBandFactor = MultiplyFilterType::New();
+      multiplyByReconstructionBandFactor->SetInput1(multiplyHighBandFilter->GetOutput());
+      double expBandFactor = 0;
+      if ( this->GetApplyReconstructionFactors() )
+        {
+        expBandFactor = ( static_cast< double >(level) - band / static_cast< double >(this->m_HighPassSubBands) )
+          * ImageDimension / 2.0;
+        }
+      multiplyByReconstructionBandFactor->SetConstant(std::pow(scaleFactor, expBandFactor));
+      multiplyByReconstructionBandFactor->InPlaceOn();
+      multiplyByReconstructionBandFactor->Update();
+
+      /******* Add high bands *****/
+      typedef itk::AddImageFilter< InputImageType > AddFilterType;
+      typename AddFilterType::Pointer addFilter = AddFilterType::New();
+      addFilter->SetInput1(reconstructed);
+      addFilter->SetInput2(multiplyByReconstructionBandFactor->GetOutput());
+      addFilter->InPlaceOn();
+      addFilter->Update();
+      reconstructed = addFilter->GetOutput();
+
+      this->UpdateProgress(static_cast< float >(m_TotalInputs - nInput - 1)
+        / static_cast< float >(m_TotalInputs));
+      }
+
+    /******* Add low pass to the sum of high pass bands. *****/
+    typedef itk::AddImageFilter< InputImageType > AddFilterType;
+    typename AddFilterType::Pointer addHighAndLow = AddFilterType::New();
+    addHighAndLow->SetInput1(reconstructed.GetPointer()); // HighBands
+    addHighAndLow->SetInput2(low_pass_per_level);
+    addHighAndLow->InPlaceOn();
+    addHighAndLow->Update();
+
+    if ( level == 0 /* Last level to compute */ ) // Graft Output
+      {
+      typedef itk::CastImageFilter< InputImageType, OutputImageType > CastFilterType;
+      typename CastFilterType::Pointer castFilter = CastFilterType::New();
+      castFilter->SetInput(addHighAndLow->GetOutput());
+      castFilter->GraftOutput(this->GetOutput());
+      castFilter->Update();
+      this->GraftOutput(castFilter->GetOutput());
+      }
+    else // Update low_pass
+      {
+      low_pass_per_level = addHighAndLow->GetOutput();
+      }
+    }
+}
+} // end namespace itk
+#endif

--- a/include/itkWaveletFrequencyInverseUndecimated.hxx
+++ b/include/itkWaveletFrequencyInverseUndecimated.hxx
@@ -54,7 +54,7 @@ WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
 ::InputIndexToLevelBand(unsigned int linear_index)
 {
   return itk::utils::IndexToLevelBandSteerablePyramid(linear_index,
-      this->m_TotalOutputs, this->m_Levels, this->m_HighPassSubBands);
+      this->m_Levels, this->m_HighPassSubBands);
 }
 
 template< typename TInputImage,

--- a/include/itkWaveletUtilities.h
+++ b/include/itkWaveletUtilities.h
@@ -1,0 +1,100 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkWaveletUtilities_h
+#define itkWaveletUtilities_h
+
+#include <vector>
+#include <math.h>
+#include <algorithm>
+#include <itkFixedArray.h>
+#include <itkSize.h>
+
+namespace itk
+{
+namespace utils
+{
+  typedef std::pair<unsigned int, unsigned int> IndexPairType;
+
+  /** Get the (Level,Band) from a linear index output.
+   * The index corresponding to the low-pass image is the last one, corresponding to the IndexPairType(this->GetLevels(), 0).
+   * In a steerable pyramid: TotalOutputs = 1 + Levels * Bands
+   * The outputs are ordered, if n is the \c linearIndex:
+   * n:0 ---> level:0 band:1,
+   * n:1 ---> l:0, b:2, etc. until b == bands.
+   * n:bands-1 ---> l:0, b=bands
+   * If there is more than one level:
+   * n:bands ---> l:1, b=1
+   * if only one level:
+   * n:bands ---> l:0, b=0
+   * Independently of the numbers of levels or bands, the last index is always the low pass:
+   * nLowPass ---> l:Levels - 1, b=0
+   *
+   * Note that bands and levels are always >= 1. The level/bands returned here corresponds to an index.
+   */
+  IndexPairType IndexToLevelBandSteerablePyramid(unsigned int linearIndex,
+    unsigned int totalOutputs, unsigned int levels, unsigned int bands);
+
+  /** Compute max number of levels depending on the size of the image.
+   * Return J: $ J = \text{min_element}\{J_0,\ldots, J_d\} $;
+   * where each $J_i$ is the  number of integer divisions that can be done with the $i$ size and the scale factor.
+   */
+template < unsigned int VImageDimension >
+unsigned int ComputeMaxNumberOfLevels(const Size< VImageDimension >& inputSize, const unsigned int & scaleFactor)
+  {
+  FixedArray< unsigned int, VImageDimension > exponentPerAxis;
+  exponentPerAxis.Fill(1);
+  for ( unsigned int axis = 0; axis < VImageDimension; ++axis )
+    {
+    size_t sizeAxis = inputSize[axis];
+    double exponent = std::log(sizeAxis) / std::log(static_cast< double >(scaleFactor));
+    // check that exponent is integer: the fractional part is 0
+    double exponentIntPart;
+    double exponentFractionPart = std::modf(exponent, &exponentIntPart );
+    if ( exponentFractionPart == 0 )
+      {
+      exponentPerAxis[axis] = static_cast< unsigned int >(exponent);
+      }
+    else
+      {
+      // increase valid levels until the division size/scale_factor gives a non-integer.
+      double sizeAtLevel = static_cast<double>(sizeAxis);
+      for (;;)
+        {
+        double division = sizeAtLevel / static_cast<double>(scaleFactor);
+        double intPartDivision;
+        double fractionPartDivision = std::modf(division, &intPartDivision );
+        if ( fractionPartDivision == 0 )
+          {
+          exponentPerAxis[axis]++;
+          sizeAtLevel = intPartDivision;
+          }
+        else
+          {
+          break;
+          }
+        }
+      }
+    }
+  // return the min_element of array (1 if any size is not power of 2)
+  return *std::min_element(exponentPerAxis.Begin(), exponentPerAxis.End());
+  }
+
+} // end namespace utils
+} // end namespace itk
+
+#endif

--- a/include/itkWaveletUtilities.h
+++ b/include/itkWaveletUtilities.h
@@ -47,7 +47,7 @@ namespace utils
    * Note that bands and levels are always >= 1. The level/bands returned here corresponds to an index.
    */
   IndexPairType IndexToLevelBandSteerablePyramid(unsigned int linearIndex,
-    unsigned int totalOutputs, unsigned int levels, unsigned int bands);
+      unsigned int levels, unsigned int bands);
 
   /** Compute max number of levels depending on the size of the image.
    * Return J: $ J = \text{min_element}\{J_0,\ldots, J_d\} $;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(IsotropicWavelets_SRCS
   itkRieszUtilities.cxx
+  itkWaveletUtilities.cxx
   )
 ### generating libraries
 itk_module_add_library( IsotropicWavelets ${IsotropicWavelets_SRCS})

--- a/src/itkWaveletUtilities.cxx
+++ b/src/itkWaveletUtilities.cxx
@@ -41,7 +41,7 @@ IndexPairType IndexToLevelBandSteerablePyramid(unsigned int linearIndex,
   unsigned int level = (linearIndex ) / bands;
   itkAssertInDebugAndIgnoreInReleaseMacro( level < levels );
   return std::make_pair(level, band);
-  };
+  }
 
 // Instantiation
 template

--- a/src/itkWaveletUtilities.cxx
+++ b/src/itkWaveletUtilities.cxx
@@ -24,17 +24,21 @@ namespace utils
 {
 
 IndexPairType IndexToLevelBandSteerablePyramid(unsigned int linearIndex,
-  unsigned int totalOutputs, unsigned int levels, unsigned int bands)
+   unsigned int levels, unsigned int bands)
   {
+  unsigned int totalOutputs = 1 + levels * bands;
   if ( linearIndex > totalOutputs - 1 )
     {
-    itkGenericExceptionMacro(<< "Failed converting liner index " << linearIndex
-      << " to Level,Band pair : out of bounds");
+    itkGenericExceptionMacro(<< "Failed converting linearIndex " << linearIndex
+      << " with levels: " << levels << " bands: " << bands <<
+      " to Level,Band pair : out of bounds");
     }
 
   // Low pass (band = 0).
   if (linearIndex == totalOutputs - 1 )
+    {
     return std::make_pair(levels - 1, 0);
+    }
 
   unsigned int band = (linearIndex ) % bands + 1;
   // note integer division ahead.

--- a/src/itkWaveletUtilities.cxx
+++ b/src/itkWaveletUtilities.cxx
@@ -1,0 +1,53 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkWaveletUtilities.h"
+
+namespace itk
+{
+namespace utils
+{
+
+IndexPairType IndexToLevelBandSteerablePyramid(unsigned int linearIndex,
+  unsigned int totalOutputs, unsigned int levels, unsigned int bands)
+  {
+  if ( linearIndex > totalOutputs - 1 )
+    {
+    itkGenericExceptionMacro(<< "Failed converting liner index " << linearIndex
+      << " to Level,Band pair : out of bounds");
+    }
+
+  // Low pass (band = 0).
+  if (linearIndex == totalOutputs - 1 )
+    return std::make_pair(levels - 1, 0);
+
+  unsigned int band = (linearIndex ) % bands + 1;
+  // note integer division ahead.
+  unsigned int level = (linearIndex ) / bands;
+  itkAssertInDebugAndIgnoreInReleaseMacro( level < levels );
+  return std::make_pair(level, band);
+  };
+
+// Instantiation
+template
+unsigned int ComputeMaxNumberOfLevels<3>(const Size< 3 >& inputSize, const unsigned int & scaleFactor);
+
+template
+unsigned int ComputeMaxNumberOfLevels<2>(const Size< 2 >& inputSize, const unsigned int & scaleFactor);
+} // end namespace utils
+} // end namespace itk

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ set(IsotropicWaveletsTests
     itkWaveletFrequencyFilterBankGeneratorDownsampleTest.cxx
     itkWaveletFrequencyForwardTest.cxx
     itkWaveletFrequencyInverseTest.cxx
+    itkWaveletFrequencyForwardUndecimatedTest.cxx
     # Phase Analysis
     itkPhaseAnalysisSoftThresholdImageFilterTest.cxx
     # Riesz / Monogenic
@@ -45,9 +46,8 @@ set(IsotropicWaveletsTests
     # TODO Wavelet + Riesz + PhaseAnalysis. This is not an unit test. Convert to example or application.
     itkRieszWaveletPhaseAnalysisTest.cxx
     itkStructureTensorWithGeneralizedRieszTest.cxx
-    # TODO add Steerable framework?
+    # Steerable Riesz Matrix
     itkRieszRotationMatrixTest.cxx
-
   )
 
 if(ITKVtkGlue_ENABLED)
@@ -172,6 +172,12 @@ itk_add_test(NAME itkWaveletFrequencyForwardTest2D
   itkWaveletFrequencyForwardTest DATA{Input/checkershadow_Lch_512x512.tiff}
   ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyForwardTest2D.tiff
   1 1 "Held" 2)
+# Wavelet Forward Undecimated
+itk_add_test(NAME itkWaveletFrequencyForwardUndecimatedTest
+  COMMAND IsotropicWaveletsTestDriver
+  itkWaveletFrequencyForwardUndecimatedTest DATA{Input/collagen_64x64x16.tiff}
+  ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyForwardUndecimatedTest.tiff
+  2 1 "Simoncelli" )
 
 #Wavelet Inverse
 itk_add_test(NAME itkWaveletFrequencyInverseTest

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,7 @@ set(IsotropicWaveletsTests
     itkWaveletFrequencyForwardTest.cxx
     itkWaveletFrequencyInverseTest.cxx
     itkWaveletFrequencyForwardUndecimatedTest.cxx
+    itkWaveletFrequencyInverseUndecimatedTest.cxx
     # Phase Analysis
     itkPhaseAnalysisSoftThresholdImageFilterTest.cxx
     # Riesz / Monogenic
@@ -200,6 +201,19 @@ itk_add_test(NAME itkWaveletFrequencyInverseTestMultiLevelMultiBand
   ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyInverseTestMultiLevelMultiBand.tiff
   2 5
   "Held"
+  )
+# Wavelet Inverse Undecimated
+itk_add_test(NAME itkWaveletFrequencyInverseUndecimatedTest
+  COMMAND IsotropicWaveletsTestDriver
+    --compare DATA{Input/collagen_64x64x16.tiff}
+              ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyInverseUndecimatedTest.tiff
+  itkWaveletFrequencyInverseUndecimatedTest
+  DATA{Input/collagen_64x64x16.tiff}
+  ${ITK_TEST_OUTPUT_DIR}/itkWaveletFrequencyInverseUndecimatedTest.tiff
+  2 1
+  "Held"
+  "noFilterBankPyramid"
+  3
   )
 #2D
 itk_add_test(NAME itkWaveletFrequencyInverseTest2D

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set(IsotropicWaveletsTests
     itkWaveletFrequencyInverseTest.cxx
     itkWaveletFrequencyForwardUndecimatedTest.cxx
     itkWaveletFrequencyInverseUndecimatedTest.cxx
+    itkWaveletUtilitiesTest.cxx
     # Phase Analysis
     itkPhaseAnalysisSoftThresholdImageFilterTest.cxx
     # Riesz / Monogenic
@@ -237,6 +238,10 @@ itk_add_test(NAME itkWaveletFrequencyInverseTest2DMultiLevelMultiBand
   5 5
   "Held"
   2)
+# WaveletUtilities
+itk_add_test(NAME itkWaveletUtilitiesTest
+  COMMAND IsotropicWaveletsTestDriver
+  itkWaveletUtilitiesTest)
 #### TODO move StructureTensorGeneralizedRiesz and RieszWavelet to examples/applications.
 set(DefaultWavelet Held)
 # StructureTensor and Generalized Riesz.

--- a/test/itkWaveletFrequencyForwardTest.cxx
+++ b/test/itkWaveletFrequencyForwardTest.cxx
@@ -47,94 +47,6 @@ AppendToFilename(const std::string& filename, const std::string & appendix)
   return filename.substr( 0, foundDot ) + appendix + filename.substr( foundDot );
 }
 
-void printComputeMaxNumberOfLevelsError(itk::Size<3> inputSize, unsigned int scaleFactor,
-  unsigned int expected, unsigned int result)
-{
-  std::cerr << "Error in ComputeMaxNumberOfLevels with" << std::endl;
-  std::cerr << "scaleFactor = " << scaleFactor << std::endl;
-  std::cerr << "inputSize = " << inputSize << std::endl;
-  std::cerr << "Expected: " << expected << ", but got " << result << std::endl;
-}
-
-bool testComputeMaxNumberOfLevels()
-{
-  bool testPassed = true;
-  const unsigned int Dimension = 3;
-  typedef itk::Image<std::complex<double>, Dimension>  ComplexImageType;
-  typedef itk::HeldIsotropicWavelet<double, Dimension> WaveletFunctionType;
-  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, WaveletFunctionType >
-    WaveletFilterBankType;
-  typedef itk::WaveletFrequencyForward< ComplexImageType, ComplexImageType, WaveletFilterBankType >
-    ForwardWaveletType;
-
-  unsigned int scaleFactor = 2;
-  typedef ComplexImageType::SizeType SizeType;
-  SizeType inputSize;
-  inputSize.Fill(12);
-  unsigned int expected = 3;
-
-  unsigned int result = ForwardWaveletType::ComputeMaxNumberOfLevels(inputSize, scaleFactor);
-  if (result != expected)
-    {
-    printComputeMaxNumberOfLevelsError(inputSize, scaleFactor, expected, result);
-    testPassed = false;
-    }
-
-  inputSize.Fill(16);
-  expected = 4;
-  result = ForwardWaveletType::ComputeMaxNumberOfLevels(inputSize, scaleFactor);
-
-  if (result != expected)
-    {
-    printComputeMaxNumberOfLevelsError(inputSize, scaleFactor, expected, result);
-    testPassed = false;
-    }
-
-  inputSize.Fill(17);
-  expected = 1;
-  result = ForwardWaveletType::ComputeMaxNumberOfLevels(inputSize, scaleFactor);
-
-  if (result != expected)
-    {
-    printComputeMaxNumberOfLevelsError(inputSize, scaleFactor, expected, result);
-    testPassed = false;
-    }
-
-  inputSize.Fill(22);
-  expected = 2;
-  result = ForwardWaveletType::ComputeMaxNumberOfLevels(inputSize, scaleFactor);
-
-  if (result != expected)
-    {
-    printComputeMaxNumberOfLevelsError(inputSize, scaleFactor, expected, result);
-    testPassed = false;
-    }
-
-  inputSize.Fill(3);
-  expected = 1;
-  result = ForwardWaveletType::ComputeMaxNumberOfLevels(inputSize, scaleFactor);
-
-  if (result != expected)
-    {
-    printComputeMaxNumberOfLevelsError(inputSize, scaleFactor, expected, result);
-    testPassed = false;
-    }
-
-  // Change scaleFactor
-  scaleFactor = 3;
-  inputSize.Fill(27);
-  expected = 3;
-  result = ForwardWaveletType::ComputeMaxNumberOfLevels(inputSize, scaleFactor);
-
-  if (result != expected)
-    {
-    printComputeMaxNumberOfLevelsError(inputSize, scaleFactor, expected, result);
-    testPassed = false;
-    }
-
-  return testPassed;
-}
-
 template< unsigned int VDimension, typename TWaveletFunction >
 int
 runWaveletFrequencyForwardTest( const std::string& inputImage,
@@ -229,50 +141,6 @@ runWaveletFrequencyForwardTest( const std::string& inputImage,
     std::cout << "InputIndex: " << i << " --> lv:" << lv << " b:" << b << std::endl;
     }
 
-  // Test OutputIndexToLevelBand
-  bool testOutputIndexToLevelBandPassed = true;
-    {
-    std::pair< unsigned int, unsigned int > pairLvBand =
-      forwardWavelet->OutputIndexToLevelBand( 0 );
-    unsigned int lv = pairLvBand.first;
-    unsigned int b  = pairLvBand.second;
-    if ( lv != 0 || b != 0 )
-      {
-      std::cerr << "Error in first index: inputindex: " << 0 << " lv:" << lv << " b:" << b << " should be (0, 0)"
-                << std::endl;
-      testOutputIndexToLevelBandPassed = false;
-      }
-    }
-    {
-    std::pair< unsigned int, unsigned int > pairLvBand =
-      forwardWavelet->OutputIndexToLevelBand( highSubBands );
-    unsigned int lv = pairLvBand.first;
-    unsigned int b  = pairLvBand.second;
-    if ( lv != 1 || b != 0 )
-      {
-      std::cerr << "Error in inputindex: " << highSubBands << " lv:" << lv << " b:" << b << " should be (1, 0)"
-                << std::endl;
-      testOutputIndexToLevelBandPassed = false;
-      }
-    }
-    {
-    std::pair< unsigned int, unsigned int > pairLvBand =
-      forwardWavelet->OutputIndexToLevelBand( forwardWavelet->GetTotalOutputs() - 1 );
-    unsigned int lv = pairLvBand.first;
-    unsigned int b  = pairLvBand.second;
-    if ( lv != levels || b != 0 )
-      {
-      std::cerr << "Error in last inputindex: " << highSubBands << " lv:" << lv << " b:" << b << " should be ("
-                << levels << ", 0)" << std::endl;
-      testOutputIndexToLevelBandPassed = false;
-      }
-    }
-  if ( !testOutputIndexToLevelBandPassed )
-    {
-    std::cerr << "Error in OutputIndexToLevelBand" << std::endl;
-    testPassed = false;
-    }
-
   // Inverse FFT Transform (Multilevel)
   typedef itk::InverseFFTImageFilter< ComplexImageType, ImageType > InverseFFTFilterType;
   typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();
@@ -362,13 +230,6 @@ runWaveletFrequencyForwardTest( const std::string& inputImage,
       writer->SetInput( inverseFFT->GetOutput() );
       TRY_EXPECT_NO_EXCEPTION( writer->Update() );
       }
-    }
-
-  // Run ComputeMaxNumberOfLevel Test.
-  bool testLevelsPassed = testComputeMaxNumberOfLevels();
-  if (!testLevelsPassed)
-    {
-    testPassed = false;
     }
 
   if ( testPassed )

--- a/test/itkWaveletFrequencyForwardUndecimatedTest.cxx
+++ b/test/itkWaveletFrequencyForwardUndecimatedTest.cxx
@@ -141,50 +141,6 @@ runWaveletFrequencyForwardUndecimatedTest( const std::string& inputImage,
     std::cout << "InputIndex: " << i << " --> lv:" << lv << " b:" << b << std::endl;
     }
 
-  // Test OutputIndexToLevelBand
-  bool testOutputIndexToLevelBandPassed = true;
-    {
-    std::pair< unsigned int, unsigned int > pairLvBand =
-      forwardWavelet->OutputIndexToLevelBand( 0 );
-    unsigned int lv = pairLvBand.first;
-    unsigned int b  = pairLvBand.second;
-    if ( lv != 0 || b != 0 )
-      {
-      std::cerr << "Error in first index: inputindex: " << 0 << " lv:" << lv << " b:" << b << " should be (0, 0)"
-                << std::endl;
-      testOutputIndexToLevelBandPassed = false;
-      }
-    }
-    {
-    std::pair< unsigned int, unsigned int > pairLvBand =
-      forwardWavelet->OutputIndexToLevelBand( highSubBands );
-    unsigned int lv = pairLvBand.first;
-    unsigned int b  = pairLvBand.second;
-    if ( lv != 1 || b != 0 )
-      {
-      std::cerr << "Error in inputindex: " << highSubBands << " lv:" << lv << " b:" << b << " should be (1, 0)"
-                << std::endl;
-      testOutputIndexToLevelBandPassed = false;
-      }
-    }
-    {
-    std::pair< unsigned int, unsigned int > pairLvBand =
-      forwardWavelet->OutputIndexToLevelBand( forwardWavelet->GetTotalOutputs() - 1 );
-    unsigned int lv = pairLvBand.first;
-    unsigned int b  = pairLvBand.second;
-    if ( lv != levels || b != 0 )
-      {
-      std::cerr << "Error in last inputindex: " << highSubBands << " lv:" << lv << " b:" << b << " should be ("
-                << levels << ", 0)" << std::endl;
-      testOutputIndexToLevelBandPassed = false;
-      }
-    }
-  if ( !testOutputIndexToLevelBandPassed )
-    {
-    std::cerr << "Error in OutputIndexToLevelBand" << std::endl;
-    testPassed = false;
-    }
-
   // Inverse FFT Transform (Multilevel)
   typedef itk::InverseFFTImageFilter< ComplexImageType, ImageType > InverseFFTFilterType;
   typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();

--- a/test/itkWaveletFrequencyForwardUndecimatedTest.cxx
+++ b/test/itkWaveletFrequencyForwardUndecimatedTest.cxx
@@ -1,0 +1,439 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImage.h"
+#include "itkImageFileReader.h"
+#include "itkImageFileWriter.h"
+#include "itkWaveletFrequencyForwardUndecimated.h"
+#include "itkWaveletFrequencyFilterBankGenerator.h"
+#include "itkHeldIsotropicWavelet.h"
+#include "itkVowIsotropicWavelet.h"
+#include "itkSimoncelliIsotropicWavelet.h"
+#include "itkShannonIsotropicWavelet.h"
+#include "itkForwardFFTImageFilter.h"
+#include "itkInverseFFTImageFilter.h"
+#include "itkComplexToRealImageFilter.h"
+#include "itkNumberToString.h"
+#include "itkTestingMacros.h"
+
+#include <memory>
+#include <string>
+#include <cmath>
+
+// Visualize for dev/debug purposes. Set in cmake file. Requires VTK
+#ifdef ITK_VISUALIZE_TESTS
+#include "itkViewImage.h"
+#endif
+
+std::string
+AppendToFilenameUndecimated(const std::string& filename, const std::string & appendix)
+{
+  std::size_t foundDot = filename.find_last_of('.');
+  return filename.substr( 0, foundDot ) + appendix + filename.substr( foundDot );
+}
+
+template< unsigned int VDimension, typename TWaveletFunction >
+int
+runWaveletFrequencyForwardUndecimatedTest( const std::string& inputImage,
+  const std::string& outputImage,
+  const unsigned int& inputLevels,
+  const unsigned int& inputBands)
+{
+  bool testPassed = true;
+  const unsigned int Dimension = VDimension;
+
+  typedef float                              PixelType;
+  typedef itk::Image< PixelType, Dimension > ImageType;
+  typedef itk::ImageFileReader< ImageType >  ReaderType;
+
+  typename ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName( inputImage );
+  reader->Update();
+
+  // Perform FFT on input image.
+  typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
+  typename FFTFilterType::Pointer fftFilter = FFTFilterType::New();
+  fftFilter->SetInput( reader->GetOutput() );
+
+  typedef typename FFTFilterType::OutputImageType ComplexImageType;
+
+  // Set the WaveletFunctionType and the WaveletFilterBank
+  typedef TWaveletFunction WaveletFunctionType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, WaveletFunctionType >
+    WaveletFilterBankType;
+  typedef itk::WaveletFrequencyForwardUndecimated< ComplexImageType, ComplexImageType, WaveletFilterBankType >
+    ForwardWaveletType;
+
+  unsigned int highSubBands = inputBands;
+  unsigned int levels = inputLevels;
+
+  typename ForwardWaveletType::Pointer forwardWavelet = ForwardWaveletType::New();
+  forwardWavelet->SetHighPassSubBands( highSubBands );
+  forwardWavelet->SetLevels(levels);
+  forwardWavelet->SetInput(fftFilter->GetOutput());
+  typename WaveletFunctionType::Pointer waveletInstance = forwardWavelet->GetModifiableWaveletFunction();
+  waveletInstance->Print(std::cout);
+  forwardWavelet->Update();
+
+  // Regression tests
+  typedef typename ForwardWaveletType::OutputsType OutputsType;
+  OutputsType allOutputs =
+    forwardWavelet->GetOutputs();
+  unsigned int expectedNumberOfOutputs = forwardWavelet->GetTotalOutputs();
+  unsigned int computedNumberOfOutputs = forwardWavelet->GetOutputs().size();
+  if ( computedNumberOfOutputs != expectedNumberOfOutputs )
+    {
+    std::cerr << "Error in GetTotalOutputs()" << std::endl;
+    std::cerr << "Expected: " << expectedNumberOfOutputs << ", but got "
+              << computedNumberOfOutputs << std::endl;
+    testPassed = false;
+    }
+
+  typename ForwardWaveletType::OutputImagePointer lowPass =
+    forwardWavelet->GetOutputLowPass();
+
+  OutputsType allHighSubBands = forwardWavelet->GetOutputsHighPass();
+  unsigned int expectedNumberOfHighSubBands =
+    forwardWavelet->GetTotalOutputs() - 1;
+  unsigned int computedNumberOfHighSubBands =
+    forwardWavelet->GetOutputsHighPass().size();
+  if ( computedNumberOfHighSubBands != expectedNumberOfHighSubBands )
+    {
+    std::cerr << "Error in GetOutputsHighPass()" << std::endl;
+    std::cerr << "Expected: " << expectedNumberOfHighSubBands << ", but got "
+              << computedNumberOfHighSubBands << std::endl;
+    testPassed = false;
+    }
+
+  OutputsType highSubBandsPerLevel = forwardWavelet->GetOutputsHighPassByLevel(0);
+  unsigned int expectedNumberOfHighSubBandsPerLevel =
+    forwardWavelet->GetHighPassSubBands();
+  unsigned int computedNumberOfHighSubBandsPerLevel =
+    forwardWavelet->GetOutputsHighPassByLevel( 0 ).size();
+  if ( computedNumberOfHighSubBandsPerLevel != expectedNumberOfHighSubBandsPerLevel )
+    {
+    std::cerr << "Error in GetOutputsHighPassByLevel()" << std::endl;
+    std::cerr << "Expected: " << expectedNumberOfHighSubBandsPerLevel << ", but got "
+              << computedNumberOfHighSubBandsPerLevel << std::endl;
+    testPassed = false;
+    }
+  for ( unsigned int i = 0; i < forwardWavelet->GetNumberOfOutputs(); ++i )
+    {
+    std::pair< unsigned int, unsigned int > pairLvBand =
+      forwardWavelet->OutputIndexToLevelBand( i );
+    unsigned int lv = pairLvBand.first;
+    unsigned int b  = pairLvBand.second;
+    std::cout << "InputIndex: " << i << " --> lv:" << lv << " b:" << b << std::endl;
+    }
+
+  // Test OutputIndexToLevelBand
+  bool testOutputIndexToLevelBandPassed = true;
+    {
+    std::pair< unsigned int, unsigned int > pairLvBand =
+      forwardWavelet->OutputIndexToLevelBand( 0 );
+    unsigned int lv = pairLvBand.first;
+    unsigned int b  = pairLvBand.second;
+    if ( lv != 0 || b != 0 )
+      {
+      std::cerr << "Error in first index: inputindex: " << 0 << " lv:" << lv << " b:" << b << " should be (0, 0)"
+                << std::endl;
+      testOutputIndexToLevelBandPassed = false;
+      }
+    }
+    {
+    std::pair< unsigned int, unsigned int > pairLvBand =
+      forwardWavelet->OutputIndexToLevelBand( highSubBands );
+    unsigned int lv = pairLvBand.first;
+    unsigned int b  = pairLvBand.second;
+    if ( lv != 1 || b != 0 )
+      {
+      std::cerr << "Error in inputindex: " << highSubBands << " lv:" << lv << " b:" << b << " should be (1, 0)"
+                << std::endl;
+      testOutputIndexToLevelBandPassed = false;
+      }
+    }
+    {
+    std::pair< unsigned int, unsigned int > pairLvBand =
+      forwardWavelet->OutputIndexToLevelBand( forwardWavelet->GetTotalOutputs() - 1 );
+    unsigned int lv = pairLvBand.first;
+    unsigned int b  = pairLvBand.second;
+    if ( lv != levels || b != 0 )
+      {
+      std::cerr << "Error in last inputindex: " << highSubBands << " lv:" << lv << " b:" << b << " should be ("
+                << levels << ", 0)" << std::endl;
+      testOutputIndexToLevelBandPassed = false;
+      }
+    }
+  if ( !testOutputIndexToLevelBandPassed )
+    {
+    std::cerr << "Error in OutputIndexToLevelBand" << std::endl;
+    testPassed = false;
+    }
+
+  // Inverse FFT Transform (Multilevel)
+  typedef itk::InverseFFTImageFilter< ComplexImageType, ImageType > InverseFFTFilterType;
+  typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();
+
+  typedef itk::ImageFileWriter< typename InverseFFTFilterType::OutputImageType > WriterType;
+  typename WriterType::Pointer writer = WriterType::New();
+
+  typename ComplexImageType::SpacingType inputSpacing;
+  inputSpacing.Fill(1.0);
+  typename ComplexImageType::SpacingType expectedSpacing = inputSpacing;
+  typename ComplexImageType::PointType inputOrigin;
+  inputOrigin.Fill(0.0);
+  typename ComplexImageType::PointType expectedOrigin = inputOrigin;
+  typename ComplexImageType::SizeType inputSize = fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize();
+  typename ComplexImageType::SizeType expectedSize = inputSize;
+  itk::NumberToString< unsigned int > n2s;
+  for ( unsigned int level = 0; level < levels + 1; ++level )
+    {
+    for ( unsigned int i = 0; i < Dimension; ++i )
+      {
+      expectedSize[i] = inputSize[i];
+      expectedOrigin[i] = inputOrigin[i];
+      expectedSpacing[i] = inputSpacing[i];
+      }
+    for ( unsigned int band = 0; band < highSubBands; ++band )
+      {
+      bool sizeIsCorrect = true;
+      bool spacingIsCorrect = true;
+      bool originIsCorrect = true;
+
+      unsigned int nOutput =
+        level * forwardWavelet->GetHighPassSubBands() + band;
+
+      // Do not compute bands in low-pass level.
+      if ( level == levels && band == 0 )
+        {
+        nOutput = forwardWavelet->GetTotalOutputs() - 1;
+        }
+      else if ( level == levels && band != 0 )
+        {
+        break;
+        }
+
+      if ( expectedSize != forwardWavelet->GetOutput( nOutput )->GetLargestPossibleRegion().GetSize() )
+        {
+        std::cerr << "Size of the output: " << forwardWavelet->GetOutput( nOutput )->GetLargestPossibleRegion().GetSize() << " is not as expected: " << expectedSize << std::endl;
+        sizeIsCorrect = false;
+        }
+      if ( expectedOrigin != forwardWavelet->GetOutput( nOutput )->GetOrigin() )
+        {
+        std::cerr << "Origin of the output: " << forwardWavelet->GetOutput( nOutput )->GetOrigin() << " is not as expected: " << expectedOrigin << std::endl;
+        originIsCorrect = false;
+        }
+      if ( expectedSpacing != forwardWavelet->GetOutput( nOutput )->GetSpacing() )
+        {
+        std::cerr << "Spacing of the output: " << forwardWavelet->GetOutput( nOutput )->GetSpacing() << " is not as expected: " << expectedSpacing << std::endl;
+        spacingIsCorrect = false;
+        }
+
+      if ( !sizeIsCorrect || !originIsCorrect || !spacingIsCorrect )
+        {
+        testPassed = false;
+        std::cerr << "OutputIndex : " << nOutput << std::endl;
+        std::cerr << "Level: " << level  << " / " << forwardWavelet->GetLevels() << std::endl;
+        std::cerr << "Band: " << band  << " / " << forwardWavelet->GetHighPassSubBands() << std::endl;
+        // std::cerr << "Largest Region: " << forwardWavelet->GetOutput( nOutput )->GetLargestPossibleRegion() << std::endl;
+        std::cerr << "Origin: " << forwardWavelet->GetOutput( nOutput )->GetOrigin() << std::endl;
+        std::cerr << "Spacing: " << forwardWavelet->GetOutput( nOutput )->GetSpacing() << std::endl;
+        std::cerr << "RegionSize: " << forwardWavelet->GetOutput( nOutput )->GetLargestPossibleRegion().GetSize()
+                  << std::endl;
+        }
+
+      inverseFFT->SetInput(forwardWavelet->GetOutput( nOutput ) );
+      inverseFFT->Update();
+
+#ifdef ITK_VISUALIZE_TESTS
+      std::pair< unsigned int, unsigned int > pairLvBand =
+        forwardWavelet->OutputIndexToLevelBand( nOutput );
+      itk::Testing::ViewImage( inverseFFT->GetOutput(),
+        "Wavelet coef. n_out: " + n2s( nOutput ) + " level: " + n2s( pairLvBand.first )
+        + " , band: " +  n2s( pairLvBand.second ) + "/" + n2s( inputBands ) );
+#endif
+
+      writer->SetFileName( AppendToFilenameUndecimated( outputImage, n2s( nOutput ) ) );
+      writer->SetInput( inverseFFT->GetOutput() );
+      TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+      }
+    }
+
+  if ( testPassed )
+    {
+    return EXIT_SUCCESS;
+    }
+  else
+    {
+    return EXIT_FAILURE;
+    }
+}
+
+int
+itkWaveletFrequencyForwardUndecimatedTest( int argc, char *argv[] )
+{
+  if ( argc < 6 || argc > 7 )
+    {
+    std::cerr << "Usage: " << argv[0]
+              << " inputImage outputImage inputLevels inputBands waveletFunction [dimension]" << std::endl;
+    return EXIT_FAILURE;
+    }
+  const std::string inputImage  = argv[1];
+  const std::string outputImage = argv[2];
+  const unsigned int inputLevels = atoi(argv[3] );
+  const unsigned int inputBands  = atoi( argv[4] );
+  const std::string waveletFunction = argv[5];
+
+  unsigned int dimension = 3;
+  if ( argc == 7 )
+    {
+    dimension = atoi( argv[6] );
+    }
+
+  const unsigned int ImageDimension = 3;
+  typedef double                                         PixelType;
+  typedef std::complex< PixelType >                      ComplexPixelType;
+  typedef itk::Point< PixelType, ImageDimension >        PointType;
+  typedef itk::Image< ComplexPixelType, ImageDimension > ComplexImageType;
+
+  // Exercise basic object methods
+  // Done outside the helper function in the test because GCC is limited
+  // when calling overloaded base class functions.
+  typedef itk::HeldIsotropicWavelet< PixelType, ImageDimension, PointType >
+    HeldIsotropicWaveletType;
+  typedef itk::VowIsotropicWavelet< PixelType, ImageDimension, PointType >
+    VowIsotropicWaveletType;
+  typedef itk::SimoncelliIsotropicWavelet< PixelType, ImageDimension, PointType >
+    SimoncelliIsotropicWaveletType;
+  typedef itk::ShannonIsotropicWavelet< PixelType, ImageDimension, PointType >
+    ShannonIsotropicWaveletType;
+
+  HeldIsotropicWaveletType::Pointer heldIsotropicWavelet =
+    HeldIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( heldIsotropicWavelet, HeldIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+  VowIsotropicWaveletType::Pointer vowIsotropicWavelet =
+    VowIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( vowIsotropicWavelet, VowIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+  SimoncelliIsotropicWaveletType::Pointer simoncellidIsotropicWavelet =
+    SimoncelliIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( simoncellidIsotropicWavelet, SimoncelliIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+  ShannonIsotropicWaveletType::Pointer shannonIsotropicWavelet = ShannonIsotropicWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( shannonIsotropicWavelet, ShannonIsotropicWavelet,
+    IsotropicWaveletFrequencyFunction );
+
+  typedef itk::HeldIsotropicWavelet< >       HeldWavelet;
+  typedef itk::VowIsotropicWavelet< >        VowWavelet;
+  typedef itk::SimoncelliIsotropicWavelet< > SimoncelliWavelet;
+  typedef itk::ShannonIsotropicWavelet< >    ShannonWavelet;
+
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, HeldWavelet >
+    HeldWaveletFilterBankType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, VowWavelet >
+    VowWaveletFilterBankType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, SimoncelliWavelet >
+    SimoncelliWaveletFilterBankType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, ShannonWavelet >
+    ShannonWaveletFilterBankType;
+
+  typedef itk::WaveletFrequencyForwardUndecimated< ComplexImageType, ComplexImageType, HeldWaveletFilterBankType >
+    HeldForwardWaveletType;
+  HeldForwardWaveletType::Pointer heldForwardWavelet = HeldForwardWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( heldForwardWavelet, WaveletFrequencyForwardUndecimated,
+    ImageToImageFilter );
+
+  typedef itk::WaveletFrequencyForwardUndecimated< ComplexImageType, ComplexImageType, VowWaveletFilterBankType >
+    VowForwardWaveletType;
+  VowForwardWaveletType::Pointer vowForwardWavelet = VowForwardWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( vowForwardWavelet, WaveletFrequencyForwardUndecimated,
+    ImageToImageFilter );
+
+  typedef itk::WaveletFrequencyForwardUndecimated< ComplexImageType, ComplexImageType, SimoncelliWaveletFilterBankType >
+    SimoncelliForwardWaveletType;
+  SimoncelliForwardWaveletType::Pointer simoncelliForwardWavelet = SimoncelliForwardWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( simoncelliForwardWavelet, WaveletFrequencyForwardUndecimated,
+    ImageToImageFilter );
+
+  typedef itk::WaveletFrequencyForwardUndecimated< ComplexImageType, ComplexImageType, ShannonWaveletFilterBankType >
+    ShannonForwardWaveletType;
+  ShannonForwardWaveletType::Pointer shannonForwardWavelet = ShannonForwardWaveletType::New();
+  EXERCISE_BASIC_OBJECT_METHODS( shannonForwardWavelet, WaveletFrequencyForwardUndecimated,
+    ImageToImageFilter );
+
+  if ( dimension == 2 )
+    {
+    if ( waveletFunction == "Held" )
+      {
+      return runWaveletFrequencyForwardUndecimatedTest< 2, HeldWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if ( waveletFunction == "Vow" )
+      {
+      return runWaveletFrequencyForwardUndecimatedTest< 2, VowWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if ( waveletFunction == "Simoncelli" )
+      {
+      return runWaveletFrequencyForwardUndecimatedTest< 2, SimoncelliWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if ( waveletFunction == "Shannon" )
+      {
+      return runWaveletFrequencyForwardUndecimatedTest< 2, ShannonWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else
+      {
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << argv[5] << " wavelet type not supported." << std::endl;
+      return EXIT_FAILURE;
+      }
+    }
+  else if ( dimension == 3 )
+    {
+    if ( waveletFunction == "Held" )
+      {
+      return runWaveletFrequencyForwardUndecimatedTest< 3, HeldWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if ( waveletFunction == "Vow" )
+      {
+      return runWaveletFrequencyForwardUndecimatedTest< 3, VowWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if ( waveletFunction == "Simoncelli" )
+      {
+      return runWaveletFrequencyForwardUndecimatedTest< 3, SimoncelliWavelet >(inputImage, outputImage, inputLevels, inputBands );
+      }
+    else if ( waveletFunction == "Shannon" )
+      {
+      return runWaveletFrequencyForwardUndecimatedTest< 3, ShannonWavelet >( inputImage, outputImage, inputLevels, inputBands );
+      }
+    else
+      {
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << argv[5] << " wavelet type not supported." << std::endl;
+      return EXIT_FAILURE;
+      }
+    }
+  else
+    {
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error: only 2 or 3 dimensions allowed, " << dimension << " selected." << std::endl;
+    return EXIT_FAILURE;
+    }
+}

--- a/test/itkWaveletFrequencyInverseUndecimatedTest.cxx
+++ b/test/itkWaveletFrequencyInverseUndecimatedTest.cxx
@@ -1,0 +1,350 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkImage.h"
+#include "itkImageFileReader.h"
+#include "itkImageFileWriter.h"
+#include "itkWaveletFrequencyForwardUndecimated.h"
+#include "itkWaveletFrequencyInverseUndecimated.h"
+#include "itkWaveletFrequencyFilterBankGenerator.h"
+#include "itkHeldIsotropicWavelet.h"
+#include "itkVowIsotropicWavelet.h"
+#include "itkSimoncelliIsotropicWavelet.h"
+#include "itkShannonIsotropicWavelet.h"
+#include "itkForwardFFTImageFilter.h"
+#include "itkInverseFFTImageFilter.h"
+#include "itkTestingMacros.h"
+
+#include <memory>
+#include <string>
+#include <cmath>
+
+#ifdef ITK_VISUALIZE_TESTS
+#include "itkComplexToRealImageFilter.h"
+#include "itkNumberToString.h"
+#include "itkViewImage.h"
+#endif
+
+template< unsigned int VDimension, typename TWaveletFunction >
+int
+runWaveletFrequencyInverseUndecimatedTest( const std::string& inputImage,
+  const std::string& outputImage,
+  const unsigned int& inputLevels,
+  const unsigned int& inputBands,
+  bool inputUseWaveletFilterBankPyramid)
+{
+  bool testPassed = true;
+  const unsigned int Dimension = VDimension;
+
+  typedef float                              PixelType;
+  typedef itk::Image< PixelType, Dimension > ImageType;
+  typedef itk::ImageFileReader< ImageType >  ReaderType;
+
+  typename ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName( inputImage );
+  reader->Update();
+  reader->UpdateLargestPossibleRegion();
+
+  // Perform FFT on input image.
+  typedef itk::ForwardFFTImageFilter< ImageType > FFTFilterType;
+  typename FFTFilterType::Pointer fftFilter = FFTFilterType::New();
+  fftFilter->SetInput( reader->GetOutput() );
+
+  typedef typename FFTFilterType::OutputImageType ComplexImageType;
+
+  // Set the WaveletFunctionType and the WaveletFilterBank
+  typedef TWaveletFunction WaveletFunctionType;
+  typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, WaveletFunctionType >
+    WaveletFilterBankType;
+  typedef itk::WaveletFrequencyForwardUndecimated< ComplexImageType, ComplexImageType, WaveletFilterBankType >
+    ForwardWaveletType;
+
+  typename ForwardWaveletType::Pointer forwardWavelet = ForwardWaveletType::New();
+
+  forwardWavelet->SetHighPassSubBands( inputBands );
+  forwardWavelet->SetLevels( inputLevels );
+  forwardWavelet->SetInput( fftFilter->GetOutput() );
+  forwardWavelet->StoreWaveletFilterBankPyramidOn();
+  forwardWavelet->Update();
+
+  unsigned int noutputs = forwardWavelet->GetNumberOfOutputs();
+
+  std::cout << "Number of inputs: " << noutputs << std::endl;
+  for ( unsigned int i = 0; i < noutputs; ++i )
+    {
+    std::cout << "Input number: " << i << std::endl;
+    std::cout << "Region: " << forwardWavelet->GetOutput(i)->GetLargestPossibleRegion() << std::endl;
+    std::cout << "Spacing: " << forwardWavelet->GetOutput(i)->GetSpacing() << std::endl;
+    }
+
+  // Inverse Wavelet Transform
+  typedef itk::WaveletFrequencyInverseUndecimated< ComplexImageType, ComplexImageType, WaveletFilterBankType >
+    InverseWaveletType;
+  typename InverseWaveletType::Pointer inverseWavelet = InverseWaveletType::New();
+
+  inverseWavelet->SetHighPassSubBands( inputBands );
+  inverseWavelet->SetLevels( inputLevels );
+  inverseWavelet->SetInputs( forwardWavelet->GetOutputs() );
+  inverseWavelet->SetUseWaveletFilterBankPyramid( inputUseWaveletFilterBankPyramid );
+  inverseWavelet->SetWaveletFilterBankPyramid( forwardWavelet->GetWaveletFilterBankPyramid() );
+  inverseWavelet->DebugOn();
+  inverseWavelet->Update();
+
+  // Check Metadata: Spacing, Origin
+  typename ComplexImageType::SpacingType outputSpacing =
+    inverseWavelet->GetOutput()->GetSpacing();
+  typename ComplexImageType::SpacingType expectedSpacing;
+  expectedSpacing.Fill(1.0);
+  typename ComplexImageType::PointType outputOrigin =
+    inverseWavelet->GetOutput()->GetOrigin();
+  typename ComplexImageType::PointType expectedOrigin;
+  expectedOrigin.Fill(0.0);
+  typename ComplexImageType::SizeType outputSize =
+    inverseWavelet->GetOutput()->GetLargestPossibleRegion().GetSize();
+  typename ComplexImageType::SizeType expectedSize =
+    fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize();
+
+  if ( outputSpacing != expectedSpacing )
+    {
+    std::cout << "outputSpacing is wrong: " << outputSpacing
+              << " expectedSpacing: " << expectedSpacing
+              << std::endl;
+    testPassed = false;
+    }
+  if ( outputOrigin != expectedOrigin )
+    {
+    std::cout << "outputOrigin is wrong: " << outputOrigin
+              << " expectedOrigin: " << expectedOrigin
+              << std::endl;
+    testPassed = false;
+    }
+  if ( outputSize != expectedSize )
+    {
+    std::cout << "outputSize is wrong: " << outputSize
+              << " expectedSize: " << expectedSize
+              << std::endl;
+    testPassed = false;
+    }
+
+  typedef itk::InverseFFTImageFilter< ComplexImageType, ImageType > InverseFFTFilterType;
+  typename InverseFFTFilterType::Pointer inverseFFT = InverseFFTFilterType::New();
+  inverseFFT->SetInput( inverseWavelet->GetOutput() );
+  inverseFFT->Update();
+
+  // Write output image
+  typedef itk::ImageFileWriter< ImageType > WriterType;
+  typename WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName( outputImage );
+  writer->SetInput( inverseFFT->GetOutput() );
+
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+
+#ifdef ITK_VISUALIZE_TESTS
+  itk::Testing::ViewImage( reader->GetOutput(), "Original" );
+  itk::Testing::ViewImage( inverseFFT->GetOutput(), "InverseWavelet" );
+#endif
+
+  // TODO move it from here to Forward test.
+#ifdef ITK_VISUALIZE_TESTS
+  std::vector< typename ComplexImageType::Pointer > waveletFilterBankPyramid =
+    forwardWavelet->GetWaveletFilterBankPyramid();
+  typedef itk::ComplexToRealImageFilter< ComplexImageType, ImageType > ComplexToRealFilterType;
+  typename ComplexToRealFilterType::Pointer complexToRealFilter = ComplexToRealFilterType::New();
+
+  itk::NumberToString< unsigned int > n2s;
+  std::cout << "Size FilterBankPyramid:" << waveletFilterBankPyramid.size() << std::endl;
+  for ( unsigned int i = 0; i < waveletFilterBankPyramid.size(); ++i )
+    {
+    complexToRealFilter->SetInput( waveletFilterBankPyramid[i]);
+    complexToRealFilter->UpdateLargestPossibleRegion();
+    itk::Testing::ViewImage( complexToRealFilter->GetOutput(), "FilterBankPyramid #" + n2s(i) );
+    }
+#endif
+
+  if ( testPassed )
+    {
+    return EXIT_SUCCESS;
+    }
+  else
+    {
+    return EXIT_FAILURE;
+    }
+}
+
+int
+itkWaveletFrequencyInverseUndecimatedTest(int argc, char *argv[])
+{
+  if ( argc != 8 )
+    {
+    std::cerr << "Usage: " << argv[0]
+              << " inputImage outputImage inputLevels inputBands waveletFunction reuseFilterBankPyramid|noFilterBankPyramid dimension" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  const std::string inputImage  = argv[1];
+  const std::string outputImage = argv[2];
+  const unsigned int inputLevels = atoi( argv[3] );
+  const unsigned int inputBands  = atoi( argv[4] );
+  const std::string waveletFunction = argv[5];
+  const std::string inputUseWaveletFilterBankPyramid = argv[6];
+  bool useWaveletFilterBankPyramid;
+  if (inputUseWaveletFilterBankPyramid == "reuseFilterBankPyramid")
+    {
+    useWaveletFilterBankPyramid = true;
+    }
+  else if (inputUseWaveletFilterBankPyramid == "noFilterBankPyramid")
+    {
+    useWaveletFilterBankPyramid = false;
+    }
+
+  unsigned int dimension = atoi( argv[7] );
+
+  // const unsigned int ImageDimension = 3;
+  // typedef double                                          PixelType;
+  // typedef std::complex< PixelType >                       ComplexPixelType;
+  // typedef itk::Point< PixelType, ImageDimension >         PointType;
+  // typedef itk::Image< ComplexPixelType, ImageDimension >  ComplexImageType;
+
+  // // Exercise basic object methods
+  // // Done outside the helper function in the test because GCC is limited
+  // // when calling overloaded base class functions.
+  // typedef itk::HeldIsotropicWavelet< PixelType, ImageDimension, PointType >
+  //   HeldIsotropicWaveletType;
+  // typedef itk::VowIsotropicWavelet< PixelType, ImageDimension, PointType >
+  //   VowIsotropicWaveletType;
+  // typedef itk::SimoncelliIsotropicWavelet< PixelType, ImageDimension, PointType >
+  //   SimoncelliIsotropicWaveletType;
+  // typedef itk::ShannonIsotropicWavelet< PixelType, ImageDimension, PointType >
+  //   ShannonIsotropicWaveletType;
+  //
+  // HeldIsotropicWaveletType::Pointer heldIsotropicWavelet =
+  //   HeldIsotropicWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( heldIsotropicWavelet, HeldIsotropicWavelet,
+  //   IsotropicWaveletFrequencyFunction );
+  //
+  // VowIsotropicWaveletType::Pointer vowIsotropicWavelet =
+  //   VowIsotropicWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( vowIsotropicWavelet, VowIsotropicWavelet,
+  //   IsotropicWaveletFrequencyFunction );
+  //
+  // SimoncelliIsotropicWaveletType::Pointer simoncellidIsotropicWavelet =
+  //   SimoncelliIsotropicWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( simoncellidIsotropicWavelet, SimoncelliIsotropicWavelet,
+  //   IsotropicWaveletFrequencyFunction );
+  //
+  // ShannonIsotropicWaveletType::Pointer shannonIsotropicWavelet = ShannonIsotropicWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( shannonIsotropicWavelet, ShannonIsotropicWavelet,
+  //   IsotropicWaveletFrequencyFunction );
+  //
+  //
+  typedef itk::HeldIsotropicWavelet< >       HeldWavelet;
+  typedef itk::VowIsotropicWavelet< >        VowWavelet;
+  typedef itk::SimoncelliIsotropicWavelet< > SimoncelliWavelet;
+  typedef itk::ShannonIsotropicWavelet< >    ShannonWavelet;
+  //
+  //
+  // typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, HeldWavelet >
+  //   HeldWaveletFilterBankType;
+  // typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, VowWavelet >
+  //   VowWaveletFilterBankType;
+  // typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, SimoncelliWavelet >
+  //   SimoncelliWaveletFilterBankType;
+  // typedef itk::WaveletFrequencyFilterBankGenerator< ComplexImageType, ShannonWavelet >
+  //   ShannonWaveletFilterBankType;
+  //
+  // typedef itk::WaveletFrequencyInverseUndecimated< ComplexImageType, ComplexImageType, HeldWaveletFilterBankType >
+  //   HeldInverseWaveletType;
+  // HeldInverseWaveletType::Pointer heldInverseWavelet = HeldInverseWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( heldInverseWavelet, WaveletFrequencyInverseUndecimated,
+  //   ImageToImageFilter );
+  //
+  // typedef itk::WaveletFrequencyInverseUndecimated< ComplexImageType, ComplexImageType, VowWaveletFilterBankType >
+  //   VowInverseWaveletType;
+  // VowInverseWaveletType::Pointer vowInverseWavelet = VowInverseWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( vowInverseWavelet, WaveletFrequencyInverseUndecimated,
+  //   ImageToImageFilter );
+  //
+  // typedef itk::WaveletFrequencyInverseUndecimated< ComplexImageType, ComplexImageType, SimoncelliWaveletFilterBankType >
+  //   SimoncelliInverseWaveletType;
+  // SimoncelliInverseWaveletType::Pointer simoncelliInverseWavelet = SimoncelliInverseWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( simoncelliInverseWavelet, WaveletFrequencyInverseUndecimated,
+  //   ImageToImageFilter );
+  //
+  // typedef itk::WaveletFrequencyInverseUndecimated< ComplexImageType, ComplexImageType, ShannonWaveletFilterBankType >
+  //   ShannonInverseWaveletType;
+  // ShannonInverseWaveletType::Pointer shannonInverseWavelet = ShannonInverseWaveletType::New();
+  // EXERCISE_BASIC_OBJECT_METHODS( shannonInverseWavelet, WaveletFrequencyInverseUndecimated,
+  //   ImageToImageFilter );
+
+  if ( dimension == 2 )
+    {
+    if ( waveletFunction == "Held" )
+      {
+      return runWaveletFrequencyInverseUndecimatedTest< 2, HeldWavelet >( inputImage, outputImage, inputLevels, inputBands, useWaveletFilterBankPyramid );
+      }
+    else if ( waveletFunction == "Vow" )
+      {
+      return runWaveletFrequencyInverseUndecimatedTest< 2, VowWavelet >( inputImage, outputImage, inputLevels, inputBands, useWaveletFilterBankPyramid );
+      }
+    else if ( waveletFunction == "Simoncelli" )
+      {
+      return runWaveletFrequencyInverseUndecimatedTest< 2, SimoncelliWavelet >( inputImage, outputImage, inputLevels, inputBands, useWaveletFilterBankPyramid );
+      }
+    else if ( waveletFunction == "Shannon" )
+      {
+      return runWaveletFrequencyInverseUndecimatedTest< 2, ShannonWavelet >( inputImage, outputImage, inputLevels, inputBands, useWaveletFilterBankPyramid );
+      }
+    else
+      {
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << argv[5] << " wavelet type not supported." << std::endl;
+      return EXIT_FAILURE;
+      }
+    }
+  else if ( dimension == 3 )
+    {
+    if ( waveletFunction == "Held" )
+      {
+      return runWaveletFrequencyInverseUndecimatedTest< 3, HeldWavelet >( inputImage, outputImage, inputLevels, inputBands, useWaveletFilterBankPyramid );
+      }
+    else if ( waveletFunction == "Vow" )
+      {
+      return runWaveletFrequencyInverseUndecimatedTest< 3, VowWavelet >( inputImage, outputImage, inputLevels, inputBands, useWaveletFilterBankPyramid );
+      }
+    else if ( waveletFunction == "Simoncelli" )
+      {
+      return runWaveletFrequencyInverseUndecimatedTest< 3, SimoncelliWavelet >( inputImage, outputImage, inputLevels, inputBands, useWaveletFilterBankPyramid );
+      }
+    else if ( waveletFunction == "Shannon" )
+      {
+      return runWaveletFrequencyInverseUndecimatedTest< 3, ShannonWavelet >( inputImage, outputImage, inputLevels, inputBands, useWaveletFilterBankPyramid );
+      }
+    else
+      {
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << argv[5] << " wavelet type not supported." << std::endl;
+      return EXIT_FAILURE;
+      }
+    }
+  else
+    {
+    std::cerr << "Test failed!" << std::endl;
+    std::cerr << "Error: only 2 or 3 dimensions allowed, " << dimension << " selected." << std::endl;
+    return EXIT_FAILURE;
+    }
+}

--- a/test/itkWaveletUtilitiesTest.cxx
+++ b/test/itkWaveletUtilitiesTest.cxx
@@ -1,0 +1,244 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkWaveletUtilities.h"
+#include "itkTestingMacros.h"
+
+bool IndexToLevelBandTest(
+    const unsigned int & linearIndex,
+    const unsigned int & levels,
+    const unsigned int & bands,
+    const unsigned int & expectedLevel,
+    const unsigned int & expectedBand)
+{
+  using namespace itk::utils;
+  IndexPairType pairLvBand =
+    IndexToLevelBandSteerablePyramid( linearIndex, levels, bands );
+  unsigned int lv = pairLvBand.first;
+  unsigned int b  = pairLvBand.second;
+  if ( lv != expectedLevel || b != expectedBand )
+  {
+    std::cerr << "Error for linearIndex: " << linearIndex << "\n"
+      << "result: (lv:" << lv << ", b:" << b << ")\n"
+      << "should be: (" << expectedLevel << ", " << expectedBand << ")."
+      << std::endl;
+    return false;
+  }
+  else
+  {
+    return true;
+  }
+}
+
+void printComputeMaxNumberOfLevelsError(itk::Size<3> inputSize, unsigned int scaleFactor,
+  unsigned int expected, unsigned int result)
+{
+  std::cerr << "Error in ComputeMaxNumberOfLevels with" << std::endl;
+  std::cerr << "scaleFactor = " << scaleFactor << std::endl;
+  std::cerr << "inputSize = " << inputSize << std::endl;
+  std::cerr << "Expected: " << expected << ", but got " << result << std::endl;
+}
+
+bool testComputeMaxNumberOfLevels()
+{
+  bool testPassed = true;
+  const unsigned int Dimension = 3;
+
+  unsigned int scaleFactor = 2;
+  typedef itk::Size<Dimension> SizeType;
+  SizeType inputSize;
+  inputSize.Fill(12);
+  unsigned int expected = 3;
+
+  unsigned int result = itk::utils::ComputeMaxNumberOfLevels(inputSize, scaleFactor);
+  if (result != expected)
+    {
+    printComputeMaxNumberOfLevelsError(inputSize, scaleFactor, expected, result);
+    testPassed = false;
+    }
+
+  inputSize.Fill(16);
+  expected = 4;
+  result = itk::utils::ComputeMaxNumberOfLevels(inputSize, scaleFactor);
+
+  if (result != expected)
+    {
+    printComputeMaxNumberOfLevelsError(inputSize, scaleFactor, expected, result);
+    testPassed = false;
+    }
+
+  inputSize.Fill(17);
+  expected = 1;
+  result = itk::utils::ComputeMaxNumberOfLevels(inputSize, scaleFactor);
+
+  if (result != expected)
+    {
+    printComputeMaxNumberOfLevelsError(inputSize, scaleFactor, expected, result);
+    testPassed = false;
+    }
+
+  inputSize.Fill(22);
+  expected = 2;
+  result = itk::utils::ComputeMaxNumberOfLevels(inputSize, scaleFactor);
+
+  if (result != expected)
+    {
+    printComputeMaxNumberOfLevelsError(inputSize, scaleFactor, expected, result);
+    testPassed = false;
+    }
+
+  inputSize.Fill(3);
+  expected = 1;
+  result = itk::utils::ComputeMaxNumberOfLevels(inputSize, scaleFactor);
+
+  if (result != expected)
+    {
+    printComputeMaxNumberOfLevelsError(inputSize, scaleFactor, expected, result);
+    testPassed = false;
+    }
+
+  // Change scaleFactor
+  scaleFactor = 3;
+  inputSize.Fill(27);
+  expected = 3;
+  result = itk::utils::ComputeMaxNumberOfLevels(inputSize, scaleFactor);
+
+  if (result != expected)
+    {
+    printComputeMaxNumberOfLevelsError(inputSize, scaleFactor, expected, result);
+    testPassed = false;
+    }
+
+  return testPassed;
+}
+
+
+int itkWaveletUtilitiesTest(int , char*[] )
+{
+  bool testPassed = true;
+
+  // Test IndexToLevelBand
+  bool testOutputIndexToLevelBandPassed = true;
+    {
+    unsigned int linearIndex = 0;
+    unsigned int levels = 1;
+    unsigned int bands = 1;
+    unsigned int expectedLevel = 0;
+    unsigned int expectedBand = 1;
+    testOutputIndexToLevelBandPassed = IndexToLevelBandTest(
+        linearIndex, levels, bands,
+        expectedLevel, expectedBand);
+    }
+    {
+    unsigned int linearIndex = 1;
+    unsigned int levels = 1;
+    unsigned int bands = 1;
+    unsigned int expectedLevel = 0;
+    unsigned int expectedBand = 0;
+    testOutputIndexToLevelBandPassed = IndexToLevelBandTest(
+        linearIndex, levels, bands,
+        expectedLevel, expectedBand);
+    }
+    {
+    unsigned int linearIndex = 4;
+    unsigned int levels = 1;
+    unsigned int bands = 1;
+    TRY_EXPECT_EXCEPTION(
+        itk::utils::IndexToLevelBandSteerablePyramid( linearIndex, levels, bands ) );
+    }
+    {
+    unsigned int linearIndex = 0;
+    unsigned int levels = 2;
+    unsigned int bands = 2;
+    unsigned int expectedLevel = 0;
+    unsigned int expectedBand = 1;
+    testOutputIndexToLevelBandPassed = IndexToLevelBandTest(
+        linearIndex, levels, bands,
+        expectedLevel, expectedBand);
+    }
+    {
+    unsigned int linearIndex = 1;
+    unsigned int levels = 2;
+    unsigned int bands = 2;
+    unsigned int expectedLevel = 0;
+    unsigned int expectedBand = 2;
+    testOutputIndexToLevelBandPassed = IndexToLevelBandTest(
+        linearIndex, levels, bands,
+        expectedLevel, expectedBand);
+    }
+    {
+    unsigned int linearIndex = 2;
+    unsigned int levels = 2;
+    unsigned int bands = 2;
+    unsigned int expectedLevel = 1;
+    unsigned int expectedBand = 1;
+    testOutputIndexToLevelBandPassed = IndexToLevelBandTest(
+        linearIndex, levels, bands,
+        expectedLevel, expectedBand);
+    }
+    {
+    unsigned int linearIndex = 3;
+    unsigned int levels = 2;
+    unsigned int bands = 2;
+    unsigned int expectedLevel = 1;
+    unsigned int expectedBand = 2;
+    testOutputIndexToLevelBandPassed = IndexToLevelBandTest(
+        linearIndex, levels, bands,
+        expectedLevel, expectedBand);
+    }
+    {
+    unsigned int linearIndex = 4;
+    unsigned int levels = 2;
+    unsigned int bands = 2;
+    unsigned int expectedLevel = 1;
+    unsigned int expectedBand = 0;
+    testOutputIndexToLevelBandPassed = IndexToLevelBandTest(
+        linearIndex, levels, bands,
+        expectedLevel, expectedBand);
+    }
+    {
+    unsigned int linearIndex = 5;
+    unsigned int levels = 2;
+    unsigned int bands = 2;
+    TRY_EXPECT_EXCEPTION(
+        itk::utils::IndexToLevelBandSteerablePyramid( linearIndex, levels, bands ) );
+    }
+
+  if ( !testOutputIndexToLevelBandPassed )
+    {
+    std::cerr << "Error in OutputIndexToLevelBand" << std::endl;
+    testPassed = false;
+    }
+
+  // Test ComputeMaxNumberOfLevels
+  bool testComputeMaxNumberOfLevelsPassed = testComputeMaxNumberOfLevels();
+  if (!testComputeMaxNumberOfLevelsPassed)
+    {
+    testPassed = false;
+    }
+
+
+  if ( testPassed )
+    {
+    return EXIT_SUCCESS;
+    }
+  else
+    {
+    return EXIT_FAILURE;
+    }
+}


### PR DESCRIPTION
Add undecimated pyramid where there is no downsampling.

It is useful when translation invariance is wanted or if analyzing upper levels --lower resolution-- and we are interested in knowing where, in the domain of the input image, is the feature, without needing any re-scaling. Note that the amount of information between regular and undecimated pyramids is the same (Shannon theorem). But the undecimated generates all its wavelet coefficients and low-pass residual with the same size than the input image. This makes it more expensive, computationally and in memory.