### PR TITLE
BUG: Fix test errors steming from the new multi-threading mechanism.

### DIFF
--- a/include/itkExpandWithZerosImageFilter.h
+++ b/include/itkExpandWithZerosImageFilter.h
@@ -134,17 +134,16 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** ExpandWithZerosImageFilter is implemented as a multithreaded filter.  Therefore,
-   * this implementation provides a ThreadedGenerateData() routine which
+   * this implementation provides a DynamicThreadedGenerateData() routine which
    * is called for each processing thread. The output image data is allocated
-   * automatically by the superclass prior to calling ThreadedGenerateData().
-   * ThreadedGenerateData can only write to the portion of the output image
+   * automatically by the superclass prior to calling DynamicThreadedGenerateData().
+   * DynamicThreadedGenerateData can only write to the portion of the output image
    * specified by the parameter "outputRegionForThread"
    *
-   * \sa ImageToImageFilter::ThreadedGenerateData(),
+   * \sa ImageToImageFilter::DynamicThreadedGenerateData(),
    *     ImageToImageFilter::GenerateData() */
 
-  void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread,
-                            ThreadIdType threadId) override;
+  void DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread ) override;
 
   /** This method is used to set the state of the filter before
    * multi-threading. */

--- a/include/itkExpandWithZerosImageFilter.hxx
+++ b/include/itkExpandWithZerosImageFilter.hxx
@@ -23,7 +23,6 @@
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkObjectFactory.h"
 #include "itkNumericTraits.h"
