### PR TITLE
WIP: ENH: Use itk::VectorContainer instead of std::vector

### DIFF
--- a/include/itkRieszFrequencyFilterBankGenerator.h
+++ b/include/itkRieszFrequencyFilterBankGenerator.h
@@ -23,6 +23,7 @@
 #include <complex>
 #include "itkRieszFrequencyFunction.h"
 #include <itkFrequencyFFTLayoutImageRegionIteratorWithIndex.h>
+#include <itkVectorContainer.h>
 
 namespace itk
 {
@@ -68,15 +69,15 @@ public:
   using RieszFunctionPointer = typename RieszFunctionType::Pointer;
   using FunctionValueType = typename RieszFunctionType::FunctionValueType;
 
-  using OutputsType = typename std::vector<OutputImagePointer>;
-  // using OutputsType = typename itk::VectorContainer<int, OutputImagePointer>;
+  using OutputsType = typename itk::VectorContainer<unsigned int, OutputImagePointer>;
+  using OutputsTypePointer = typename OutputsType::Pointer;
 
   /** Dimension */
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Get Outputs *****/
   /** Return vector of images from all directions */
-  OutputsType GetOutputs();
+  OutputsTypePointer GetOutputs();
 
 // #ifdef ITK_USE_CONCEPT_CHECKING
 //   itkConceptMacro( OutputPixelTypeIsFloatCheck,

--- a/include/itkRieszFrequencyFilterBankGenerator.hxx
+++ b/include/itkRieszFrequencyFilterBankGenerator.hxx
@@ -44,14 +44,14 @@ RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction, TFrequencyRegio
 /* ******* Get Outputs *****/
 template< typename TOutputImage, typename TRieszFunction, typename TFrequencyRegionIterator >
 typename RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction,
-    TFrequencyRegionIterator >::OutputsType
+    TFrequencyRegionIterator >::OutputsTypePointer
 RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction, TFrequencyRegionIterator >
 ::GetOutputs()
 {
-  OutputsType outputList;
+  auto outputList = OutputsType::New();
   for ( unsigned int comp = 0; comp < this->GetNumberOfOutputs(); ++comp )
     {
-    outputList.push_back(this->GetOutput(comp));
+    outputList->push_back(this->GetOutput(comp));
     }
   return outputList;
 }
@@ -62,14 +62,14 @@ RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction, TFrequencyRegio
 ::GenerateData()
 {
   /***************** Allocate Outputs *****************/
-  std::vector< OutputImagePointer > outputList;
+  auto outputList = OutputsType::New();
   std::vector< OutputRegionIterator > outputItList;
   for ( unsigned int comp = 0; comp < this->GetNumberOfOutputs(); ++comp )
     {
-    outputList.push_back(this->GetOutput(comp));
-    OutputImagePointer& outputPtr = outputList.back();
+    outputList->push_back(this->GetOutput(comp));
+    OutputImagePointer& outputPtr = outputList->back();
     // GenerateImageSource superclass allocates primary output, so use its region.
-    outputPtr->SetRegions(outputList[0]->GetLargestPossibleRegion());
+    outputPtr->SetRegions(outputList->ElementAt(0)->GetLargestPossibleRegion());
     outputPtr->Allocate();
     outputPtr->FillBuffer(0);
     outputItList.push_back(OutputRegionIterator(outputPtr, outputPtr->GetRequestedRegion()));
@@ -77,7 +77,7 @@ RieszFrequencyFilterBankGenerator< TOutputImage, TRieszFunction, TFrequencyRegio
     }
 
   /***************** Set Outputs *****************/
-  OutputRegionIterator frequencyIt(outputList[0], outputList[0]->GetRequestedRegion());
+  OutputRegionIterator frequencyIt(outputList->ElementAt(0), outputList->ElementAt(0)->GetRequestedRegion());
   for ( frequencyIt.GoToBegin(); !frequencyIt.IsAtEnd(); ++frequencyIt )
     {
     typename TRieszFunction::OutputComponentsType evaluatedArray =

--- a/include/itkRieszRotationMatrix.h
+++ b/include/itkRieszRotationMatrix.h
@@ -61,8 +61,8 @@ public:
    * To perform the rotation with the output of
    * \ref RieszFrequencyFilterBankGenerator.
    */
-  template <typename TImage>
-  std::vector< typename TImage::Pointer > MultiplyWithVectorOfImages(const std::vector< typename TImage::Pointer > & vect) const;
+  template <typename TImagesVectorContainer>
+  TImagesVectorContainer MultiplyWithVectorOfImages(const TImagesVectorContainer & vect) const;
 
   /**
    * Multi-index notation

--- a/include/itkRieszRotationMatrix.hxx
+++ b/include/itkRieszRotationMatrix.hxx
@@ -65,10 +65,10 @@ RieszRotationMatrix< T, VImageDimension >
 }
 
 template< typename T, unsigned int VImageDimension >
-template <typename TImage>
-std::vector< typename TImage::Pointer >
+template <typename TImagesVectorContainer>
+TImagesVectorContainer
 RieszRotationMatrix< T, VImageDimension >
-::MultiplyWithVectorOfImages(const std::vector< typename TImage::Pointer > & vect) const
+::MultiplyWithVectorOfImages(const TImagesVectorContainer & vect) const
 {
   unsigned int rows = this->Rows();
   unsigned int cols = this->Cols();
@@ -79,9 +79,9 @@ RieszRotationMatrix< T, VImageDimension >
                               << "multiplied with vector of images of length: " << vect.size() );
     }
 
-  using ImageType = TImage;
-  using ImagePointer = typename ImageType::Pointer;
-  std::vector< ImagePointer > result(rows);
+  using ImagePointer = typename TImagesVectorContainer::value_type;
+  using ImageType = typename ImagePointer::ObjectType;
+  TImagesVectorContainer result(rows);
   for ( unsigned int r = 0; r < rows; r++ )
     {
     // Init result image to zero.

--- a/include/itkStructureTensor.h
+++ b/include/itkStructureTensor.h
@@ -25,6 +25,7 @@
 #include <itkVariableSizeMatrix.h>
 #include <itkSymmetricSecondRankTensor.h>
 #include <itkGaussianImageSource.h>
+#include <itkVectorContainer.h>
 namespace itk
 {
 /** \class StructureTensor
@@ -133,10 +134,10 @@ public:
   using SymmetricEigenAnalysisType = itk::SymmetricEigenAnalysis<EigenMatrixType, EigenValuesType>;
   using GaussianSourceType = GaussianImageSource< FloatImageType >;
 
-  using InputsType = typename std::vector<InputImagePointer>;
-  // using InputsType = typename itk::VectorContainer<int, InputImagePointer>;
-  //
-  void SetInputs(const InputsType & inputs);
+  using InputsType = typename itk::VectorContainer<unsigned int, InputImagePointer>;
+  using InputsTypePointer = typename InputsType::Pointer;
+
+  void SetInputs(const InputsTypePointer & inputs);
 
   /**
   * Set/Get Radius of the gaussian window.
@@ -204,7 +205,7 @@ private:
   unsigned int                         m_GaussianWindowRadius;
   FloatType                            m_GaussianWindowSigma;
   typename GaussianSourceType::Pointer m_GaussianSource;
-  InputsType                           m_SquareSmoothedImages;
+  InputsTypePointer                    m_SquareSmoothedImages;
 };
 } // end namespace itk
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/include/itkStructureTensor.hxx
+++ b/include/itkStructureTensor.hxx
@@ -38,6 +38,7 @@ StructureTensor< TInputImage, TOutputImage >
   m_GaussianWindowSigma(1.0)
 {
   this->m_GaussianSource = GaussianSourceType::New();
+  this->m_SquareSmoothedImages = InputsType::New();
 
   this->DynamicMultiThreadingOn();
 }
@@ -45,19 +46,19 @@ StructureTensor< TInputImage, TOutputImage >
 template< typename TInputImage, typename TOutputImage >
 void
 StructureTensor< TInputImage, TOutputImage >
-::SetInputs(const InputsType & inputs)
+::SetInputs(const InputsTypePointer & inputs)
 {
-  if ( inputs.size() <= 1 )
+  if ( inputs->size() <= 1 )
     {
     itkExceptionMacro(
         << "StructureTensor requires at least 2 input images. Current size of input vector in SetInputs: "
-        << inputs.size());
+        << inputs->size());
     }
-  for ( unsigned int nin = 0; nin < inputs.size(); ++nin )
+  for ( unsigned int nin = 0; nin < inputs->size(); ++nin )
     {
-    if ( this->GetInput(nin) != inputs[nin] )
+    if ( this->GetInput(nin) != inputs->ElementAt(nin) )
       {
-      this->SetNthInput(nin, inputs[nin]);
+      this->SetNthInput(nin, inputs->ElementAt(nin));
       }
     }
 }
@@ -131,8 +132,8 @@ StructureTensor< TInputImage, TOutputImage >
       multiply->Update();
       convolve->SetInput(multiply->GetOutput());
       convolve->Update();
-      this->m_SquareSmoothedImages.push_back(convolve->GetOutput());
-      this->m_SquareSmoothedImages.back()->DisconnectPipeline();
+      this->m_SquareSmoothedImages->push_back(convolve->GetOutput());
+      this->m_SquareSmoothedImages->back()->DisconnectPipeline();
       }
     }
 }
@@ -172,7 +173,7 @@ StructureTensor< TInputImage, TOutputImage >
       {
       unsigned int linear_index = this->LowerTriangleToLinearIndex(m, n);
       inputIts.push_back(
-        InputImageConstIterator(this->m_SquareSmoothedImages[linear_index], outputRegionForThread) );
+        InputImageConstIterator(this->m_SquareSmoothedImages->ElementAt(linear_index), outputRegionForThread) );
       inputIts.back().GoToBegin();
       }
     }

--- a/include/itkWaveletFrequencyFilterBankGenerator.h
+++ b/include/itkWaveletFrequencyFilterBankGenerator.h
@@ -22,6 +22,7 @@
 #include <complex>
 #include <itkGenerateImageSource.h>
 #include <itkFrequencyFFTLayoutImageRegionIteratorWithIndex.h>
+#include <itkVectorContainer.h>
 
 namespace itk
 {
@@ -78,8 +79,8 @@ public:
   using WaveletFunctionPointer = typename WaveletFunctionType::Pointer;
   using FunctionValueType = typename WaveletFunctionType::FunctionValueType;
 
-  using OutputsType = typename std::vector<OutputImagePointer>;
-  // using OutputsType = typename itk::VectorContainer<int, OutputImagePointer>;
+  using OutputsType = typename itk::VectorContainer<unsigned int, OutputImagePointer>;
+  using OutputsTypePointer = typename OutputsType::Pointer;
 
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
@@ -115,10 +116,10 @@ public:
   OutputImagePointer GetOutputSubBand(unsigned int k);
 
   /** Returns all the outputs, starting at low-pass to highest subband*/
-  OutputsType GetOutputsAll();
+  OutputsTypePointer GetOutputsAll();
 
   /** Returns all the high pass subbands in ascending order, but not the low pass*/
-  OutputsType GetOutputsHighPassBands();
+  OutputsTypePointer GetOutputsHighPassBands();
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /// This ensure that OutputPixelType is complex<float||double>

--- a/include/itkWaveletFrequencyFilterBankGenerator.hxx
+++ b/include/itkWaveletFrequencyFilterBankGenerator.hxx
@@ -106,28 +106,28 @@ WaveletFrequencyFilterBankGenerator< TOutputImage, TWaveletFunction, TFrequencyR
 
 template< typename TOutputImage, typename TWaveletFunction, typename TFrequencyRegionIterator >
 typename WaveletFrequencyFilterBankGenerator< TOutputImage, TWaveletFunction,
-    TFrequencyRegionIterator >::OutputsType
+    TFrequencyRegionIterator >::OutputsTypePointer
 WaveletFrequencyFilterBankGenerator< TOutputImage, TWaveletFunction, TFrequencyRegionIterator >
 ::GetOutputsAll()
 {
-  OutputsType outputList;
+  auto outputList = OutputsType::New();
   for ( unsigned int band = 0; band < this->m_HighPassSubBands + 1; ++band )
     {
-    outputList.push_back(this->GetOutputSubBand(band));
+    outputList->push_back(this->GetOutputSubBand(band));
     }
   return outputList;
 }
 
 template< typename TOutputImage, typename TWaveletFunction, typename TFrequencyRegionIterator >
 typename WaveletFrequencyFilterBankGenerator< TOutputImage, TWaveletFunction,
-    TFrequencyRegionIterator >::OutputsType
+    TFrequencyRegionIterator >::OutputsTypePointer
 WaveletFrequencyFilterBankGenerator< TOutputImage, TWaveletFunction, TFrequencyRegionIterator >
 ::GetOutputsHighPassBands()
 {
-  OutputsType outputList;
+  auto outputList = OutputsType::New();
   for ( unsigned int band = 1; band < this->m_HighPassSubBands + 1; ++band )
     {
-    outputList.push_back(this->GetOutputSubBand(band));
+    outputList->push_back(this->GetOutputSubBand(band));
     }
   return outputList;
 }
@@ -140,18 +140,18 @@ WaveletFrequencyFilterBankGenerator< TOutputImage, TWaveletFunction, TFrequencyR
   this->m_WaveletFunction->SetHighPassSubBands(this->m_HighPassSubBands);
 
   /***************** Allocate Outputs *****************/
-  std::vector< OutputImagePointer > outputList;
+  auto outputList = OutputsType::New();
   std::vector< OutputRegionIterator > outputItList;
   for ( unsigned int band = 0; band < this->m_HighPassSubBands + 1; ++band )
     {
-    outputList.push_back(this->GetOutput(band));
-    OutputImagePointer& outputPtr = outputList.back();
+    outputList->push_back(this->GetOutput(band));
+    OutputImagePointer& outputPtr = outputList->back();
     // TODO maybe you need a GenerateOutputInformation instead of setting here metadata.
     // outputPtr->SetOrigin(this->GetOrigin());
     // outputPtr->SetSpacing(this->GetSpacing());
     // outputPtr->SetDirection(this->GetDirection());
     // GenerateImageSource superclass allocates primary output, so use its region.
-    outputPtr->SetRegions(outputList[0]->GetLargestPossibleRegion());
+    outputPtr->SetRegions(outputList->ElementAt(0)->GetLargestPossibleRegion());
     outputPtr->Allocate();
     outputPtr->FillBuffer(0);
     outputItList.push_back(OutputRegionIterator(outputPtr, outputPtr->GetRequestedRegion()));
@@ -161,7 +161,7 @@ WaveletFrequencyFilterBankGenerator< TOutputImage, TWaveletFunction, TFrequencyR
   /***************** Set Outputs *****************/
   FunctionValueType w(0);
   // Iterator to calculate frequency modulo only once (optimization)
-  OutputRegionIterator frequencyIt(outputList[0], outputList[0]->GetRequestedRegion());
+  OutputRegionIterator frequencyIt(outputList->ElementAt(0), outputList->ElementAt(0)->GetRequestedRegion());
   for ( frequencyIt.GoToBegin(); !frequencyIt.IsAtEnd(); ++frequencyIt )
     {
     w = static_cast< FunctionValueType >(

--- a/include/itkWaveletFrequencyForward.h
+++ b/include/itkWaveletFrequencyForward.h
@@ -26,6 +26,7 @@
 #include <itkImageToImageFilter.h>
 #include <itkFrequencyShrinkImageFilter.h>
 #include <itkFrequencyShrinkViaInverseFFTImageFilter.h>
+#include <itkVectorContainer.h>
 
 namespace itk
 {
@@ -68,8 +69,8 @@ public:
   using OutputImagePointer = typename Superclass::OutputImagePointer;
   using InputImageConstPointer = typename Superclass::InputImageConstPointer;
 
-  using OutputsType = typename std::vector<OutputImagePointer>;
-  // using OutputsType = typename itk::VectorContainer<int, OutputImagePointer>;
+  using OutputsType = typename itk::VectorContainer<unsigned int, OutputImagePointer>;
+  using OutputsTypePointer = typename OutputsType::Pointer;
 
   using OutputRegionIterator = typename itk::ImageRegionIterator<OutputImageType>;
   using InputRegionConstIterator = typename itk::ImageRegionConstIterator<InputImageType>;
@@ -118,7 +119,7 @@ public:
   itkGetMacro(StoreWaveletFilterBankPyramid, bool)
   itkBooleanMacro(StoreWaveletFilterBankPyramid);
 
-  itkGetMacro(WaveletFilterBankPyramid, OutputsType);
+  itkGetMacro(WaveletFilterBankPyramid, OutputsTypePointer);
 
   /** Compute max number of levels depending on the size of the image.
    * Return J: $ J = \text{min_element}\{J_0,\ldots, J_d\} $;
@@ -136,13 +137,13 @@ public:
   IndexPairType OutputIndexToLevelBand(unsigned int linear_index);
 
   /** Retrieve outputs */
-  OutputsType GetOutputs();
+  OutputsTypePointer GetOutputs();
 
-  OutputsType GetOutputsHighPass();
+  OutputsTypePointer GetOutputsHighPass();
 
   OutputImagePointer GetOutputLowPass();
 
-  OutputsType GetOutputsHighPassByLevel(unsigned int level);
+  OutputsTypePointer GetOutputsHighPassByLevel(unsigned int level);
 
 protected:
   WaveletFrequencyForward();
@@ -187,7 +188,7 @@ private:
   unsigned int             m_ScaleFactor;
   WaveletFilterBankPointer m_WaveletFilterBank;
   bool                     m_StoreWaveletFilterBankPyramid;
-  OutputsType              m_WaveletFilterBankPyramid;
+  OutputsTypePointer       m_WaveletFilterBankPyramid;
 };
 } // end namespace itk
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/include/itkWaveletFrequencyForwardUndecimated.h
+++ b/include/itkWaveletFrequencyForwardUndecimated.h
@@ -24,6 +24,7 @@
 #include <complex>
 #include <itkFixedArray.h>
 #include <itkImageToImageFilter.h>
+#include <itkVectorContainer.h>
 
 namespace itk
 {
@@ -63,8 +64,8 @@ public:
   using OutputImagePointer = typename Superclass::OutputImagePointer;
   using InputImageConstPointer = typename Superclass::InputImageConstPointer;
 
-  using OutputsType = typename std::vector<OutputImagePointer>;
-  // using OutputsType = typename itk::VectorContainer<int, OutputImagePointer>;
+  using OutputsType = typename itk::VectorContainer<unsigned int, OutputImagePointer>;
+  using OutputsTypePointer = typename OutputsType::Pointer;
 
   using OutputRegionIterator = typename itk::ImageRegionIterator<OutputImageType>;
   using InputRegionConstIterator = typename itk::ImageRegionConstIterator<InputImageType>;
@@ -111,7 +112,7 @@ public:
   itkGetMacro(StoreWaveletFilterBankPyramid, bool)
   itkBooleanMacro(StoreWaveletFilterBankPyramid);
 
-  itkGetMacro(WaveletFilterBankPyramid, OutputsType);
+  itkGetMacro(WaveletFilterBankPyramid, OutputsTypePointer);
 
   /** Compute max number of levels depending on the size of the image.
    * Return J: $ J = \text{min_element}\{J_0,\ldots, J_d\} $;
@@ -129,13 +130,13 @@ public:
   IndexPairType OutputIndexToLevelBand(unsigned int linear_index);
 
   /** Retrieve outputs */
-  OutputsType GetOutputs();
+  OutputsTypePointer GetOutputs();
 
-  OutputsType GetOutputsHighPass();
+  OutputsTypePointer GetOutputsHighPass();
 
   OutputImagePointer GetOutputLowPass();
 
-  OutputsType GetOutputsHighPassByLevel(unsigned int level);
+  OutputsTypePointer GetOutputsHighPassByLevel(unsigned int level);
 
 protected:
   WaveletFrequencyForwardUndecimated();
@@ -180,7 +181,7 @@ private:
   unsigned int             m_ScaleFactor;
   WaveletFilterBankPointer m_WaveletFilterBank;
   bool                     m_StoreWaveletFilterBankPyramid;
-  OutputsType              m_WaveletFilterBankPyramid;
+  OutputsTypePointer       m_WaveletFilterBankPyramid;
 };
 } // end namespace itk
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/include/itkWaveletFrequencyInverse.h
+++ b/include/itkWaveletFrequencyInverse.h
@@ -60,8 +60,8 @@ public:
   using OutputImagePointer = typename Superclass::OutputImagePointer;
   using InputImageConstPointer = typename Superclass::InputImageConstPointer;
 
-  using InputsType = typename std::vector<InputImagePointer>;
-  // using InputsType = typename itk::VectorContainer<int, InputImagePointer>;
+  using InputsType = typename itk::VectorContainer<unsigned int, InputImagePointer>;
+  using InputsTypePointer = typename InputsType::Pointer;
 
   using WaveletFilterBankType = TWaveletFilterBank;
   using WaveletFilterBankPointer = typename WaveletFilterBankType::Pointer;
@@ -112,7 +112,7 @@ public:
    * Set vector containing the WaveletFilterBankPyramid.
    * This vector is generated in the ForwardWavelet when StoreWaveletFilterBankPyramid is On.
    */
-  void SetWaveletFilterBankPyramid(const InputsType &filterBankPyramid)
+  void SetWaveletFilterBankPyramid(const InputsTypePointer& filterBankPyramid)
     {
     this->m_WaveletFilterBankPyramid = filterBankPyramid;
     }
@@ -121,11 +121,11 @@ public:
   /** Get the (Level,Band) from a linear index input */
   IndexPairType InputIndexToLevelBand(unsigned int linear_index);
 
-  void SetInputs(const InputsType & inputs);
+  void SetInputs(const InputsTypePointer & inputs);
 
   void SetInputLowPass(const InputImagePointer & input_low_pass);
 
-  void SetInputsHighPass(const InputsType & inputs);
+  void SetInputsHighPass(const InputsTypePointer & inputs);
 
 protected:
   WaveletFrequencyInverse();
@@ -175,7 +175,7 @@ private:
   bool                     m_ApplyReconstructionFactors;
   bool                     m_UseWaveletFilterBankPyramid;
   WaveletFilterBankPointer m_WaveletFilterBank;
-  InputsType               m_WaveletFilterBankPyramid;
+  InputsTypePointer        m_WaveletFilterBankPyramid;
 };
 } // end namespace itk
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/include/itkWaveletFrequencyInverseUndecimated.h
+++ b/include/itkWaveletFrequencyInverseUndecimated.h
@@ -55,8 +55,8 @@ public:
   using OutputImagePointer = typename Superclass::OutputImagePointer;
   using InputImageConstPointer = typename Superclass::InputImageConstPointer;
 
-  using InputsType = typename std::vector<InputImagePointer>;
-  // using InputsType = typename itk::VectorContainer<int, InputImagePointer>;
+  using InputsType = typename itk::VectorContainer<unsigned int, InputImagePointer>;
+  using InputsTypePointer = typename InputsType::Pointer;
 
   using WaveletFilterBankType = TWaveletFilterBank;
   using WaveletFilterBankPointer = typename WaveletFilterBankType::Pointer;
@@ -105,7 +105,7 @@ public:
    * Set vector containing the WaveletFilterBankPyramid.
    * This vector is generated in the ForwardWavelet when StoreWaveletFilterBankPyramid is On.
    */
-  void SetWaveletFilterBankPyramid(const InputsType &filterBankPyramid)
+  void SetWaveletFilterBankPyramid(const InputsTypePointer &filterBankPyramid)
     {
     this->m_WaveletFilterBankPyramid = filterBankPyramid;
     }
@@ -114,11 +114,11 @@ public:
   /** Get the (Level,Band) from a linear index input */
   IndexPairType InputIndexToLevelBand(unsigned int linear_index);
 
-  void SetInputs(const InputsType & inputs);
+  void SetInputs(const InputsTypePointer & inputs);
 
   void SetInputLowPass(const InputImagePointer & input_low_pass);
 
-  void SetInputsHighPass(const InputsType & inputs);
+  void SetInputsHighPass(const InputsTypePointer & inputs);
 
 protected:
   WaveletFrequencyInverseUndecimated();
@@ -168,7 +168,7 @@ private:
   bool                     m_ApplyReconstructionFactors;
   bool                     m_UseWaveletFilterBankPyramid;
   WaveletFilterBankPointer m_WaveletFilterBank;
-  InputsType               m_WaveletFilterBankPyramid;
+  InputsTypePointer        m_WaveletFilterBankPyramid;
 };
 } // end namespace itk
 #ifndef ITK_MANUAL_INSTANTIATION

