### PR TITLE
ENH: Add wrapping for itk::RieszRotationMatrix class.

### DIFF
--- a/wrapping/itkRieszRotationMatrix.wrap
+++ b/wrapping/itkRieszRotationMatrix.wrap
@@ -1,0 +1,8 @@
+itk_wrap_class("itk::RieszRotationMatrix")
+  foreach(d1 ${ITK_WRAP_IMAGE_DIMS})
+    foreach(d2 ${ITK_WRAP_IMAGE_DIMS})
+      itk_wrap_template("${ITKM_F}${d1}${d2}" "${ITKT_F},${d1},${d2}")
+      itk_wrap_template("${ITKM_D}${d1}${d2}" "${ITKT_D},${d1},${d2}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
Add wrapping for the itk::RieszRotationMatrix class.