### PR TITLE
COMP: Add -Wno-undefined-var-template to CMAKE_CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ set(IsotropicWavelets_LIBRARIES IsotropicWavelets)
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK REQUIRED)
   list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
+  # Hide clang warnings about undefined-var-template
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang") # using regular Clang or AppleClang
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-undefined-var-template")
+  endif()
   include(ITKModuleExternal)
 else()
   itk_module_impl()


### PR DESCRIPTION
Only needed when building the template externally with a clang compiler.

Hides the following spurious warnings:

```cpp
Modules/Core/Common/include/itkNumericTraits.h:1083:36: warning:
instantiation of variable 'itk::NumericTraits<std::__1::complex<double> >::Zero'
required here, but no definition is available [-Wundefined-var-template]

  static Self ZeroValue() { return Zero; }

Modules/Core/Common/include/itkNumericTraits.h:1083:36: note: add an
explicit instantiation declaration to suppress this warning if
'itk::NumericTraits<std::__1::complex<double> >::Zero' is explicitly
instantiated in another translation unit

  static Self ZeroValue() { return Zero; }
```

Fixes #120