### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if].

### DIFF
--- a/test/itkExpandWithZerosImageFilterTest.cxx
+++ b/test/itkExpandWithZerosImageFilterTest.cxx
@@ -173,8 +173,8 @@ itkExpandWithZerosImageFilterTest( int argc, char *argv[] )
     ImageToImageFilter );
 
   // Parse input arguments
-  unsigned int dimension = atoi( argv[1] );
-  auto expandFactor = static_cast< unsigned int >( atoi(argv[2]) );
+  unsigned int dimension = std::stoi( argv[1] );
+  auto expandFactor = static_cast< unsigned int >( std::stoi(argv[2]) );
 
 
   if ( dimension == 2 )

--- a/test/itkFFTPadPositiveIndexImageFilterTest.cxx
+++ b/test/itkFFTPadPositiveIndexImageFilterTest.cxx
@@ -54,7 +54,7 @@ int itkFFTPadPositiveIndexImageFilterTest( int argc, char * argv[] )
     ImageToImageFilter );
 
 
-  auto sizeGreatestPrimeFactor = static_cast< FFTPadType::SizeType::SizeValueType >( atoi( argv[3] ) );
+  auto sizeGreatestPrimeFactor = static_cast< FFTPadType::SizeType::SizeValueType >( std::stoi( argv[3] ) );
   fftpad->SetSizeGreatestPrimeFactor( sizeGreatestPrimeFactor );
   TEST_SET_GET_VALUE( sizeGreatestPrimeFactor, fftpad->GetSizeGreatestPrimeFactor() );
 

--- a/test/itkFrequencyExpandAndShrinkTest.cxx
+++ b/test/itkFrequencyExpandAndShrinkTest.cxx
@@ -269,7 +269,7 @@ itkFrequencyExpandAndShrinkTest( int argc, char* argv[] )
   unsigned int dimension = 3;
   if ( argc == 4 )
     {
-    dimension = atoi( argv[3] );
+    dimension = std::stoi( argv[3] );
     }
 
   if ( dimension == 2 )

--- a/test/itkFrequencyExpandTest.cxx
+++ b/test/itkFrequencyExpandTest.cxx
@@ -296,7 +296,7 @@ itkFrequencyExpandTest( int argc, char* argv[] )
   unsigned int dimension = 3;
   if ( argc == 4 )
     {
-    dimension = atoi(argv[3]);
+    dimension = std::stoi(argv[3]);
     }
 
   if ( dimension == 2 )

--- a/test/itkFrequencyShrinkTest.cxx
+++ b/test/itkFrequencyShrinkTest.cxx
@@ -396,7 +396,7 @@ itkFrequencyShrinkTest( int argc, char* argv[] )
   unsigned int dimension = 3;
   if ( argc == 4 )
     {
-    dimension = atoi( argv[3] );
+    dimension = std::stoi( argv[3] );
     }
 
   if ( dimension == 2 )

--- a/test/itkIsotropicWaveletFrequencyFunctionTest.cxx
+++ b/test/itkIsotropicWaveletFrequencyFunctionTest.cxx
@@ -139,13 +139,13 @@ itkIsotropicWaveletFrequencyFunctionTest( int argc, char *argv[] )
     }
   const std::string profileDataRootPath = argv[1];
   const std::string outputImage = argv[2];
-  const unsigned int inputBands = atoi( argv[3] );
+  const unsigned int inputBands = std::stoi( argv[3] );
   const std::string waveletFunction = argv[4];
 
   unsigned int dimension = 3;
   if ( argc == 6 )
     {
-    dimension = atoi( argv[5] );
+    dimension = std::stoi( argv[5] );
     }
 
   using HeldWavelet = itk::HeldIsotropicWavelet< >;

--- a/test/itkPhaseAnalysisSoftThresholdImageFilterTest.cxx
+++ b/test/itkPhaseAnalysisSoftThresholdImageFilterTest.cxx
@@ -103,11 +103,11 @@ int itkPhaseAnalysisSoftThresholdImageFilterTest( int argc, char* argv[] )
   EXERCISE_BASIC_OBJECT_METHODS( phaseAnalyzer, PhaseAnalysisSoftThresholdImageFilter,
     PhaseAnalysisImageFilter );
 
-  auto applySoftThreshold = static_cast< bool >( atoi( argv[3] ) );
+  auto applySoftThreshold = static_cast< bool >( std::stoi( argv[3] ) );
   TEST_SET_GET_BOOLEAN( phaseAnalyzer, ApplySoftThreshold, applySoftThreshold );
 
   auto numOfSigmas =
