### PR TITLE
ENH: Allow multiply RieszRotationMatrix with vector of image pointers.

### DIFF
--- a/include/itkRieszRotationMatrix.h
+++ b/include/itkRieszRotationMatrix.h
@@ -57,8 +57,12 @@ public:
   using InternalMatrixType = typename Superclass::InternalMatrixType;
   using SpatialRotationMatrixType = itk::Matrix< T, VImageDimension, VImageDimension >;
 
-  /** Matrix by std::vector multiplication.  */
-  std::vector< T > operator *(const std::vector< T > & vector) const;
+  /** Matrix by std::vector<TImage> multiplication.
+   * To perform the rotation with the output of
+   * \ref RieszFrequencyFilterBankGenerator.
+   */
+  template <typename TImage>
+  std::vector< typename TImage::Pointer > MultiplyWithVectorOfImages(const std::vector< typename TImage::Pointer > & vect) const;
 
   /**
    * Multi-index notation


### PR DESCRIPTION
This provides a method to easily multiply the RieszRotationMatrix with
the output of the RieszFilterBankGenerator, to be able to steer the
filter bank.

Fix #83