### PR TITLE
BUG: Fix build and CI badge syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 [![DOI](https://zenodo.org/badge/67762635.svg)](https://zenodo.org/badge/latestdoi/67762635)
 
-.. image:: https://circleci.com/gh/phcerdan/ITKIsotropicWavelets.svg?style=shield
-   :target: https://circleci.com/gh/phcerdan/ITKIsotropicWavelets
+[![CircleCI](https://circleci.com/gh/phcerdan/ITKIsotropicWavelets.svg?style=shield)](https://circleci.com/gh/phcerdan/ITKIsotropicWavelets)
 
-.. image:: https://travis-ci.org/phcerdan/ITKIsotropicWavelets.svg?branch=master
-   :target: https://travis-ci.org/phcerdan/ITKIsotropicWavelets
+[![Travis CI](https://travis-ci.org/phcerdan/ITKIsotropicWavelets.svg?branch=master)](https://travis-ci.org/phcerdan/ITKIsotropicWavelets)
 
-.. image:: https://img.shields.io/appveyor/ci/phcerdan/itksotropicwavelets.svg
-   :target: https://ci.appveyor.com/project/phcerdan/ITKIsotropicWavelets
+[![AppVeyor](https://img.shields.io/appveyor/ci/phcerdan/itksotropicwavelets.svg)](https://ci.appveyor.com/project/phcerdan/ITKIsotropicWavelets)
 
 # [IsotropicWavelets](https://github.com/phcerdan/ITKIsotropicWavelets)
 External Module for ITK, implementing Isotropic Wavelets and Riesz Filter for multiscale phase analysis.


### PR DESCRIPTION
Fix build and CI badge syntax in the `README.md` file. Were mistakenly
added as reST syntax instead of Markdown by commit 4a4d435.