-    static_cast< PhaseAnalysisSoftThresholdFilterType::OutputImagePixelType >( atof( argv[4] ) );
+    static_cast< PhaseAnalysisSoftThresholdFilterType::OutputImagePixelType >( std::stod( argv[4] ) );
   phaseAnalyzer->SetNumOfSigmas( numOfSigmas );
   TEST_SET_GET_VALUE( numOfSigmas, phaseAnalyzer->GetNumOfSigmas() );
 
@@ -118,7 +118,7 @@ int itkPhaseAnalysisSoftThresholdImageFilterTest( int argc, char* argv[] )
 
   // Regression tests
   auto expectedMeanAmp =
-    static_cast< PhaseAnalysisSoftThresholdFilterType::OutputImagePixelType >( atof( argv[5] ) );
+    static_cast< PhaseAnalysisSoftThresholdFilterType::OutputImagePixelType >( std::stod( argv[5] ) );
   PhaseAnalysisSoftThresholdFilterType::OutputImagePixelType computedMeanAmp =
     phaseAnalyzer->GetMeanAmp();
   if( itk::Math::NotAlmostEquals( expectedMeanAmp, computedMeanAmp ) )
@@ -133,7 +133,7 @@ int itkPhaseAnalysisSoftThresholdImageFilterTest( int argc, char* argv[] )
     }
 
   auto expectedSigmaAmp =
-    static_cast< PhaseAnalysisSoftThresholdFilterType::OutputImagePixelType >( atof( argv[6] ) );
+    static_cast< PhaseAnalysisSoftThresholdFilterType::OutputImagePixelType >( std::stod( argv[6] ) );
   PhaseAnalysisSoftThresholdFilterType::OutputImagePixelType computedSigmaAmp =
     phaseAnalyzer->GetSigmaAmp();
   if( itk::Math::NotAlmostEquals( expectedSigmaAmp, computedSigmaAmp ) )
@@ -147,7 +147,7 @@ int itkPhaseAnalysisSoftThresholdImageFilterTest( int argc, char* argv[] )
     }
 
   auto expectedThreshold =
-    static_cast< PhaseAnalysisSoftThresholdFilterType::OutputImagePixelType >( atof( argv[7] ) );
+    static_cast< PhaseAnalysisSoftThresholdFilterType::OutputImagePixelType >( std::stod( argv[7] ) );
   PhaseAnalysisSoftThresholdFilterType::OutputImagePixelType computedThreshold =
     phaseAnalyzer->GetThreshold();
   if( itk::Math::NotAlmostEquals( expectedThreshold, computedThreshold ) )

--- a/test/itkRieszFrequencyFilterBankGeneratorTest.cxx
+++ b/test/itkRieszFrequencyFilterBankGeneratorTest.cxx
@@ -76,7 +76,7 @@ itkRieszFrequencyFilterBankGeneratorTest( int argc, char* argv[] )
   unsigned int inputOrder = 0;
   TRY_EXPECT_EXCEPTION( filterBank->SetOrder(inputOrder) );
 
-  inputOrder = atoi(argv[3]);
+  inputOrder = std::stoi(argv[3]);
   filterBank->SetOrder(inputOrder);
   TEST_SET_GET_VALUE( inputOrder, filterBank->GetOrder() );
 

--- a/test/itkRieszFrequencyFunctionTest.cxx
+++ b/test/itkRieszFrequencyFunctionTest.cxx
@@ -181,11 +181,11 @@ itkRieszFrequencyFunctionTest( int argc, char* argv[] )
     return EXIT_FAILURE;
     }
 
-  unsigned int dimension = atoi( argv[1] );
+  unsigned int dimension = std::stoi( argv[1] );
   unsigned int order = 5;
   if ( argc == 3 )
     {
-    order = atoi( argv[2] );
+    order = std::stoi( argv[2] );
     }
 
   if ( dimension == 2 )

--- a/test/itkRieszRotationMatrixTest.cxx
+++ b/test/itkRieszRotationMatrixTest.cxx
@@ -322,7 +322,7 @@ itkRieszRotationMatrixTest(int argc, char* argv[])
     }
 
 