--- a/include/itkWaveletFrequencyInverseUndecimated.hxx
+++ b/include/itkWaveletFrequencyInverseUndecimated.hxx
@@ -43,6 +43,7 @@ WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
 {
   this->SetNumberOfRequiredOutputs(1);
   this->m_WaveletFilterBank = WaveletFilterBankType::New();
+  this->m_WaveletFilterBankPyramid = InputsType::New();
 }
 
 template< typename TInputImage,
@@ -104,18 +105,18 @@ template< typename TInputImage,
 void
 WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
   TWaveletFilterBank >
-::SetInputs(const InputsType & inputs)
+::SetInputs(const InputsTypePointer & inputs)
 {
-  if ( inputs.size() != this->m_TotalInputs )
+  if ( inputs->size() != this->m_TotalInputs )
     {
     itkExceptionMacro(<< "Error seting inputs in inverse wavelet. Wrong vector size: "
-                      << inputs.size() << " .According to number of levels and bands it should be: " << m_TotalInputs);
+                      << inputs->size() << " .According to number of levels and bands it should be: " << m_TotalInputs);
     }
   for ( unsigned int nin = 0; nin < this->m_TotalInputs; ++nin )
     {
-    if ( this->GetInput(nin) != inputs[nin] )
+    if ( this->GetInput(nin) != inputs->ElementAt(nin) )
       {
-      this->SetNthInput(nin, inputs[nin]);
+      this->SetNthInput(nin, inputs->ElementAt(nin));
       }
     }
 }