-#include "itkProgressReporter.h"
 
 namespace itk
 {
@@ -39,6 +38,8 @@ ExpandWithZerosImageFilter< TInputImage, TOutputImage >
     {
     m_ExpandFactors[j] = 1;
     }
+
+  this->DynamicMultiThreadingOn();
 }
 
 /**
@@ -108,8 +109,7 @@ ExpandWithZerosImageFilter< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 void
 ExpandWithZerosImageFilter< TInputImage, TOutputImage >
-::ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread,
-  ThreadIdType threadId)
+::DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread )
 {
   // Get the input and output pointers
   OutputImagePointer outputPtr    = this->GetOutput();
@@ -127,7 +127,6 @@ ExpandWithZerosImageFilter< TInputImage, TOutputImage >
     return;
     }
   const size_t numberOfLinesToProcess = outputRegionForThread.GetNumberOfPixels() / size0;
-  ProgressReporter progress( this, threadId, static_cast< SizeValueType >( numberOfLinesToProcess ) );
 
   const typename OutputImageType::IndexType outputOriginIndex = outputPtr->GetLargestPossibleRegion().GetIndex();
   // Walk the output region, and interpolate the input image
@@ -170,7 +169,6 @@ ExpandWithZerosImageFilter< TInputImage, TOutputImage >
       }
 
     outIt.NextLine();
-    progress.CompletedPixel();
     }
 }
 

--- a/include/itkFrequencyBandImageFilter.h
+++ b/include/itkFrequencyBandImageFilter.h
@@ -182,8 +182,7 @@ protected:
 
   void BeforeThreadedGenerateData() override;
 
-  void ThreadedGenerateData(const ImageRegionType & outputRegionForThread,
-                                    ThreadIdType threadId) override;
+  void DynamicThreadedGenerateData(const ImageRegionType & outputRegionForThread) override;
 
 private:
   FrequencyValueType m_LowFrequencyThreshold;

--- a/include/itkFrequencyBandImageFilter.hxx
+++ b/include/itkFrequencyBandImageFilter.hxx
@@ -36,6 +36,7 @@ FrequencyBandImageFilter< TImageType, TFrequencyIteratorType >
   m_PassNegativeLowFrequencyThreshold(true),
   m_PassNegativeHighFrequencyThreshold(true)
 {
+  this->DynamicMultiThreadingOn();
 }
 
 template< typename TImageType, typename TFrequencyIteratorType >
@@ -133,9 +134,7 @@ FrequencyBandImageFilter< TImageType, TFrequencyIteratorType >
 template< typename TImageType, typename TFrequencyIteratorType >
 void
 FrequencyBandImageFilter< TImageType, TFrequencyIteratorType >
-::ThreadedGenerateData(
-  const ImageRegionType & outputRegionForThread,
-  ThreadIdType )
+::DynamicThreadedGenerateData( const ImageRegionType & outputRegionForThread )
 {
   // outputPtr is a copy of input image from BeforeThreadedGenerateData
   ImagePointer outputPtr = this->GetOutput();

--- a/include/itkFrequencyShrinkViaInverseFFTImageFilter.hxx
+++ b/include/itkFrequencyShrinkViaInverseFFTImageFilter.hxx
@@ -19,7 +19,6 @@
 #define itkFrequencyShrinkViaInverseFFTImageFilter_hxx
 
 #include <itkFrequencyShrinkViaInverseFFTImageFilter.h>
-#include <itkProgressReporter.h>
 
 namespace itk
 {

--- a/include/itkMonogenicSignalFrequencyImageFilter.h
+++ b/include/itkMonogenicSignalFrequencyImageFilter.h
@@ -93,8 +93,7 @@ protected:
 
   void GenerateOutputInformation() override;
 
-  void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread,
-                                     ThreadIdType threadId) override;
+  void DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread ) override;
 
 private:
   RieszFunctionPointer m_Evaluator;

--- a/include/itkMonogenicSignalFrequencyImageFilter.hxx
+++ b/include/itkMonogenicSignalFrequencyImageFilter.hxx
@@ -23,10 +23,12 @@ namespace itk
 {
 template< typename TInputImage, typename TFrequencyImageRegionConstIterator >
 MonogenicSignalFrequencyImageFilter< TInputImage, TFrequencyImageRegionConstIterator >
-::MonogenicSignalFrequencyImageFilter()
+::MonogenicSignalFrequencyImageFilter() :
 {
   m_Evaluator = RieszFunctionType::New();
   m_Evaluator->SetOrder(1);
+
+  this->DynamicMultiThreadingOn();
 }
 
 template< typename TInputImage, typename TFrequencyImageRegionConstIterator >
@@ -43,8 +45,7 @@ MonogenicSignalFrequencyImageFilter< TInputImage, TFrequencyImageRegionConstIter
 template< typename TInputImage, typename TFrequencyImageRegionConstIterator >
 void
 MonogenicSignalFrequencyImageFilter< TInputImage, TFrequencyImageRegionConstIterator >
-::ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread,
-  ThreadIdType itkNotUsed(threadId))
+::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread)
 {
   // Allocate the outputs
   this->AllocateOutputs();

--- a/include/itkPhaseAnalysisImageFilter.h
+++ b/include/itkPhaseAnalysisImageFilter.h
@@ -133,8 +133,7 @@ protected:
 
   void BeforeThreadedGenerateData() override;
 
-  void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread,
-                                    ThreadIdType threadId) override;
+  void DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread ) override;
 
   inline OutputImagePixelType ComputeFeatureVectorNormSquare( const InputImagePixelType & inputPixel) const
   {

--- a/include/itkPhaseAnalysisImageFilter.hxx
+++ b/include/itkPhaseAnalysisImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkPhaseAnalysisImageFilter_hxx
 #define itkPhaseAnalysisImageFilter_hxx
 #include "itkPhaseAnalysisImageFilter.h"
-#include "itkProgressReporter.h"
 
 namespace itk
 {
@@ -32,6 +31,8 @@ PhaseAnalysisImageFilter< TInputImage, TOutputImage >
     {
     this->SetNthOutput(n_output, this->MakeOutput(n_output));
     }
+
+  this->DynamicMultiThreadingOn();
 }
 
 template< typename TInputImage, typename TOutputImage >
@@ -60,13 +61,8 @@ PhaseAnalysisImageFilter< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 void
 PhaseAnalysisImageFilter< TInputImage, TOutputImage >
-::ThreadedGenerateData(
-  const OutputImageRegionType & outputRegionForThread,
-  ThreadIdType threadId)
+::DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread )
 {
-  ProgressReporter progress(this, threadId,
-    outputRegionForThread.GetNumberOfPixels() / outputRegionForThread.GetSize()[0]);
-
   typename OutputImageType::Pointer phasePtr     = this->GetOutputPhase();
   typename OutputImageType::Pointer amplitudePtr = this->GetOutputAmplitude();
 
@@ -89,7 +85,6 @@ PhaseAnalysisImageFilter< TInputImage, TOutputImage >
       }
 
     inputIt.NextLine(); ampIt.NextLine(); phaseIt.NextLine();
-    progress.CompletedPixel();
     }
 }
 

--- a/include/itkPhaseAnalysisSoftThresholdImageFilter.hxx
+++ b/include/itkPhaseAnalysisSoftThresholdImageFilter.hxx
@@ -21,7 +21,6 @@
 #include "itkImageScanlineConstIterator.h"
 #include "itkImageScanlineIterator.h"
 
-#include "itkProgressReporter.h"
 #include "itkStatisticsImageFilter.h"
 namespace itk
 {
@@ -40,6 +39,8 @@ PhaseAnalysisSoftThresholdImageFilter< TInputImage, TOutputImage >
     {
     this->SetNthOutput(n_output, this->MakeOutput(n_output));
     }
+
+  this->DynamicMultiThreadingOn();
 }
 
 template< typename TInputImage, typename TOutputImage >
@@ -85,13 +86,9 @@ PhaseAnalysisSoftThresholdImageFilter< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 void
 PhaseAnalysisSoftThresholdImageFilter< TInputImage, TOutputImage >
-::ThreadedGenerateData(
-  const OutputImageRegionType & outputRegionForThread,
-  ThreadIdType threadId)
+::DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread )
 {
-  ProgressReporter progress( this, threadId, outputRegionForThread.GetNumberOfPixels() );
-
-  Superclass::ThreadedGenerateData(outputRegionForThread, threadId);
+  Superclass::DynamicThreadedGenerateData(outputRegionForThread);
 
   auto phasePtr     = this->GetOutputPhase();
   auto amplitudePtr = this->GetOutputAmplitude();
@@ -139,7 +136,6 @@ PhaseAnalysisSoftThresholdImageFilter< TInputImage, TOutputImage >
       }
 
     outIt.NextLine(), ampIt.NextLine(), phaseIt.NextLine();
-    progress.CompletedPixel(); // Per line
     }
 }
 } // end namespace itk

--- a/include/itkShrinkDecimateImageFilter.h
+++ b/include/itkShrinkDecimateImageFilter.h
@@ -109,8 +109,7 @@ protected:
   ShrinkDecimateImageFilter();
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
-  void ThreadedGenerateData(const OutputImageRegionType& outputRegionForThread,
-                            ThreadIdType threadId ) override;
+  void DynamicThreadedGenerateData( const OutputImageRegionType& outputRegionForThread ) override;
 
 private:
   ShrinkFactorsType m_ShrinkFactors;

--- a/include/itkShrinkDecimateImageFilter.hxx
+++ b/include/itkShrinkDecimateImageFilter.hxx
@@ -20,7 +20,6 @@
 
 #include "itkShrinkDecimateImageFilter.h"
 #include "itkImageScanlineIterator.h"
-#include "itkProgressReporter.h"
 #include <numeric>
 #include <functional>
 
@@ -34,6 +33,8 @@ ShrinkDecimateImageFilter< TInputImage, TOutputImage >
     {
     m_ShrinkFactors[j] = 1;
     }
+
+  this->DynamicMultiThreadingOn();
 }
 
 template< class TInputImage, class TOutputImage >
@@ -99,8 +100,7 @@ ShrinkDecimateImageFilter< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 void
 ShrinkDecimateImageFilter< TInputImage, TOutputImage >
-::ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread,
-  ThreadIdType threadId)
+::DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread )
 {
   // Get the input and output pointers
   OutputImagePointer outputPtr    = this->GetOutput();
@@ -118,7 +118,6 @@ ShrinkDecimateImageFilter< TInputImage, TOutputImage >
     return;
     }
   const size_t numberOfLinesToProcess = outputRegionForThread.GetNumberOfPixels() / size0;
-  ProgressReporter progress( this, threadId, static_cast< SizeValueType >( numberOfLinesToProcess ) );
 
   // const typename OutputImageType::IndexType outputOriginIndex = outputPtr->GetLargestPossibleRegion().GetIndex();
   // const typename InputImageType::IndexType  inputOriginIndex  = inputPtr->GetLargestPossibleRegion().GetIndex();
@@ -145,7 +144,6 @@ ShrinkDecimateImageFilter< TInputImage, TOutputImage >
       }
 
     outIt.NextLine();
-    progress.CompletedPixel();
     }
 }
 

--- a/include/itkStructureTensor.h
+++ b/include/itkStructureTensor.h
@@ -192,8 +192,7 @@ protected:
 
   void BeforeThreadedGenerateData() override;
 
-  void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread,
-                                    ThreadIdType threadId) override;
+  void DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread ) override;
 
   /** Assuming that row>=column */
   static unsigned int LowerTriangleToLinearIndex(unsigned int r, unsigned int c)

