### PR TITLE
Fix shared library build

### DIFF
--- a/include/itkFrequencyExpandImageFilter.hxx
+++ b/include/itkFrequencyExpandImageFilter.hxx
@@ -121,7 +121,6 @@ FrequencyExpandImageFilter< TImageType >
   typename TImageType::SizeType inputSize = inputPtr->GetLargestPossibleRegion().GetSize();
   typename TImageType::IndexType inputOriginIndex = inputPtr->GetLargestPossibleRegion().GetIndex();
   typename TImageType::SizeType outputSize = outputPtr->GetLargestPossibleRegion().GetSize();
-  FixedArray< bool, TImageType::ImageDimension > inputSizeIsEven;
 
   const typename TImageType::IndexType indexRequested = outputPtr->GetLargestPossibleRegion().GetIndex();
 
@@ -273,7 +272,7 @@ FrequencyExpandImageFilter< TImageType >
   typename TImageType::IndexType outputStartIndex;
   typename TImageType::PointType outputOrigin;
 
-  typename TImageType::SpacingType inputOriginShift;
+  //typename TImageType::SpacingType inputOriginShift;
   for ( unsigned int i = 0; i < TImageType::ImageDimension; i++ )
     {
     outputSpacing[i]    = inputSpacing[i] / m_ExpandFactors[i];

--- a/include/itkFrequencyExpandViaInverseFFTImageFilter.hxx
+++ b/include/itkFrequencyExpandViaInverseFFTImageFilter.hxx
@@ -212,7 +212,6 @@ FrequencyExpandViaInverseFFTImageFilter< TImageType >
   typename TImageType::IndexType outputStartIndex;
   typename TImageType::PointType outputOrigin;
 
-  typename TImageType::SpacingType inputOriginShift;
   for ( unsigned int i = 0; i < TImageType::ImageDimension; i++ )
     {
     outputSpacing[i]    = inputSpacing[i] / m_ExpandFactors[i];

--- a/include/itkRieszUtilities.h
+++ b/include/itkRieszUtilities.h
@@ -18,18 +18,19 @@
 #ifndef itkRieszUtilities_h
 #define itkRieszUtilities_h
 
+#include <algorithm>
+#include <functional>
 #include <set>
 #include <vector>
-#include <functional>
-#include <algorithm>
+
+#include "IsotropicWaveletsExport.h"
 
 namespace itk
 {
 namespace utils
 {
 /// Factorial
-long
-Factorial(long n);
+IsotropicWavelets_EXPORT long Factorial(long n);
 
 /**
  * Compute number of components p(N, d), where N = Order, d = Dimension.
@@ -40,8 +41,9 @@ Factorial(long n);
  *
  * @return NumberOfComponents given the order for the ImageDimension.
  */
-unsigned int
-ComputeNumberOfComponents( const unsigned int & order, const unsigned int & dimension );
+IsotropicWavelets_EXPORT
+unsigned int ComputeNumberOfComponents( const unsigned int & order,
+    const unsigned int & dimension );
 
 /**
  * Compute all possible unique indices given the subIndex: (X, 0, ..., 0).
@@ -55,8 +57,8 @@ ComputeNumberOfComponents( const unsigned int & order, const unsigned int & dime
  * @param init position to evaluate  subIndex. Needed for recursion purposes.
  */
 template< typename TIndicesArrayType, unsigned int VImageDimension >
-void
-ComputeUniqueIndices( TIndicesArrayType subIndex,
+IsotropicWavelets_EXPORT
+void ComputeUniqueIndices( TIndicesArrayType subIndex,
   std::set< TIndicesArrayType, std::greater< TIndicesArrayType > > & uniqueIndices,
   unsigned int init = 0 )
 {
@@ -99,6 +101,7 @@ ComputeUniqueIndices( TIndicesArrayType subIndex,
  * Compute all the permutations from a set of uniqueIndices.
  */
 template< typename TIndicesArrayType >
+IsotropicWavelets_EXPORT
 std::set< TIndicesArrayType, std::greater< TIndicesArrayType > >
 ComputeAllPermutations(
   const std::set< TIndicesArrayType, std::greater< TIndicesArrayType > > & uniqueIndices)
@@ -124,6 +127,7 @@ ComputeAllPermutations(
  * where \f$ \text{index}[i]>=0 \f$
  */
 template< typename TIndicesArrayType, unsigned int VImageDimension >
+IsotropicWavelets_EXPORT
 std::set< TIndicesArrayType, std::greater< TIndicesArrayType > >
 ComputeAllPossibleIndices(const unsigned int & order)
 {
@@ -137,8 +141,8 @@ ComputeAllPossibleIndices(const unsigned int & order)
 }
 
 template< typename TIndicesArrayType, unsigned int VImageDimension >
-bool
-LessOrEqualIndiceComparisson(
+IsotropicWavelets_EXPORT
+bool LessOrEqualIndiceComparisson(
   const TIndicesArrayType& rhs,
   const TIndicesArrayType& lhs)
 {

--- a/include/itkRieszUtilities.h
+++ b/include/itkRieszUtilities.h
@@ -23,6 +23,8 @@
 #include <set>
 #include <vector>
 
+#include "itkMacro.h"
+
 #include "IsotropicWaveletsExport.h"
 
 namespace itk
@@ -57,7 +59,7 @@ unsigned int ComputeNumberOfComponents( const unsigned int & order,
  * @param init position to evaluate  subIndex. Needed for recursion purposes.
  */
 template< typename TIndicesArrayType, unsigned int VImageDimension >
-IsotropicWavelets_EXPORT
+ITK_TEMPLATE_EXPORT
 void ComputeUniqueIndices( TIndicesArrayType subIndex,
   std::set< TIndicesArrayType, std::greater< TIndicesArrayType > > & uniqueIndices,
   unsigned int init = 0 )
@@ -101,7 +103,7 @@ void ComputeUniqueIndices( TIndicesArrayType subIndex,
  * Compute all the permutations from a set of uniqueIndices.
  */
 template< typename TIndicesArrayType >
-IsotropicWavelets_EXPORT
+ITK_TEMPLATE_EXPORT
 std::set< TIndicesArrayType, std::greater< TIndicesArrayType > >
 ComputeAllPermutations(
   const std::set< TIndicesArrayType, std::greater< TIndicesArrayType > > & uniqueIndices)
@@ -127,7 +129,7 @@ ComputeAllPermutations(
  * where \f$ \text{index}[i]>=0 \f$
  */
 template< typename TIndicesArrayType, unsigned int VImageDimension >
-IsotropicWavelets_EXPORT
+ITK_TEMPLATE_EXPORT
 std::set< TIndicesArrayType, std::greater< TIndicesArrayType > >
 ComputeAllPossibleIndices(const unsigned int & order)
 {
@@ -141,7 +143,7 @@ ComputeAllPossibleIndices(const unsigned int & order)
 }
 
 template< typename TIndicesArrayType, unsigned int VImageDimension >
-IsotropicWavelets_EXPORT
+ITK_TEMPLATE_EXPORT
 bool LessOrEqualIndiceComparisson(
   const TIndicesArrayType& rhs,
   const TIndicesArrayType& lhs)

--- a/include/itkShrinkDecimateImageFilter.hxx
+++ b/include/itkShrinkDecimateImageFilter.hxx
@@ -243,8 +243,6 @@ ShrinkDecimateImageFilter< TInputImage, TOutputImage >
   const typename TInputImage::SizeType & inputSize       = inputPtr->GetLargestPossibleRegion().GetSize();
   const typename TInputImage::IndexType & inputStartIndex = inputPtr->GetLargestPossibleRegion().GetIndex();
 
-  ContinuousIndex< double, ImageDimension > inputIndexOutputOrigin;
-
   typename TOutputImage::SpacingType outputSpacing(inputSpacing);
   typename TOutputImage::SizeType outputSize;
   typename TOutputImage::IndexType outputStartIndex;

--- a/include/itkWaveletUtilities.h
+++ b/include/itkWaveletUtilities.h
@@ -18,12 +18,14 @@
 #ifndef itkWaveletUtilities_h
 #define itkWaveletUtilities_h
 
-#include <vector>
-#include <cmath>
 #include <algorithm>
+#include <cmath>
+#include <vector>
 #include <itkFixedArray.h>
 #include <itkMath.h>
 #include <itkSize.h>
+
+#include "IsotropicWaveletsExport.h"
 
 namespace itk
 {
@@ -47,8 +49,8 @@ namespace utils
    *
    * Note that bands and levels are always >= 1. The level/bands returned here corresponds to an index.
    */
-  IndexPairType IndexToLevelBandSteerablePyramid(unsigned int linearIndex,
-      unsigned int levels, unsigned int bands);
+  IsotropicWavelets_EXPORT IndexPairType IndexToLevelBandSteerablePyramid(
+    unsigned int linearIndex, unsigned int levels, unsigned int bands);
 
   /** Compute max number of levels depending on the size of the image.
    * Return J: $ J = \text{min_element}\{J_0,\ldots, J_d\} $;
@@ -56,7 +58,8 @@ namespace utils
    * returns 1 if any size is not divisible by the scale factor.
    */
 template < unsigned int VImageDimension >
-unsigned int ComputeMaxNumberOfLevels(const Size< VImageDimension >& inputSize, const unsigned int & scaleFactor)
+IsotropicWavelets_EXPORT unsigned int ComputeMaxNumberOfLevels(
+  const Size< VImageDimension >& inputSize, const unsigned int & scaleFactor)
   {
   FixedArray< unsigned int, VImageDimension > exponentPerAxis;
   // The minimum level is 1.

--- a/include/itkWaveletUtilities.h
+++ b/include/itkWaveletUtilities.h
@@ -58,7 +58,7 @@ namespace utils
    * returns 1 if any size is not divisible by the scale factor.
    */
 template < unsigned int VImageDimension >
-IsotropicWavelets_EXPORT unsigned int ComputeMaxNumberOfLevels(
+ITK_TEMPLATE_EXPORT unsigned int ComputeMaxNumberOfLevels(
   const Size< VImageDimension >& inputSize, const unsigned int & scaleFactor)
   {
   FixedArray< unsigned int, VImageDimension > exponentPerAxis;

--- a/src/itkRieszUtilities.cxx
+++ b/src/itkRieszUtilities.cxx
@@ -41,40 +41,40 @@ ComputeNumberOfComponents(const unsigned int &order, const unsigned int &dimensi
 }
 
 // explicit instantiation of template functions with std::vector<unsigned int>
-template
+template<>
 void
 ComputeUniqueIndices<std::vector<unsigned int>, 3>(
   std::vector<unsigned int> subIndex,
   std::set< std::vector<unsigned int>, std::greater<std::vector<unsigned int> > > &uniqueIndices,
   unsigned int init );
 
-template
+template<>
 void
 ComputeUniqueIndices<std::vector<unsigned int>, 2>(
   std::vector<unsigned int> subIndex,
   std::set< std::vector<unsigned int>, std::greater<std::vector<unsigned int> > > &uniqueIndices,
   unsigned int init );
 
-template
+template<>
 std::set< std::vector<unsigned int>, std::greater<std::vector<unsigned int> > >
 ComputeAllPermutations<std::vector<unsigned int> >( 
     const std::set< std::vector<unsigned int>, std::greater<std::vector<unsigned int> > > & uniqueIndices);
 
-template
+template<>
 std::set< std::vector<unsigned int>, std::greater<std::vector<unsigned int> > >
 ComputeAllPossibleIndices<std::vector<unsigned int>, 3>(
   const unsigned int &order);
 
-template
+template<>
 std::set< std::vector<unsigned int>, std::greater<std::vector<unsigned int> > >
 ComputeAllPossibleIndices<std::vector<unsigned int>, 2>(
   const unsigned int &order);
 
-template
+template<>
 bool
 LessOrEqualIndiceComparisson<std::vector<unsigned int>, 3>(const std::vector<unsigned int> & rhs, const std::vector<unsigned int> & lhs);
 
-template
+template<>
 bool
 LessOrEqualIndiceComparisson<std::vector<unsigned int>, 2>(const std::vector<unsigned int> & rhs, const std::vector<unsigned int> & lhs);
 } // end namespace utils

--- a/src/itkWaveletUtilities.cxx
+++ b/src/itkWaveletUtilities.cxx
@@ -48,10 +48,10 @@ IndexPairType IndexToLevelBandSteerablePyramid(unsigned int linearIndex,
   }
 
 // Instantiation
-template
+template<>
 unsigned int ComputeMaxNumberOfLevels<3>(const Size< 3 >& inputSize, const unsigned int & scaleFactor);
 
-template
+template<>
 unsigned int ComputeMaxNumberOfLevels<2>(const Size< 2 >& inputSize, const unsigned int & scaleFactor);
 } // end namespace utils
 } // end namespace itk


### PR DESCRIPTION
Supersedes #91. Closes #89. Closes #91.

This still might not work correctly as shared libraries on Mac. `ITK_TEMPLATE_EXPORT` expands to something only on Mac, and it might not be consistently applied.