### PR TITLE
ENH: Add wrapping for RieszRotationMatrix

### DIFF
--- a/wrapping/itkRieszRotationMatrix.wrap
+++ b/wrapping/itkRieszRotationMatrix.wrap
@@ -1,0 +1,5 @@
+itk_wrap_class("itk::RieszRotationMatrix")
+    foreach(d ${ITK_WRAP_IMAGE_DIMS})
+        itk_wrap_template("${ITKM_D}${d}" "${ITKT_D},${d}")
+    endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
Wrap only double, as base class VariableSizeMatrix

Supersedes and closes #59

Co-authored-by: Jon Haitz Legarreta Gorroño<jon.haitz.legarreta@gmail.com>
Co-authored-by: Matt McCormick<matt.mccormick@kitware.com>