### PR TITLE
COMP: Remove unused itkFilterWatcher header include.

### DIFF
--- a/test/itkFFTPadPositiveIndexImageFilterTest.cxx
+++ b/test/itkFFTPadPositiveIndexImageFilterTest.cxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
-#include "itkFilterWatcher.h"
 #include "itkFFTPadPositiveIndexImageFilter.h"
 #include "itkZeroFluxNeumannBoundaryCondition.h"
 #include "itkPeriodicBoundaryCondition.h"


### PR DESCRIPTION
Remove unused `itkFilterWatcher` header include.

The `itk::FilterWatcher` class was removed in favour of
`itk::SimpleFilterWatcher` (and thus, its header file named
`itkFilterWatcher.h` was deleted) in this gerrit topic:
http://review.source.kitware.com/#/c/23415/

This bug was identified thanks to the following gerrit topic:
http://review.source.kitware.com/#/c/23428/