@@ -137,17 +138,17 @@ template< typename TInputImage,
 void
 WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
   TWaveletFilterBank >
-::SetInputsHighPass(const InputsType & inputs)
+::SetInputsHighPass(const InputsTypePointer & inputs)
 {
-  if ( inputs.size() != this->m_TotalInputs - 1 )
+  if ( inputs->size() != this->m_TotalInputs - 1 )
     {
     itkExceptionMacro(<< "Error seting inputs in inverse wavelet. Wrong vector size: "
-                      << inputs.size() << " .According to number of levels and bands it should be: " << m_TotalInputs
+                      << inputs->size() << " .According to number of levels and bands it should be: " << m_TotalInputs
         - 1);
     }
   for ( unsigned int nin = 0; nin < this->m_TotalInputs - 1; ++nin )
     {
-    this->SetNthInput(nin, inputs[nin]);
+    this->SetNthInput(nin, inputs->ElementAt(nin));
     }
 }
 
@@ -312,7 +313,7 @@ WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
       }
     else
       {
-      waveletLow = this->m_WaveletFilterBankPyramid[level * (1 + this->m_HighPassSubBands)];
+      waveletLow = this->m_WaveletFilterBankPyramid->ElementAt(level * (1 + this->m_HighPassSubBands));
       }
     itkDebugMacro(<< "waveletLow: " << level << " Region:" << waveletLow->GetLargestPossibleRegion() );
     using ChangeInformationFilterType = itk::ChangeInformationImageFilter< InputImageType >;
