### PR TITLE
ENH: Set RieszRotationMatrix ValueType to std::complex

### DIFF
--- a/include/itkRieszRotationMatrix.h
+++ b/include/itkRieszRotationMatrix.h
@@ -17,10 +17,12 @@
  *=========================================================================*/
 #ifndef itkRieszRotationMatrix_h
 #define itkRieszRotationMatrix_h
-#include "itkVariableSizeMatrix.h"
 #include <vector>
+#include "itkImage.h"
 #include "itkMatrix.h"
 #include "itkRieszUtilities.h"
+#include "itkVariableSizeMatrix.h"
+#include "itkVectorContainer.h"
 
 namespace itk
 {
@@ -35,7 +37,7 @@ namespace itk
  *
  * \f[ M := p(N,d) = \frac{(N+d-1)!}{(d-1)! N!} \f]
  *
- * The rotation matrix is a dxd matrix.
+ * The rotation matrix is a dxd matrix of real type.
  *
  * \sa RieszFrequencyFunction
  * \sa RieszFrequencyFilterBankGenerator
@@ -43,18 +45,20 @@ namespace itk
  * \ingroup IsotropicWavelets
  */
 
-template <typename T = double, unsigned int VImageDimension = 3>
-class RieszRotationMatrix : public itk::VariableSizeMatrix<T>
+template <unsigned int VImageDimension>
+class RieszRotationMatrix : public itk::VariableSizeMatrix<std::complex<double>>
 {
 public:
   /** Standard type alias */
   using Self = RieszRotationMatrix;
-  using Superclass = itk::VariableSizeMatrix<T>;
+  using ValueType = std::complex<double>;
+  using Superclass = itk::VariableSizeMatrix<ValueType>;
 
   /** Component value type */
-  using ValueType = typename Superclass::ValueType;
+  using RealType = typename ValueType::value_type;
   using InternalMatrixType = typename Superclass::InternalMatrixType;
-  using SpatialRotationMatrixType = itk::Matrix<T, VImageDimension, VImageDimension>;
+  using SpatialRotationMatrixType = itk::Matrix<RealType, VImageDimension, VImageDimension>;
+  using ComplexImageType = itk::Image<ValueType, VImageDimension>;
 
   /** Matrix by std::vector<TImage> multiplication.
    * To perform the rotation with the output of
@@ -194,7 +198,7 @@ public:
     return this->m_MaxAbsoluteDifferenceCloseToZero;
   }
   inline void
-  SetMaxAbsoluteDifferenceCloseToZero(const ValueType & maxAbsoluteDifference)
+  SetMaxAbsoluteDifferenceCloseToZero(const RealType & maxAbsoluteDifference)
   {
     this->m_MaxAbsoluteDifferenceCloseToZero = maxAbsoluteDifference;
   }
@@ -228,10 +232,11 @@ public:
 #endif
 
 private:
+  using ResultValueType = std::complex<long double>;
   SpatialRotationMatrixType m_SpatialRotationMatrix;
   unsigned int              m_Order{ 0 };
   unsigned int              m_Components{ 0 };
-  ValueType                 m_MaxAbsoluteDifferenceCloseToZero;
+  RealType                  m_MaxAbsoluteDifferenceCloseToZero;
   bool                      m_Debug{ false };
 
 }; // end of class

--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,5 +1,7 @@
 itk_wrap_module(IsotropicWavelets)
 set(WRAPPER_SUBMODULE_ORDER
+  itkMatrixComplex
+  itkVariableSizeMatrixComplex
   itkStructureTensor
   itkMonogenicSignalFrequencyImageFilter
   itkVectorInverseFFTImageFilter

--- a/wrapping/itkMatrixComplex.wrap
+++ b/wrapping/itkMatrixComplex.wrap
@@ -1,0 +1,7 @@
+itk_wrap_class("itk::Matrix")
+  foreach(d 2 3)
+    foreach(t ${WRAP_ITK_COMPLEX_REAL})
+      itk_wrap_template("${ITKM_${t}}${d}${d}" "${ITKT_${t}},${d},${d}")
+    endforeach()
+  endforeach()
+itk_end_wrap_class()

--- a/wrapping/itkRieszRotationMatrix.wrap
+++ b/wrapping/itkRieszRotationMatrix.wrap
@@ -1,5 +1,10 @@
+itk_wrap_include("complex")
+itk_wrap_class("itk::VariableSizeMatrix")
+  itk_wrap_template("CD" "std::complex<double>")
+itk_end_wrap_class()
+
 itk_wrap_class("itk::RieszRotationMatrix")
-    foreach(d ${ITK_WRAP_IMAGE_DIMS})
-        itk_wrap_template("${ITKM_D}${d}" "${ITKT_D},${d}")
-    endforeach()
+  foreach(d ${ITK_WRAP_IMAGE_DIMS})
+    itk_wrap_template("${d}" "${d}")
+  endforeach()
 itk_end_wrap_class()

--- a/wrapping/itkVariableSizeMatrixComplex.wrap
+++ b/wrapping/itkVariableSizeMatrixComplex.wrap
@@ -1,0 +1,5 @@
+itk_wrap_class("itk::VariableSizeMatrix")
+  foreach(t ${WRAP_ITK_COMPLEX_REAL})
+    itk_wrap_template("${ITKM_${t}}" "${ITKT_${t}}")
+  endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
 - Allow multiplying it with a real matrix.
- Add wrapping of few other missing types from ITK core wrappings.

Still some wrappings warnings at configure time (Ok at runtime)
```cpp
Generating /path/../IsotropicWavelets_snake_case.py
itkMatrixComplex: warning(4): ITK type not wrapped, or currently not known: itk::Vector< std::complex< float >, 2 >
itkMatrixComplex: warning(4): ITK type not wrapped, or currently not known: itk::Point< std::complex< float >, 2 >
itkMatrixComplex: warning(4): ITK type not wrapped, or currently not known: itk::CovariantVector< std::complex< float >, 2 >
itkMatrixComplex: warning(4): ITK type not wrapped, or currently not known: itk::Vector< std::complex< float >, 3 >
itkMatrixComplex: warning(4): ITK type not wrapped, or currently not known: itk::Point< std::complex< float >, 3 >
itkMatrixComplex: warning(4): ITK type not wrapped, or currently not known: itk::CovariantVector< std::complex< float >, 3 >
itkVariableSizeMatrixComplex: warning(4): ITK type not wrapped, or currently not known: itk::Array< std::complex< float > >
itkStructureTensor: warning(4): ITK type not wrapped, or currently not known: itk::GaussianImageSource< itk::Image< double, 3 > >
itkRieszRotationMatrix: warning(4): ITK type not wrapped, or currently not known: itk::Array< std::complex< double > >
```
