### PR TITLE
ENH: Use transfer.sh for macOS package upload.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ script:
 - chmod u+x macpython-download-cache-and-build-module-wheels.sh
 - ./macpython-download-cache-and-build-module-wheels.sh 2.7 3.5
 - tar -zcvf dist.tar.gz dist/
-- curl -F file="@dist.tar.gz" https://file.io
+- curl --upload-file dist.tar.gz https://transfer.sh/dist.tar.gz


### PR DESCRIPTION
Prefer transfer.sh over file.io for macOS package upload.