-  const unsigned int dimension = atoi(argv[1]);
+  const unsigned int dimension = std::stoi(argv[1]);
   if ( dimension == 2 )
     {
     return runRieszRotationMatrixTest< 2 >();

--- a/test/itkRieszWaveletPhaseAnalysisTest.cxx
+++ b/test/itkRieszWaveletPhaseAnalysisTest.cxx
@@ -228,10 +228,10 @@ itkRieszWaveletPhaseAnalysisTest( int argc, char *argv[] )
 
   const std::string inputImage  = argv[1];
   const std::string outputImage = argv[2];
-  const unsigned int inputLevels = atoi( argv[3] );
-  const unsigned int inputBands  = atoi( argv[4] );
+  const unsigned int inputLevels = std::stoi( argv[3] );
+  const unsigned int inputBands  = std::stoi( argv[4] );
   const std::string waveletFunction = argv[5];
-  const unsigned int dimension = atoi( argv[6] );
+  const unsigned int dimension = std::stoi( argv[6] );
   const std::string applySoftThresholdInput = argv[7];
   bool applySoftThreshold = false;
   if ( applySoftThresholdInput == "Apply" )
@@ -251,7 +251,7 @@ itkRieszWaveletPhaseAnalysisTest( int argc, char *argv[] )
   double thresholdNumOfSigmas = 2.0;
   if ( argc == 9 )
     {
-    thresholdNumOfSigmas = atof(argv[8]);
+    thresholdNumOfSigmas = std::stod(argv[8]);
     }
 
   constexpr unsigned int ImageDimension = 2;

--- a/test/itkShrinkDecimateImageFilterTest.cxx
+++ b/test/itkShrinkDecimateImageFilterTest.cxx
@@ -144,7 +144,7 @@ itkShrinkDecimateImageFilterTest( int argc, char *argv[] )
   unsigned int dimension = 3;
   if ( argc == 2 )
     {
-    dimension = atoi( argv[1] );
+    dimension = std::stoi( argv[1] );
     }
 
   if ( dimension == 2 )

--- a/test/itkStructureTensorWithGeneralizedRieszTest.cxx
+++ b/test/itkStructureTensorWithGeneralizedRieszTest.cxx
@@ -240,10 +240,10 @@ itkStructureTensorWithGeneralizedRieszTest( int argc, char *argv[] )
 
   const std::string inputImage  = argv[1];
   const std::string outputImage = argv[2];
-  const unsigned int inputLevels = atoi( argv[3] );
-  const unsigned int inputBands  = atoi( argv[4] );
+  const unsigned int inputLevels = std::stoi( argv[3] );
+  const unsigned int inputBands  = std::stoi( argv[4] );
   const std::string waveletFunction = argv[5];
-  const unsigned int inputRieszOrder  = atoi( argv[6] );
+  const unsigned int inputRieszOrder  = std::stoi( argv[6] );
   const std::string applyReconstructionFactorsInput = argv[7];
   bool applyReconstructionFactors = false;
   if ( applyReconstructionFactorsInput == "Apply" )
@@ -263,7 +263,7 @@ itkStructureTensorWithGeneralizedRieszTest( int argc, char *argv[] )
   unsigned int dimension = 3;
   if ( argc == 9 )
     {
-    dimension = atoi( argv[8] );
+    dimension = std::stoi( argv[8] );
     }
 
   if ( dimension == 2 )

--- a/test/itkWaveletFrequencyFilterBankGeneratorDownsampleTest.cxx
+++ b/test/itkWaveletFrequencyFilterBankGeneratorDownsampleTest.cxx
@@ -126,13 +126,13 @@ itkWaveletFrequencyFilterBankGeneratorDownsampleTest( int argc, char *argv[] )
     }
   const std::string inputImage  = argv[1];
   const std::string outputImage = argv[2];
-  const unsigned int inputBands = atoi( argv[3] );
+  const unsigned int inputBands = std::stoi( argv[3] );
   const std::string waveletFunction  = argv[4];
 
   unsigned int dimension = 3;
   if ( argc == 6 )
     {
-    dimension = atoi( argv[5] );
+    dimension = std::stoi( argv[5] );
     }
 
   constexpr unsigned int ImageDimension = 2;

--- a/test/itkWaveletFrequencyFilterBankGeneratorTest.cxx
+++ b/test/itkWaveletFrequencyFilterBankGeneratorTest.cxx
@@ -183,13 +183,13 @@ itkWaveletFrequencyFilterBankGeneratorTest( int argc, char *argv[] )
     }
   const std::string inputImage  = argv[1];
   const std::string outputImage = argv[2];
-  const unsigned int inputBands = atoi( argv[3] );
+  const unsigned int inputBands = std::stoi( argv[3] );
   const std::string waveletFunction  = argv[4];
 
   unsigned int dimension = 3;
   if ( argc == 6 )
     {
-    dimension = atoi( argv[5] );
+    dimension = std::stoi( argv[5] );
     }
 
   constexpr unsigned int ImageDimension = 2;

--- a/test/itkWaveletFrequencyForwardTest.cxx
+++ b/test/itkWaveletFrequencyForwardTest.cxx
@@ -250,14 +250,14 @@ itkWaveletFrequencyForwardTest( int argc, char *argv[] )
     }
   const std::string inputImage  = argv[1];
   const std::string outputImage = argv[2];