@@ -326,17 +327,17 @@ WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
     low_pass_per_level = multiplyLowPass->GetOutput();
 
     /******* HighPass sub-bands *****/
-    InputsType highPassMasks;
+    auto highPassMasks = InputsType::New();
     if ( !this->m_UseWaveletFilterBankPyramid )
       {
       highPassMasks = this->m_WaveletFilterBank->GetOutputsHighPassBands();
       }
     else
       {
-      highPassMasks.insert(highPassMasks.begin(),
-        this->m_WaveletFilterBankPyramid.begin()
+      highPassMasks->insert(highPassMasks->begin(),
+        this->m_WaveletFilterBankPyramid->begin()
         + 1 + level * (1 + this->m_HighPassSubBands),
-        this->m_WaveletFilterBankPyramid.begin()
+        this->m_WaveletFilterBankPyramid->begin()
         + this->m_HighPassSubBands + 1 + level * (1 + this->m_HighPassSubBands) );
       }
     // Store HighBands steps into high_pass_reconstruction image:
@@ -353,7 +354,7 @@ WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
       reconstructed->SetOrigin(bandInputImage->GetOrigin());
 
       auto changeWaveletHighInfoFilter = ChangeInformationFilterType::New();
-      changeWaveletHighInfoFilter->SetInput(highPassMasks[band]);
+      changeWaveletHighInfoFilter->SetInput(highPassMasks->ElementAt(band));
       changeWaveletHighInfoFilter->UseReferenceImageOn();
       changeWaveletHighInfoFilter->SetReferenceImage( bandInputImage );
       changeWaveletHighInfoFilter->ChangeDirectionOff();
@@ -361,11 +362,11 @@ WaveletFrequencyInverseUndecimated< TInputImage, TOutputImage,
       changeWaveletHighInfoFilter->ChangeSpacingOn();
       changeWaveletHighInfoFilter->ChangeOriginOn();
       changeWaveletHighInfoFilter->UpdateLargestPossibleRegion();
-      highPassMasks[band] = changeWaveletHighInfoFilter->GetOutput();
-      highPassMasks[band]->DisconnectPipeline();
+      highPassMasks->ElementAt(band) = changeWaveletHighInfoFilter->GetOutput();
+      highPassMasks->ElementAt(band)->DisconnectPipeline();
 
       auto multiplyHighBandFilter = MultiplyFilterType::New();
-      multiplyHighBandFilter->SetInput1(highPassMasks[band]);
+      multiplyHighBandFilter->SetInput1(highPassMasks->ElementAt(band));
       multiplyHighBandFilter->SetInput2(bandInputImage);
       multiplyHighBandFilter->UpdateLargestPossibleRegion();
 

--- a/test/itkRieszRotationMatrixTest.cxx
+++ b/test/itkRieszRotationMatrixTest.cxx
@@ -130,7 +130,7 @@ runRieszRotationMatrixInterfaceWithRieszFrequencyFilterBankGeneratorTest()
   }
 
   auto imagesMultipliedByRieszRotationMatrix =