--- a/include/itkStructureTensor.hxx
+++ b/include/itkStructureTensor.hxx
@@ -28,7 +28,7 @@
 // Convolution/Neighborhood Operations
 #include <itkConvolutionImageFilter.h>
 #include <itkConstantBoundaryCondition.h>
-#include "itkProgressReporter.h"
+
 namespace itk
 {
 template< typename TInputImage, typename TOutputImage >
@@ -38,6 +38,8 @@ StructureTensor< TInputImage, TOutputImage >
   m_GaussianWindowSigma(1.0)
 {
   this->m_GaussianSource = GaussianSourceType::New();
+
+  this->DynamicMultiThreadingOn();
 }
 
 template< typename TInputImage, typename TOutputImage >
@@ -151,11 +153,8 @@ StructureTensor< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 void
 StructureTensor< TInputImage, TOutputImage >
-::ThreadedGenerateData(
-  const OutputImageRegionType & outputRegionForThread,
-  ThreadIdType threadId)
+::DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread )
 {
-  ProgressReporter progress( this, threadId, outputRegionForThread.GetNumberOfPixels() );
   unsigned int nInputs = this->GetNumberOfInputs();
 
   auto outputPtr = this->GetOutput();


### PR DESCRIPTION
Fix errors steming from the use of the new `itk::PoolMultiThreader`
class for multi-threading.

The solution adopted in this patch set was based on the discussion in:
http://review.source.kitware.com/#/c/23434/