-  const unsigned int inputLevels = atoi(argv[3] );
-  const unsigned int inputBands  = atoi( argv[4] );
+  const unsigned int inputLevels = std::stoi(argv[3] );
+  const unsigned int inputBands  = std::stoi( argv[4] );
   const std::string waveletFunction = argv[5];
 
   unsigned int dimension = 3;
   if ( argc == 7 )
     {
-    dimension = atoi( argv[6] );
+    dimension = std::stoi( argv[6] );
     }
 
   constexpr unsigned int ImageDimension = 3;

--- a/test/itkWaveletFrequencyForwardUndecimatedTest.cxx
+++ b/test/itkWaveletFrequencyForwardUndecimatedTest.cxx
@@ -236,14 +236,14 @@ itkWaveletFrequencyForwardUndecimatedTest( int argc, char *argv[] )
     }
   const std::string inputImage  = argv[1];
   const std::string outputImage = argv[2];
-  const unsigned int inputLevels = atoi(argv[3] );
-  const unsigned int inputBands  = atoi( argv[4] );
+  const unsigned int inputLevels = std::stoi(argv[3] );
+  const unsigned int inputBands  = std::stoi( argv[4] );
   const std::string waveletFunction = argv[5];
 
   unsigned int dimension = 3;
   if ( argc == 7 )
     {
-    dimension = atoi( argv[6] );
+    dimension = std::stoi( argv[6] );
     }
 
   constexpr unsigned int ImageDimension = 3;

--- a/test/itkWaveletFrequencyInverseTest.cxx
+++ b/test/itkWaveletFrequencyInverseTest.cxx
@@ -205,14 +205,14 @@ itkWaveletFrequencyInverseTest(int argc, char *argv[])
 
   const std::string inputImage  = argv[1];
   const std::string outputImage = argv[2];
-  const unsigned int inputLevels = atoi( argv[3] );
-  const unsigned int inputBands  = atoi( argv[4] );
+  const unsigned int inputLevels = std::stoi( argv[3] );
+  const unsigned int inputBands  = std::stoi( argv[4] );
   const std::string waveletFunction = argv[5];
 
   unsigned int dimension = 3;
   if ( argc == 7 )
     {
-    dimension = atoi( argv[6] );
+    dimension = std::stoi( argv[6] );
     }
 
   // const unsigned int ImageDimension = 3;

--- a/test/itkWaveletFrequencyInverseUndecimatedTest.cxx
+++ b/test/itkWaveletFrequencyInverseUndecimatedTest.cxx
@@ -194,8 +194,8 @@ itkWaveletFrequencyInverseUndecimatedTest(int argc, char *argv[])
 
   const std::string inputImage  = argv[1];
   const std::string outputImage = argv[2];
-  const unsigned int inputLevels = atoi( argv[3] );
-  const unsigned int inputBands  = atoi( argv[4] );
+  const unsigned int inputLevels = std::stoi( argv[3] );
+  const unsigned int inputBands  = std::stoi( argv[4] );
   const std::string waveletFunction = argv[5];
   const std::string inputUseWaveletFilterBankPyramid = argv[6];
   bool useWaveletFilterBankPyramid = false;
@@ -208,7 +208,7 @@ itkWaveletFrequencyInverseUndecimatedTest(int argc, char *argv[])
     useWaveletFilterBankPyramid = false;
     }
 
-  unsigned int dimension = atoi( argv[7] );
+  unsigned int dimension = std::stoi( argv[7] );
 
   // const unsigned int ImageDimension = 3;
   // using PixelType = double;

--- a/test/itkZeroDCImageFilterTest.cxx
+++ b/test/itkZeroDCImageFilterTest.cxx
@@ -94,7 +94,7 @@ itkZeroDCImageFilterTest( int argc, char *argv[] )
   unsigned int dimension  = 3;
   if ( argc == 3 )
     {
-    dimension = atoi( argv[2] );
+    dimension = std::stoi( argv[2] );
     }
 
   constexpr unsigned int ImageDimension = 3;


### PR DESCRIPTION
The `ato[if]` functions do not provide mechanisms for distinguishing
between `0` and the error condition where the input can not be converted.

`std::sto[id]` provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

`ato[if]()`
 - **Con**: No error handling.
 - **Con**: Handle neither hexadecimal nor octal.

The use of `ato[if]` in code can cause it to be subtly broken.
`ato[if]` makes two very big assumptions indeed:
 - The string represents an integer/floating point value.
 - The integer can fit into an int.

In agreement with:
http://review.source.kitware.com/#/c/23738/