### PR TITLE
PERF: Add DynamicThreadedGenerateData to Riesz and Wavelet Bank Generators

### DIFF
--- a/include/itkRieszFrequencyFilterBankGenerator.h
+++ b/include/itkRieszFrequencyFilterBankGenerator.h
@@ -115,7 +115,8 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Generate data */
-  void GenerateData() override;
+  void BeforeThreadedGenerateData() override;
+  void DynamicThreadedGenerateData(const OutputImageRegionType & threadRegion) override;
 
 private:
   unsigned int         m_Order;

--- a/include/itkWaveletFrequencyFilterBankGenerator.h
+++ b/include/itkWaveletFrequencyFilterBankGenerator.h
@@ -131,7 +131,8 @@ protected:
   ~WaveletFrequencyFilterBankGenerator() override {}
   void PrintSelf(std::ostream & os, Indent indent) const override;
 
-  void GenerateData() override;
+  void BeforeThreadedGenerateData() override;
+  void DynamicThreadedGenerateData(const OutputImageRegionType & threadRegion) override;
 
 private:
   unsigned int           m_HighPassSubBands;


### PR DESCRIPTION
PERF: Add DynamicThreaded to WaveletBankGenerator
Non-scientific perf test: From 13.96s to 12.07s

PERF: Add DynamicThreaded to RieszBankGenerator
Non-scientific perf test: From 14.45s to 13.96s

Perf test was using a simple: `ctest -L "IsotropicWavelets"`