### PR TITLE
BUG: Wrap VectorInverseFFTImageFilter with correct output type

### DIFF
--- a/wrapping/itkVectorInverseFFTImageFilter.wrap
+++ b/wrapping/itkVectorInverseFFTImageFilter.wrap
@@ -10,8 +10,8 @@ itk_end_wrap_class()
 itk_wrap_class("itk::VectorInverseFFTImageFilter" POINTER)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     foreach(t ${WRAP_ITK_COMPLEX_REAL})
-      itk_wrap_template("${ITKM_VI${t}${d}}${ITKM_I${t}${d}}"
-        "${ITKT_VI${t}${d}}, ${ITKT_I${t}${d}}")
+      itk_wrap_template("${ITKM_VI${t}${d}}"
+        "${ITKT_VI${t}${d}}")
     endforeach()
   endforeach()
 itk_end_wrap_class()


### PR DESCRIPTION
The output image type is an image of float's as opposed to complex
float's. Use the default template parameter for the output type.

Closes #99 