### PR TITLE
BUG: Fix origin of itkFFTPadPositiveIndexImageFilter

### DIFF
--- a/include/itkFFTPadPositiveIndexImageFilter.h
+++ b/include/itkFFTPadPositiveIndexImageFilter.h
@@ -21,6 +21,8 @@
 
 #include "itkFFTPadImageFilter.h"
 #include "itkImageBoundaryCondition.h"
+#include "itkConstantBoundaryCondition.h"
+#include "itkPeriodicBoundaryCondition.h"
 #include "itkChangeInformationImageFilter.h"
 
 namespace itk
@@ -101,7 +103,20 @@ public:
       this->Modified();
       }
     }
-
+  itkGetConstMacro(HalfPadSize, SizeType);
+  void SetBoundaryConditionToConstant(const OutputImagePixelType & boundaryValue)
+  {
+    using BoundaryCondition = itk::ConstantBoundaryCondition< InputImageType, OutputImageType >;
+    static BoundaryCondition boundaryCondition;
+    boundaryCondition.SetConstant(boundaryValue);
+    this->SetBoundaryCondition(&boundaryCondition);
+  }
+  void SetBoundaryConditionToPeriodic()
+  {
+    using BoundaryCondition = itk::PeriodicBoundaryCondition< InputImageType, OutputImageType >;
+    static BoundaryCondition boundaryCondition;
+    this->SetBoundaryCondition(&boundaryCondition);
+  }
 protected:
   FFTPadPositiveIndexImageFilter();
   ~FFTPadPositiveIndexImageFilter() override {};
@@ -118,6 +133,7 @@ private:
   typename ChangeInfoFilterType::Pointer m_ChangeInfoFilter;
   SizeValueType                          m_SizeGreatestPrimeFactor;
   BoundaryConditionPointerType           m_BoundaryCondition;
+  SizeType                               m_HalfPadSize;
 }; // end of class
 } // end namespace itk
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -345,23 +345,12 @@ itk_add_test(NAME itkFrequencyShrinkEvenTest
     2
     )
 ##FFTPad
-itk_add_test(NAME itkFFTPadPositiveIndexImageFilterTestZeroFluxNeumann
-  COMMAND IsotropicWaveletsTestDriver
-  itkFFTPadPositiveIndexImageFilterTest
-    DATA{Input/checkershadow_Lch_512x512.tiff}
-    ${ITK_TEST_OUTPUT_DIR}/itkFFTPadPositiveIndexImageFilterTestZeroFluxNeumann.tiff 2 ZEROFLUXNEUMANN
-    )
+# TODO: Add 2D Odd Data, current 512x512 input does not cover the class well. Other boundary conditions have been removed.
 itk_add_test(NAME itkFFTPadPositiveIndexImageFilterTestConstant
   COMMAND IsotropicWaveletsTestDriver
   itkFFTPadPositiveIndexImageFilterTest
     DATA{Input/checkershadow_Lch_512x512.tiff}
     ${ITK_TEST_OUTPUT_DIR}/itkFFTPadPositiveIndexImageFilterTestConstant.tiff 2 CONSTANT
-    )
- itk_add_test(NAME itkFFTPadPositiveIndexImageFilterTestPeriodic
-  COMMAND IsotropicWaveletsTestDriver
-  itkFFTPadPositiveIndexImageFilterTest
-    DATA{Input/checkershadow_Lch_512x512.tiff}
-    ${ITK_TEST_OUTPUT_DIR}/itkFFTPadPositiveIndexImageFilterTestPeriodic.tiff 2 PERIODIC
     )
 ## ZeroDC
 itk_add_test(NAME itkZeroDCImageFilterTest

--- a/test/itkFFTPadPositiveIndexImageFilterTest.cxx
+++ b/test/itkFFTPadPositiveIndexImageFilterTest.cxx
@@ -67,6 +67,7 @@ int itkFFTPadPositiveIndexImageFilterTest( int argc, char * argv[] )
     {
     fftpad->SetBoundaryCondition( &constantBoundaryCondition );
     TEST_SET_GET_VALUE( &constantBoundaryCondition, fftpad->GetBoundaryCondition() );
+    fftpad->SetBoundaryConditionToConstant(0);
     }
   else if ( boundaryCondition == "PERIODIC" )
     {
@@ -99,6 +100,25 @@ int itkFFTPadPositiveIndexImageFilterTest( int argc, char * argv[] )
       {
       std::cerr << "Test failed!" << std::endl;
       std::cerr << "Negative index found." << std::endl;
+      return EXIT_FAILURE;
+      }
+    }
+  auto inOrigin = reader->GetOutput()->GetOrigin();
+  auto outOrigin = fftpad->GetOutput()->GetOrigin();
+  std::cout << "InputOrigin: " << inOrigin << ". OutputOrigin: " << outOrigin << std::endl;
+
+  auto expectedOrigin = reader->GetOutput()->GetOrigin();
+  auto computedIndex =
+    reader->GetOutput()->GetLargestPossibleRegion().GetIndex() - fftpad->GetHalfPadSize();
+  reader->GetOutput()->TransformIndexToPhysicalPoint( computedIndex, expectedOrigin);
+  for ( unsigned int i = 0; i < Dimension; ++i )
+    {
+    if ( expectedOrigin[i] != outOrigin[i] )
+      {
+      std::cerr << "Test failed!" << std::endl;
+      std::cerr << "Origin is not updated." << std::endl;
+      std::cerr << "Dim: " << i  << ". Expected: " << expectedOrigin[i] <<
+        ". Output: " << outOrigin[i] << std::endl;
       return EXIT_FAILURE;
       }
     }

--- a/wrapping/itkFFTPadPositiveIndexImageFilter.wrap
+++ b/wrapping/itkFFTPadPositiveIndexImageFilter.wrap
@@ -1,7 +1,3 @@
 itk_wrap_class("itk::FFTPadPositiveIndexImageFilter" POINTER)
-  foreach(d ${ITK_WRAP_IMAGE_DIMS})
-    foreach(t ${WRAP_ITK_REAL})
-      itk_wrap_template("${ITKM_I${t}${d}}" "${ITKT_I${t}${d}}")
-    endforeach()
-  endforeach()
+  itk_wrap_image_filter("${WRAP_ITK_ALL_TYPES}" 1)
 itk_end_wrap_class()


### PR DESCRIPTION
See https://github.com/InsightSoftwareConsortium/ITK/issues/400
for more context on the origin in ITK.
It corresponds to the index{0}, not to the first index.

Some tests related with boundary condition are removed, as they are not
needed.