### PR TITLE
ENH: Add (not)wrapping for Iterator-like classes.

### DIFF
--- a/wrapping/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.notwrapped
+++ b/wrapping/itkFrequencyFFTLayoutImageRegionConstIteratorWithIndex.notwrapped
@@ -1,0 +1,1 @@
+message(FATAL_ERROR "No use to wrapping the iterator.")

--- a/wrapping/itkFrequencyFFTLayoutImageRegionIteratorWithIndex.notwrapped
+++ b/wrapping/itkFrequencyFFTLayoutImageRegionIteratorWithIndex.notwrapped
@@ -1,0 +1,1 @@
+message(FATAL_ERROR "No use to wrapping the iterator.")

--- a/wrapping/itkFrequencyImageRegionConstIteratorWithIndex.notwrapped
+++ b/wrapping/itkFrequencyImageRegionConstIteratorWithIndex.notwrapped
@@ -1,0 +1,1 @@
+message(FATAL_ERROR "No use to wrapping the iterator.")

--- a/wrapping/itkFrequencyImageRegionIteratorWithIndex.notwrapped
+++ b/wrapping/itkFrequencyImageRegionIteratorWithIndex.notwrapped
@@ -1,0 +1,1 @@
+message(FATAL_ERROR "No use to wrapping the iterator.")

--- a/wrapping/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.notwrapped
+++ b/wrapping/itkFrequencyShiftedFFTLayoutImageRegionConstIteratorWithIndex.notwrapped
@@ -1,0 +1,1 @@
+message(FATAL_ERROR "No use to wrapping the iterator.")

--- a/wrapping/itkFrequencyShiftedFFTLayoutImageRegionIteratorWithIndex.notwrapped
+++ b/wrapping/itkFrequencyShiftedFFTLayoutImageRegionIteratorWithIndex.notwrapped
@@ -1,0 +1,1 @@
+message(FATAL_ERROR "No use to wrapping the iterator.")


### PR DESCRIPTION
ITK iterator class wrapping has no use, but corresponding files with
.notwrapped extension are added with a message warning about it are added
so that developers know about this.