-    S.MultiplyWithVectorOfImages<ImageType>(images);
+    S.MultiplyWithVectorOfImages<std::vector<ImagePointer>>(images);
   std::cout << "Size: ";
   std::cout << imagesMultipliedByRieszRotationMatrix.size() << std::endl;
 

--- a/test/itkStructureTensorTest.cxx
+++ b/test/itkStructureTensorTest.cxx
@@ -125,9 +125,9 @@ runStructureTensorTest()
     tensor->GetModifiableGaussianSource();
   gaussianSource = StructureTensorType::GaussianSourceType::New();
 
-  std::vector< typename ImageType::Pointer > inputs;
-  inputs.push_back( inputImage1 );
-  inputs.push_back( inputImage2 );
+  auto inputs = StructureTensorType::InputsType::New();
+  inputs->push_back( inputImage1 );
+  inputs->push_back( inputImage2 );
   tensor->SetInputs( inputs );
   tensor->Update();
 

--- a/test/itkWaveletFrequencyForwardTest.cxx
+++ b/test/itkWaveletFrequencyForwardTest.cxx
@@ -89,10 +89,10 @@ int runWaveletFrequencyForwardTest( const std::string& inputImage,
 
   // Regression tests
   using OutputsType = typename ForwardWaveletType::OutputsType;
-  OutputsType allOutputs =
-    forwardWavelet->GetOutputs();
+  auto allOutputs = OutputsType::New();
+  allOutputs = forwardWavelet->GetOutputs();
   unsigned int expectedNumberOfOutputs = forwardWavelet->GetTotalOutputs();
-  unsigned int computedNumberOfOutputs = forwardWavelet->GetOutputs().size();
+  unsigned int computedNumberOfOutputs = forwardWavelet->GetOutputs()->size();
   if ( computedNumberOfOutputs != expectedNumberOfOutputs )
     {
     std::cerr << "Error in GetTotalOutputs()" << std::endl;
@@ -104,11 +104,11 @@ int runWaveletFrequencyForwardTest( const std::string& inputImage,
   typename ForwardWaveletType::OutputImagePointer lowPass =
     forwardWavelet->GetOutputLowPass();
 
-  OutputsType allHighSubBands = forwardWavelet->GetOutputsHighPass();
+  auto allHighSubBands = forwardWavelet->GetOutputsHighPass();
   unsigned int expectedNumberOfHighSubBands =
     forwardWavelet->GetTotalOutputs() - 1;
   unsigned int computedNumberOfHighSubBands =
-    forwardWavelet->GetOutputsHighPass().size();
+    forwardWavelet->GetOutputsHighPass()->size();
   if ( computedNumberOfHighSubBands != expectedNumberOfHighSubBands )
     {
     std::cerr << "Error in GetOutputsHighPass()" << std::endl;
@@ -117,11 +117,11 @@ int runWaveletFrequencyForwardTest( const std::string& inputImage,
     testPassed = false;
     }
 
-  OutputsType highSubBandsPerLevel = forwardWavelet->GetOutputsHighPassByLevel(0);
+  auto highSubBandsPerLevel = forwardWavelet->GetOutputsHighPassByLevel(0);
   unsigned int expectedNumberOfHighSubBandsPerLevel =
     forwardWavelet->GetHighPassSubBands();
   unsigned int computedNumberOfHighSubBandsPerLevel =
-    forwardWavelet->GetOutputsHighPassByLevel( 0 ).size();
+    forwardWavelet->GetOutputsHighPassByLevel( 0 )->size();
   if ( computedNumberOfHighSubBandsPerLevel != expectedNumberOfHighSubBandsPerLevel )
     {
     std::cerr << "Error in GetOutputsHighPassByLevel()" << std::endl;

--- a/test/itkWaveletFrequencyForwardUndecimatedTest.cxx
+++ b/test/itkWaveletFrequencyForwardUndecimatedTest.cxx
@@ -89,11 +89,9 @@ runWaveletFrequencyForwardUndecimatedTest( const std::string& inputImage,
   forwardWavelet->Update();
 
   // Regression tests
-  using OutputsType = typename ForwardWaveletType::OutputsType;
-  OutputsType allOutputs =
-    forwardWavelet->GetOutputs();
+  auto allOutputs = forwardWavelet->GetOutputs();
   unsigned int expectedNumberOfOutputs = forwardWavelet->GetTotalOutputs();
-  unsigned int computedNumberOfOutputs = forwardWavelet->GetOutputs().size();
+  unsigned int computedNumberOfOutputs = forwardWavelet->GetOutputs()->size();
   if ( computedNumberOfOutputs != expectedNumberOfOutputs )
     {
     std::cerr << "Error in GetTotalOutputs()" << std::endl;
@@ -105,11 +103,11 @@ runWaveletFrequencyForwardUndecimatedTest( const std::string& inputImage,
   typename ForwardWaveletType::OutputImagePointer lowPass =
     forwardWavelet->GetOutputLowPass();
 
-  OutputsType allHighSubBands = forwardWavelet->GetOutputsHighPass();
+  auto allHighSubBands = forwardWavelet->GetOutputsHighPass();
   unsigned int expectedNumberOfHighSubBands =
     forwardWavelet->GetTotalOutputs() - 1;
   unsigned int computedNumberOfHighSubBands =
-    forwardWavelet->GetOutputsHighPass().size();
+    forwardWavelet->GetOutputsHighPass()->size();
   if ( computedNumberOfHighSubBands != expectedNumberOfHighSubBands )
     {
     std::cerr << "Error in GetOutputsHighPass()" << std::endl;
@@ -118,11 +116,11 @@ runWaveletFrequencyForwardUndecimatedTest( const std::string& inputImage,
     testPassed = false;
     }
 
-  OutputsType highSubBandsPerLevel = forwardWavelet->GetOutputsHighPassByLevel(0);
+  auto highSubBandsPerLevel = forwardWavelet->GetOutputsHighPassByLevel(0);
   unsigned int expectedNumberOfHighSubBandsPerLevel =
     forwardWavelet->GetHighPassSubBands();
   unsigned int computedNumberOfHighSubBandsPerLevel =
-    forwardWavelet->GetOutputsHighPassByLevel( 0 ).size();
+    forwardWavelet->GetOutputsHighPassByLevel( 0 )->size();
   if ( computedNumberOfHighSubBandsPerLevel != expectedNumberOfHighSubBandsPerLevel )
     {
     std::cerr << "Error in GetOutputsHighPassByLevel()" << std::endl;

--- a/test/itkWaveletFrequencyInverseTest.cxx
+++ b/test/itkWaveletFrequencyInverseTest.cxx
@@ -168,8 +168,7 @@ runWaveletFrequencyInverseTest( const std::string& inputImage,
 
   // TODO move it from here to Forward test.
 #ifdef ITK_VISUALIZE_TESTS
-  std::vector< typename ComplexImageType::Pointer > waveletFilterBankPyramid =
-    forwardWavelet->GetWaveletFilterBankPyramid();
+  auto waveletFilterBankPyramid = forwardWavelet->GetWaveletFilterBankPyramid();
   using ComplexToRealFilterType = itk::ComplexToRealImageFilter< ComplexImageType, ImageType >;
   auto complexToRealFilter = ComplexToRealFilterType::New();
 

--- a/test/itkWaveletFrequencyInverseUndecimatedTest.cxx
+++ b/test/itkWaveletFrequencyInverseUndecimatedTest.cxx
@@ -157,8 +157,7 @@ int runWaveletFrequencyInverseUndecimatedTest( const std::string& inputImage,
 
   // TODO move it from here to Forward test.
 #ifdef ITK_VISUALIZE_TESTS
-  std::vector< typename ComplexImageType::Pointer > waveletFilterBankPyramid =
-    forwardWavelet->GetWaveletFilterBankPyramid();
+  auto waveletFilterBankPyramid = forwardWavelet->GetWaveletFilterBankPyramid();
   using ComplexToRealFilterType = itk::ComplexToRealImageFilter< ComplexImageType, ImageType >;
   auto complexToRealFilter = ComplexToRealFilterType::New();
 

--- a/wrapping/itkVectorContainerComplexImage.wrap
+++ b/wrapping/itkVectorContainerComplexImage.wrap
@@ -1,0 +1,9 @@
+itk_wrap_class("itk::VectorContainer" POINTER)
+  # used in IsotropicWavelets (outputs/inputs)
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    foreach(tc ${WRAP_ITK_COMPLEX_REAL})
+      itk_wrap_template("${ITKM_UI}${ITKM_I${tc}${d}}" "${ITKT_UI}, ${ITKT_I${tc}${d}}::Pointer")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()
+


### PR DESCRIPTION
This allows wrapping of inputs/outputs of the pyramid in
python.

Added a itkVectorContainer.wrap (already existing in core)
with the new wraper for VectorContainer.

This work triggered the question in discourse
of using a base class: itkImageToImageList for the case of a
std::vector<itk::SmartPointer<itk::ImageType>>

https://discourse.itk.org/t/about-introducing-imagelists/1365/4