### PR TITLE
ENH: Avoid TravisCI build timeouts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ cache:
 script:
 - curl -L https://rawgit.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/macpython-download-cache-and-build-module-wheels.sh -O
 - chmod u+x macpython-download-cache-and-build-module-wheels.sh
-- ./macpython-download-cache-and-build-module-wheels.sh
+- ./macpython-download-cache-and-build-module-wheels.sh 2.7 3.5
 - tar -zcvf dist.tar.gz dist/
 - curl -F file="@dist.tar.gz" https://file.io


### PR DESCRIPTION
Avoid TravisCI build timeouts by restricting the Python package builds to
Python versions 2.7 and 3.5.