### PR TITLE
BUG: Fix level returning from IndexToLevelBandSteerablePyramid

### DIFF
--- a/include/itkWaveletUtilities.h
+++ b/include/itkWaveletUtilities.h
@@ -45,7 +45,7 @@ namespace utils
    * if only one level:
    * n:bands ---> l:0, b=0
    * Independently of the numbers of levels or bands, the last index is always the low pass:
-   * nLowPass ---> l:Levels - 1, b=0
+   * nLowPass ---> l:Levels, b=0
    *
    * Note that bands and levels are always >= 1. The level/bands returned here corresponds to an index.
    */

--- a/src/itkWaveletUtilities.cxx
+++ b/src/itkWaveletUtilities.cxx
@@ -37,7 +37,7 @@ IndexPairType IndexToLevelBandSteerablePyramid(unsigned int linearIndex,
   // Low pass (band = 0).
   if (linearIndex == totalOutputs - 1 )
     {
-    return std::make_pair(levels - 1, 0);
+    return std::make_pair(levels, 0);
     }
 
   unsigned int band = (linearIndex ) % bands + 1;

--- a/test/itkWaveletUtilitiesTest.cxx
+++ b/test/itkWaveletUtilitiesTest.cxx
@@ -170,7 +170,8 @@ int itkWaveletUtilitiesTest(int , char*[] )
     unsigned int bands = 1;
     unsigned int expectedLevel = 0;
     unsigned int expectedBand = 1;
-    testOutputIndexToLevelBandPassed = IndexToLevelBandTest(
+    testOutputIndexToLevelBandPassed = testOutputIndexToLevelBandPassed &&
+      IndexToLevelBandTest(
         linearIndex, levels, bands,
         expectedLevel, expectedBand);
     }
@@ -178,9 +179,10 @@ int itkWaveletUtilitiesTest(int , char*[] )
     unsigned int linearIndex = 1;
     unsigned int levels = 1;
     unsigned int bands = 1;
-    unsigned int expectedLevel = 0;
+    unsigned int expectedLevel = levels;
     unsigned int expectedBand = 0;
-    testOutputIndexToLevelBandPassed = IndexToLevelBandTest(
+    testOutputIndexToLevelBandPassed = testOutputIndexToLevelBandPassed &&
+      IndexToLevelBandTest(
         linearIndex, levels, bands,
         expectedLevel, expectedBand);
     }
@@ -197,7 +199,8 @@ int itkWaveletUtilitiesTest(int , char*[] )
     unsigned int bands = 2;
     unsigned int expectedLevel = 0;
     unsigned int expectedBand = 1;
-    testOutputIndexToLevelBandPassed = IndexToLevelBandTest(
+    testOutputIndexToLevelBandPassed = testOutputIndexToLevelBandPassed &&
+      IndexToLevelBandTest(
         linearIndex, levels, bands,
         expectedLevel, expectedBand);
     }
@@ -207,7 +210,8 @@ int itkWaveletUtilitiesTest(int , char*[] )
     unsigned int bands = 2;
     unsigned int expectedLevel = 0;
     unsigned int expectedBand = 2;
-    testOutputIndexToLevelBandPassed = IndexToLevelBandTest(
+    testOutputIndexToLevelBandPassed = testOutputIndexToLevelBandPassed &&
+      IndexToLevelBandTest(
         linearIndex, levels, bands,
         expectedLevel, expectedBand);
     }
@@ -217,7 +221,8 @@ int itkWaveletUtilitiesTest(int , char*[] )
     unsigned int bands = 2;
     unsigned int expectedLevel = 1;
     unsigned int expectedBand = 1;
-    testOutputIndexToLevelBandPassed = IndexToLevelBandTest(
+    testOutputIndexToLevelBandPassed = testOutputIndexToLevelBandPassed &&
+      IndexToLevelBandTest(
         linearIndex, levels, bands,
         expectedLevel, expectedBand);
     }
@@ -227,7 +232,8 @@ int itkWaveletUtilitiesTest(int , char*[] )
     unsigned int bands = 2;
     unsigned int expectedLevel = 1;
     unsigned int expectedBand = 2;
-    testOutputIndexToLevelBandPassed = IndexToLevelBandTest(
+    testOutputIndexToLevelBandPassed = testOutputIndexToLevelBandPassed &&
+      IndexToLevelBandTest(
         linearIndex, levels, bands,
         expectedLevel, expectedBand);
     }
@@ -235,9 +241,10 @@ int itkWaveletUtilitiesTest(int , char*[] )
     unsigned int linearIndex = 4;
     unsigned int levels = 2;
     unsigned int bands = 2;
-    unsigned int expectedLevel = 1;
+    unsigned int expectedLevel = levels;
     unsigned int expectedBand = 0;
-    testOutputIndexToLevelBandPassed = IndexToLevelBandTest(
+    testOutputIndexToLevelBandPassed = testOutputIndexToLevelBandPassed &&
+      IndexToLevelBandTest(
         linearIndex, levels, bands,
         expectedLevel, expectedBand);
     }
@@ -251,18 +258,18 @@ int itkWaveletUtilitiesTest(int , char*[] )
 
   if ( !testOutputIndexToLevelBandPassed )
     {
-    std::cerr << "Error in OutputIndexToLevelBand" << std::endl;
-    testPassed = false;
+    std::cerr << "Test failed in OutputIndexToLevelBand." << std::endl;
     }
 
   // Test ComputeMaxNumberOfLevels
   bool testComputeMaxNumberOfLevelsPassed = testComputeMaxNumberOfLevels();
   if (!testComputeMaxNumberOfLevelsPassed)
     {
-    testPassed = false;
+    std::cerr << "Test failed in ComputerMaxNumberOfLevels." << std::endl;
     }
 
 
+  testPassed = testOutputIndexToLevelBandPassed && testComputeMaxNumberOfLevelsPassed;
   if ( testPassed )
     {
     return EXIT_SUCCESS;


### PR DESCRIPTION
At last index
When index == forwardWavelet->GetNumberOfOutputs() - 1
IndexToLevelBandSteerablePyramid returns the pair
(max_level, 0)
instead of:
(max_level - 1, 0)

Now it returns the right level, according to the pyramid, the last
output is downsampled. This is compatible with the spacing of
the outputs of forwardWavelets.