### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkExpandWithZerosImageFilter.h
+++ b/include/itkExpandWithZerosImageFilter.h
@@ -63,7 +63,7 @@ template <typename TInputImage, typename TOutputImage>
 class ExpandWithZerosImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ExpandWithZerosImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ExpandWithZerosImageFilter);
 
   /** Standard class type alias. */
   using Self = ExpandWithZerosImageFilter;

--- a/include/itkFrequencyExpandImageFilter.h
+++ b/include/itkFrequencyExpandImageFilter.h
@@ -102,7 +102,7 @@ template <typename TImageType>
 class FrequencyExpandImageFilter : public ImageToImageFilter<TImageType, TImageType>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FrequencyExpandImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(FrequencyExpandImageFilter);
 
   /** Standard class type alias. */
   using Self = FrequencyExpandImageFilter;

--- a/include/itkFrequencyExpandViaInverseFFTImageFilter.h
+++ b/include/itkFrequencyExpandViaInverseFFTImageFilter.h
@@ -50,7 +50,7 @@ template <typename TImageType>
 class FrequencyExpandViaInverseFFTImageFilter : public ImageToImageFilter<TImageType, TImageType>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FrequencyExpandViaInverseFFTImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(FrequencyExpandViaInverseFFTImageFilter);
 
   /** Standard class type alias. */
   using Self = FrequencyExpandViaInverseFFTImageFilter;

--- a/include/itkFrequencyFunction.h
+++ b/include/itkFrequencyFunction.h
@@ -35,7 +35,7 @@ template <typename TFunctionValue = double,
 class FrequencyFunction : public SpatialFunction<TFunctionValue, VImageDimension, TInput>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FrequencyFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(FrequencyFunction);
 
   /** Standard class type alias. */
   using Self = FrequencyFunction;

--- a/include/itkFrequencyShrinkImageFilter.h
+++ b/include/itkFrequencyShrinkImageFilter.h
@@ -77,7 +77,7 @@ template <typename TImageType>
 class FrequencyShrinkImageFilter : public ImageToImageFilter<TImageType, TImageType>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FrequencyShrinkImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(FrequencyShrinkImageFilter);
 
   /** Standard class type alias. */
   using Self = FrequencyShrinkImageFilter;

--- a/include/itkFrequencyShrinkViaInverseFFTImageFilter.h
+++ b/include/itkFrequencyShrinkViaInverseFFTImageFilter.h
@@ -43,7 +43,7 @@ template <typename TImageType>
 class FrequencyShrinkViaInverseFFTImageFilter : public ImageToImageFilter<TImageType, TImageType>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FrequencyShrinkViaInverseFFTImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(FrequencyShrinkViaInverseFFTImageFilter);
 
   /** Standard class type alias. */
   using Self = FrequencyShrinkViaInverseFFTImageFilter;

--- a/include/itkHeldIsotropicWavelet.h
+++ b/include/itkHeldIsotropicWavelet.h
@@ -45,7 +45,7 @@ template <typename TFunctionValue = double,
 class HeldIsotropicWavelet : public IsotropicWaveletFrequencyFunction<TFunctionValue, VImageDimension, TInput>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(HeldIsotropicWavelet);
+  ITK_DISALLOW_COPY_AND_MOVE(HeldIsotropicWavelet);
 
   /** Standard class type alias. */
   using Self = HeldIsotropicWavelet;

--- a/include/itkIsotropicFrequencyFunction.h
+++ b/include/itkIsotropicFrequencyFunction.h
@@ -39,7 +39,7 @@ template <typename TFunctionValue = double,
 class IsotropicFrequencyFunction : public FrequencyFunction<TFunctionValue, VImageDimension, TInput>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(IsotropicFrequencyFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(IsotropicFrequencyFunction);
 
   /** Standard class type alias. */
   using Self = IsotropicFrequencyFunction;

--- a/include/itkIsotropicWaveletFrequencyFunction.h
+++ b/include/itkIsotropicWaveletFrequencyFunction.h
@@ -57,7 +57,7 @@ template <typename TFunctionValue = double,
 class IsotropicWaveletFrequencyFunction : public IsotropicFrequencyFunction<TFunctionValue, VImageDimension, TInput>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(IsotropicWaveletFrequencyFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(IsotropicWaveletFrequencyFunction);
 
   /** Standard class type alias. */
   using Self = IsotropicWaveletFrequencyFunction;

--- a/include/itkMonogenicSignalFrequencyImageFilter.h
+++ b/include/itkMonogenicSignalFrequencyImageFilter.h
@@ -45,7 +45,7 @@ class MonogenicSignalFrequencyImageFilter
   : public ImageToImageFilter<TInputImage, VectorImage<typename TInputImage::PixelType, TInputImage::ImageDimension>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MonogenicSignalFrequencyImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(MonogenicSignalFrequencyImageFilter);
 
   /** Standard class type alias. */
   using Self = MonogenicSignalFrequencyImageFilter;

--- a/include/itkPhaseAnalysisImageFilter.h
+++ b/include/itkPhaseAnalysisImageFilter.h
@@ -65,7 +65,7 @@ template <typename TInputImage,
 class PhaseAnalysisImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(PhaseAnalysisImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(PhaseAnalysisImageFilter);
 
   /** Standard class type alias. */
   using Self = PhaseAnalysisImageFilter;

--- a/include/itkPhaseAnalysisSoftThresholdImageFilter.h
+++ b/include/itkPhaseAnalysisSoftThresholdImageFilter.h
@@ -43,7 +43,7 @@ template <typename TInputImage,
 class PhaseAnalysisSoftThresholdImageFilter : public PhaseAnalysisImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(PhaseAnalysisSoftThresholdImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(PhaseAnalysisSoftThresholdImageFilter);
 
   /** Standard class type alias. */
   using Self = PhaseAnalysisSoftThresholdImageFilter;

--- a/include/itkRieszFrequencyFilterBankGenerator.h
+++ b/include/itkRieszFrequencyFilterBankGenerator.h
@@ -42,7 +42,7 @@ template <typename TOutputImage,
 class RieszFrequencyFilterBankGenerator : public itk::GenerateImageSource<TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(RieszFrequencyFilterBankGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(RieszFrequencyFilterBankGenerator);
 
   /** Standard type alias */
   using Self = RieszFrequencyFilterBankGenerator;

--- a/include/itkRieszFrequencyFilterBankGenerator.hxx
+++ b/include/itkRieszFrequencyFilterBankGenerator.hxx
@@ -39,7 +39,7 @@ RieszFrequencyFilterBankGenerator<TOutputImage, TRieszFunction, TFrequencyRegion
 {
   Superclass::PrintSelf(os, indent);
   os << indent << "m_Order: " << this->m_Order << std::endl;
-  itkPrintSelfObjectMacro(Evaluator)
+  itkPrintSelfObjectMacro(Evaluator);
 }
 
 /* ******* Get Outputs *****/

--- a/include/itkRieszFrequencyFunction.h
+++ b/include/itkRieszFrequencyFunction.h
@@ -39,7 +39,7 @@ template <typename TFunctionValue = std::complex<double>,
 class RieszFrequencyFunction : public FrequencyFunction<TFunctionValue, VImageDimension, TInput>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(RieszFrequencyFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(RieszFrequencyFunction);
 
   /** Standard class type alias. */
   using Self = RieszFrequencyFunction;

--- a/include/itkShannonIsotropicWavelet.h
+++ b/include/itkShannonIsotropicWavelet.h
@@ -47,7 +47,7 @@ template <typename TFunctionValue = double,
 class ShannonIsotropicWavelet : public IsotropicWaveletFrequencyFunction<TFunctionValue, VImageDimension, TInput>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ShannonIsotropicWavelet);
+  ITK_DISALLOW_COPY_AND_MOVE(ShannonIsotropicWavelet);
 
   /** Standard class type alias. */
   using Self = ShannonIsotropicWavelet;

--- a/include/itkShrinkDecimateImageFilter.h
+++ b/include/itkShrinkDecimateImageFilter.h
@@ -42,7 +42,7 @@ template <typename TInputImage, typename TOutputImage>
 class ShrinkDecimateImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ShrinkDecimateImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ShrinkDecimateImageFilter);
 
   /** Standard class type alias. */
   using Self = ShrinkDecimateImageFilter;

--- a/include/itkSimoncelliIsotropicWavelet.h
+++ b/include/itkSimoncelliIsotropicWavelet.h
@@ -52,7 +52,7 @@ template <typename TFunctionValue = double,
 class SimoncelliIsotropicWavelet : public IsotropicWaveletFrequencyFunction<TFunctionValue, VImageDimension, TInput>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SimoncelliIsotropicWavelet);
+  ITK_DISALLOW_COPY_AND_MOVE(SimoncelliIsotropicWavelet);
 
   /** Standard class type alias. */
   using Self = SimoncelliIsotropicWavelet;

--- a/include/itkStructureTensor.h
+++ b/include/itkStructureTensor.h
@@ -83,7 +83,7 @@ template <typename TInputImage,
 class StructureTensor : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(StructureTensor);
+  ITK_DISALLOW_COPY_AND_MOVE(StructureTensor);
 
   /** Some convenient type alias. */
   /** Standard class type alias. */

--- a/include/itkVectorInverseFFTImageFilter.h
+++ b/include/itkVectorInverseFFTImageFilter.h
@@ -45,7 +45,7 @@ template <typename TInputImage,
 class VectorInverseFFTImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VectorInverseFFTImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(VectorInverseFFTImageFilter);
 
   /** Standard class type alias. */
   using InputImageType = TInputImage;

--- a/include/itkVowIsotropicWavelet.h
+++ b/include/itkVowIsotropicWavelet.h
@@ -49,7 +49,7 @@ template <typename TFunctionValue = double,
 class VowIsotropicWavelet : public IsotropicWaveletFrequencyFunction<TFunctionValue, VImageDimension, TInput>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(VowIsotropicWavelet);
+  ITK_DISALLOW_COPY_AND_MOVE(VowIsotropicWavelet);
 
   /** Standard class type alias. */
   using Self = VowIsotropicWavelet;

--- a/include/itkWaveletCoeffsPhaseAnalyzisImageFilter.h
+++ b/include/itkWaveletCoeffsPhaseAnalyzisImageFilter.h
@@ -56,7 +56,7 @@ template <typename TImageType, typename TWaveletFunction>
 class WaveletCoeffsPhaseAnalyzisImageFilter : public ImageToImageFilter<TImageType, TImageType>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(WaveletCoeffsPhaseAnalyzisImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(WaveletCoeffsPhaseAnalyzisImageFilter);
 
   /** Standard typenames type alias. */
   using Self = WaveletCoeffsPhaseAnalyzisImageFilter;

--- a/include/itkWaveletCoeffsSpatialDomainImageFilter.h
+++ b/include/itkWaveletCoeffsSpatialDomainImageFilter.h
@@ -58,7 +58,7 @@ template <typename TImageType, typename TWaveletFunction>
 class WaveletCoeffsSpatialDomainImageFilter : public ImageToImageFilter<TImageType, TImageType>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(WaveletCoeffsSpatialDomainImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(WaveletCoeffsSpatialDomainImageFilter);
 
   /** Standard typenames type alias. */
   using Self = WaveletCoeffsSpatialDomainImageFilter;

--- a/include/itkWaveletFrequencyFilterBankGenerator.h
+++ b/include/itkWaveletFrequencyFilterBankGenerator.h
@@ -53,7 +53,7 @@ template <typename TOutputImage,
 class WaveletFrequencyFilterBankGenerator : public itk::GenerateImageSource<TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(WaveletFrequencyFilterBankGenerator);
+  ITK_DISALLOW_COPY_AND_MOVE(WaveletFrequencyFilterBankGenerator);
 
   /** Standard type alias */
   using Self = WaveletFrequencyFilterBankGenerator;

--- a/include/itkWaveletFrequencyForward.h
+++ b/include/itkWaveletFrequencyForward.h
@@ -51,7 +51,7 @@ template <typename TInputImage,
 class WaveletFrequencyForward : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(WaveletFrequencyForward);
+  ITK_DISALLOW_COPY_AND_MOVE(WaveletFrequencyForward);
 
   /** Standard typenames type alias. */
   using Self = WaveletFrequencyForward;

--- a/include/itkWaveletFrequencyForward.h
+++ b/include/itkWaveletFrequencyForward.h
@@ -114,7 +114,7 @@ public:
 
   /** Flag to store the wavelet Filter Bank Pyramid, for all levels and all bands.
    * Access to it with GetWaveletFilterBankPyramid()*/
-  itkSetMacro(StoreWaveletFilterBankPyramid, bool) itkGetMacro(StoreWaveletFilterBankPyramid, bool)
+  itkSetMacro(StoreWaveletFilterBankPyramid, bool); itkGetMacro(StoreWaveletFilterBankPyramid, bool);
     itkBooleanMacro(StoreWaveletFilterBankPyramid);
 
   itkGetMacro(WaveletFilterBankPyramid, OutputsType);

--- a/include/itkWaveletFrequencyForwardUndecimated.h
+++ b/include/itkWaveletFrequencyForwardUndecimated.h
@@ -45,7 +45,7 @@ template <typename TInputImage, typename TOutputImage, typename TWaveletFilterBa
 class WaveletFrequencyForwardUndecimated : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(WaveletFrequencyForwardUndecimated);
+  ITK_DISALLOW_COPY_AND_MOVE(WaveletFrequencyForwardUndecimated);
 
   /** Standard typenames type alias. */
   using Self = WaveletFrequencyForwardUndecimated;

--- a/include/itkWaveletFrequencyForwardUndecimated.h
+++ b/include/itkWaveletFrequencyForwardUndecimated.h
@@ -106,7 +106,7 @@ public:
 
   /** Flag to store the wavelet Filter Bank Pyramid, for all levels and all bands.
    * Access to it with GetWaveletFilterBankPyramid()*/
-  itkSetMacro(StoreWaveletFilterBankPyramid, bool) itkGetMacro(StoreWaveletFilterBankPyramid, bool)
+  itkSetMacro(StoreWaveletFilterBankPyramid, bool); itkGetMacro(StoreWaveletFilterBankPyramid, bool);
     itkBooleanMacro(StoreWaveletFilterBankPyramid);
 
   itkGetMacro(WaveletFilterBankPyramid, OutputsType);

--- a/include/itkWaveletFrequencyInverse.h
+++ b/include/itkWaveletFrequencyInverse.h
@@ -92,17 +92,17 @@ public:
 
   /** Shrink/Expand factor at each level.
    * Set to 2 (dyadic), not modifiable, but providing future flexibility */
-  itkGetConstReferenceMacro(ScaleFactor, unsigned int)
+  itkGetConstReferenceMacro(ScaleFactor, unsigned int);
 
     /**
      * If On, applies to each input the appropiate Level-Band multiplicative factor. Needed for perfect reconstruction.
      * It has to be turned off for some applications (phase analysis for example) */
-    itkGetConstReferenceMacro(ApplyReconstructionFactors, bool) itkSetMacro(ApplyReconstructionFactors, bool)
+    itkGetConstReferenceMacro(ApplyReconstructionFactors, bool); itkSetMacro(ApplyReconstructionFactors, bool);
       itkBooleanMacro(ApplyReconstructionFactors);
 
   /** Flag to use external WaveletFilterBankPyramid generated in ForwardWavelet.
    * Requires to use SetWaveletFilterBankPyramid. */
-  itkGetConstReferenceMacro(UseWaveletFilterBankPyramid, bool) itkSetMacro(UseWaveletFilterBankPyramid, bool)
+  itkGetConstReferenceMacro(UseWaveletFilterBankPyramid, bool); itkSetMacro(UseWaveletFilterBankPyramid, bool);
     itkBooleanMacro(UseWaveletFilterBankPyramid);
 
   /**

--- a/include/itkWaveletFrequencyInverse.h
+++ b/include/itkWaveletFrequencyInverse.h
@@ -43,7 +43,7 @@ template <typename TInputImage,
 class WaveletFrequencyInverse : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(WaveletFrequencyInverse);
+  ITK_DISALLOW_COPY_AND_MOVE(WaveletFrequencyInverse);
 
   /** Standard classs type alias. */
   using Self = WaveletFrequencyInverse;

--- a/include/itkWaveletFrequencyInverseUndecimated.h
+++ b/include/itkWaveletFrequencyInverseUndecimated.h
@@ -84,17 +84,17 @@ public:
 
   /** Shrink/Expand factor at each level.
    * Set to 2 (dyadic), not modifiable, but providing future flexibility */
-  itkGetConstReferenceMacro(ScaleFactor, unsigned int)
+  itkGetConstReferenceMacro(ScaleFactor, unsigned int);
 
     /**
      * If On, applies to each input the appropiate Level-Band multiplicative factor. Needed for perfect reconstruction.
      * It has to be turned off for some applications (phase analysis for example) */
-    itkGetConstReferenceMacro(ApplyReconstructionFactors, bool) itkSetMacro(ApplyReconstructionFactors, bool)
+    itkGetConstReferenceMacro(ApplyReconstructionFactors, bool); itkSetMacro(ApplyReconstructionFactors, bool);
       itkBooleanMacro(ApplyReconstructionFactors);
 
   /** Flag to use external WaveletFilterBankPyramid generated in ForwardWavelet.
    * Requires to use SetWaveletFilterBankPyramid. */
-  itkGetConstReferenceMacro(UseWaveletFilterBankPyramid, bool) itkSetMacro(UseWaveletFilterBankPyramid, bool)
+  itkGetConstReferenceMacro(UseWaveletFilterBankPyramid, bool); itkSetMacro(UseWaveletFilterBankPyramid, bool);
     itkBooleanMacro(UseWaveletFilterBankPyramid);
 
   /**

--- a/include/itkWaveletFrequencyInverseUndecimated.h
+++ b/include/itkWaveletFrequencyInverseUndecimated.h
@@ -37,7 +37,7 @@ template <typename TInputImage, typename TOutputImage, typename TWaveletFilterBa
 class WaveletFrequencyInverseUndecimated : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(WaveletFrequencyInverseUndecimated);
+  ITK_DISALLOW_COPY_AND_MOVE(WaveletFrequencyInverseUndecimated);
 
   /** Standard classs type alias. */
   using Self = WaveletFrequencyInverseUndecimated;

--- a/include/itkZeroDCImageFilter.h
+++ b/include/itkZeroDCImageFilter.h
@@ -41,7 +41,7 @@ template <typename TImageType>
 class ZeroDCImageFilter : public ImageToImageFilter<TImageType, TImageType>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ZeroDCImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ZeroDCImageFilter);
 
   /** Standard class type alias. */
   using Self = ZeroDCImageFilter;

--- a/test/itkExpandWithZerosImageFilterTest.cxx
+++ b/test/itkExpandWithZerosImageFilterTest.cxx
@@ -59,10 +59,10 @@ runExpandWithZerosImageFilterTest(unsigned int expandFactor)
   typename ExpanderType::ExpandFactorsType expandFactors;
   expandFactors.Fill(expandFactor);
   expander->SetExpandFactors(expandFactors);
-  TEST_SET_GET_VALUE(expandFactors, expander->GetExpandFactors());
+  ITK_TEST_SET_GET_VALUE(expandFactors, expander->GetExpandFactors());
 
   expander->SetExpandFactors(expandFactor);
-  TEST_SET_GET_VALUE(expandFactors, expander->GetExpandFactors());
+  ITK_TEST_SET_GET_VALUE(expandFactors, expander->GetExpandFactors());
 
   expander->SetInput(input);
   expander->Update();
@@ -165,7 +165,7 @@ itkExpandWithZerosImageFilterTest(int argc, char * argv[])
   // when calling overloaded base class functions.
   using ExpanderType = itk::ExpandWithZerosImageFilter<ImageType, ImageType>;
   auto expander = ExpanderType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(expander, ExpandWithZerosImageFilter, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(expander, ExpandWithZerosImageFilter, ImageToImageFilter);
 
   // Parse input arguments
   unsigned int dimension = std::stoi(argv[1]);

--- a/test/itkFrequencyExpandAndShrinkTest.cxx
+++ b/test/itkFrequencyExpandAndShrinkTest.cxx
@@ -92,12 +92,12 @@ runFrequencyExpandAndShrinkTest(const std::string & inputImage, const std::strin
   typename ExpandViaInverseFFTType::ExpandFactorsType expandFactors;
   expandFactors.Fill(resizeFactor);
   expandViaInverseFFTFilter->SetExpandFactors(resizeFactor);
-  TEST_SET_GET_VALUE(expandFactors, expandViaInverseFFTFilter->GetExpandFactors());
+  ITK_TEST_SET_GET_VALUE(expandFactors, expandViaInverseFFTFilter->GetExpandFactors());
 
   expandViaInverseFFTFilter->SetExpandFactors(expandFactors);
-  TEST_SET_GET_VALUE(expandFactors, expandViaInverseFFTFilter->GetExpandFactors());
+  ITK_TEST_SET_GET_VALUE(expandFactors, expandViaInverseFFTFilter->GetExpandFactors());
 
-  TRY_EXPECT_NO_EXCEPTION(expandViaInverseFFTFilter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(expandViaInverseFFTFilter->Update());
 
   // #ifdef ITK_VISUALIZE_TESTS
   //   auto inverseFFTExpand1 = InverseFFTFilterType::New();
@@ -116,7 +116,7 @@ runFrequencyExpandAndShrinkTest(const std::string & inputImage, const std::strin
   shrinkFilter->SetInput(expandFilter->GetOutput());
   shrinkFilter->SetShrinkFactors(resizeFactor);
 
-  TRY_EXPECT_NO_EXCEPTION(shrinkFilter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(shrinkFilter->Update());
 
   using ShrinkViaInverseFFTType = itk::FrequencyShrinkViaInverseFFTImageFilter<ComplexImageType>;
   auto shrinkViaInverseFFTFilter = ShrinkViaInverseFFTType::New();
@@ -125,12 +125,12 @@ runFrequencyExpandAndShrinkTest(const std::string & inputImage, const std::strin
   typename ShrinkViaInverseFFTType::ShrinkFactorsType shrinkFactors;
   shrinkFactors.Fill(resizeFactor);
   shrinkViaInverseFFTFilter->SetShrinkFactors(resizeFactor);
-  TEST_SET_GET_VALUE(shrinkFactors, shrinkViaInverseFFTFilter->GetShrinkFactors());
+  ITK_TEST_SET_GET_VALUE(shrinkFactors, shrinkViaInverseFFTFilter->GetShrinkFactors());
 
   shrinkViaInverseFFTFilter->SetShrinkFactors(shrinkFactors);
-  TEST_SET_GET_VALUE(shrinkFactors, shrinkViaInverseFFTFilter->GetShrinkFactors());
+  ITK_TEST_SET_GET_VALUE(shrinkFactors, shrinkViaInverseFFTFilter->GetShrinkFactors());
 
-  TRY_EXPECT_NO_EXCEPTION(shrinkViaInverseFFTFilter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(shrinkViaInverseFFTFilter->Update());
 
 
   // Test size and metadata
@@ -215,7 +215,7 @@ runFrequencyExpandAndShrinkTest(const std::string & inputImage, const std::strin
   writer->SetFileName(outputImage);
   writer->SetInput(castFilter->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   if (testPassed)
   {
@@ -250,12 +250,12 @@ itkFrequencyExpandAndShrinkTest(int argc, char * argv[])
   using ExpandViaInverseFFTType = itk::FrequencyExpandViaInverseFFTImageFilter<ComplexImageType>;
   auto expandViaInverseFFTFilter = ExpandViaInverseFFTType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(expandViaInverseFFTFilter, FrequencyExpandViaInverseFFTImageFilter, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(expandViaInverseFFTFilter, FrequencyExpandViaInverseFFTImageFilter, ImageToImageFilter);
 
   using ShrinkViaInverseFFTType = itk::FrequencyShrinkViaInverseFFTImageFilter<ComplexImageType>;
   auto shrinkViaInverseFFTFilter = ShrinkViaInverseFFTType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(shrinkViaInverseFFTFilter, FrequencyShrinkViaInverseFFTImageFilter, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(shrinkViaInverseFFTFilter, FrequencyShrinkViaInverseFFTImageFilter, ImageToImageFilter);
 
   unsigned int dimension = 3;
   if (argc == 4)

--- a/test/itkFrequencyExpandTest.cxx
+++ b/test/itkFrequencyExpandTest.cxx
@@ -78,7 +78,7 @@ runFrequencyExpandTest(const std::string & inputImage, const std::string & outpu
   typename ExpandType::ExpandFactorsType expandFactors;
   expandFactors.Fill(expandFactor);
   expandFilter->SetExpandFactors(expandFactors);
-  TEST_SET_GET_VALUE(expandFactors, expandFilter->GetExpandFactors());
+  ITK_TEST_SET_GET_VALUE(expandFactors, expandFilter->GetExpandFactors());
   expandFilter->Update();
 
   // Test size and metadata
@@ -219,7 +219,7 @@ runFrequencyExpandTest(const std::string & inputImage, const std::string & outpu
 
   writer->SetInput(castFilter->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 #ifdef ITK_VISUALIZE_TESTS
   itk::ViewImage<ImageType>::View(zeroDCFilter->GetOutput(), "Original");
@@ -278,7 +278,7 @@ itkFrequencyExpandTest(int argc, char * argv[])
   using FrequencyExpandImageFilterType = itk::FrequencyExpandImageFilter<ComplexImageType>;
   auto expandFilter = FrequencyExpandImageFilterType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(expandFilter, FrequencyExpandImageFilter, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(expandFilter, FrequencyExpandImageFilter, ImageToImageFilter);
 
   unsigned int dimension = 3;
   if (argc == 4)

--- a/test/itkFrequencyShrinkTest.cxx
+++ b/test/itkFrequencyShrinkTest.cxx
@@ -83,12 +83,12 @@ runFrequencyShrinkTest(const std::string & inputImage, const std::string & outpu
   {
     shrinkFilter->SetShrinkFactor(i, shrinkFactors[i]);
   }
-  TEST_SET_GET_VALUE(shrinkFactors, shrinkFilter->GetShrinkFactors());
+  ITK_TEST_SET_GET_VALUE(shrinkFactors, shrinkFilter->GetShrinkFactors());
 
   shrinkFactor = 2;
   shrinkFactors.Fill(shrinkFactor);
   shrinkFilter->SetShrinkFactors(shrinkFactors);
-  TEST_SET_GET_VALUE(shrinkFactors, shrinkFilter->GetShrinkFactors());
+  ITK_TEST_SET_GET_VALUE(shrinkFactors, shrinkFilter->GetShrinkFactors());
 
   shrinkFilter->SetInput(fftFilter->GetOutput());
 
@@ -252,21 +252,21 @@ runFrequencyShrinkTest(const std::string & inputImage, const std::string & outpu
 
   auto shrinkBandFilter = ShrinkType::New();
   bool applyBandFilter = true;
-  TEST_SET_GET_BOOLEAN(shrinkBandFilter, ApplyBandFilter, applyBandFilter);
+  ITK_TEST_SET_GET_BOOLEAN(shrinkBandFilter, ApplyBandFilter, applyBandFilter);
   shrinkBandFilter->SetInput(changeInputInfoFilter->GetOutput());
   bool lowFreqThresholdPassing = true;
   bool highFreqThresholdPassing = true;
   shrinkBandFilter->GetFrequencyBandFilter()->SetPassBand(lowFreqThresholdPassing, highFreqThresholdPassing);
 
   auto shrinkNoIntersectionFilter = ShrinkType::New();
-  TEST_SET_GET_BOOLEAN(shrinkNoIntersectionFilter, ApplyBandFilter, applyBandFilter);
+  ITK_TEST_SET_GET_BOOLEAN(shrinkNoIntersectionFilter, ApplyBandFilter, applyBandFilter);
   shrinkNoIntersectionFilter->SetInput(changeInputInfoFilter->GetOutput());
   lowFreqThresholdPassing = true;
   highFreqThresholdPassing = false;
   shrinkNoIntersectionFilter->GetFrequencyBandFilter()->SetPassBand(lowFreqThresholdPassing, highFreqThresholdPassing);
 
   auto shrinkIntersectionPassFilter = ShrinkType::New();
-  TEST_SET_GET_BOOLEAN(shrinkIntersectionPassFilter, ApplyBandFilter, applyBandFilter);
+  ITK_TEST_SET_GET_BOOLEAN(shrinkIntersectionPassFilter, ApplyBandFilter, applyBandFilter);
   shrinkIntersectionPassFilter->SetInput(changeInputInfoFilter->GetOutput());
   lowFreqThresholdPassing = true;
   highFreqThresholdPassing = true;
@@ -312,7 +312,7 @@ runFrequencyShrinkTest(const std::string & inputImage, const std::string & outpu
   writer->SetFileName(outputImage);
   writer->SetInput(castFilter->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 #ifdef ITK_VISUALIZE_TESTS
   itk::ViewImage<ImageType>::View(zeroDCFilter->GetOutput(), "Original");
@@ -383,7 +383,7 @@ itkFrequencyShrinkTest(int argc, char * argv[])
   using ShrinkType = itk::FrequencyShrinkImageFilter<ComplexImageType>;
   auto shrinkFilter = ShrinkType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(shrinkFilter, FrequencyShrinkImageFilter, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(shrinkFilter, FrequencyShrinkImageFilter, ImageToImageFilter);
 
   unsigned int dimension = 3;
   if (argc == 4)

--- a/test/itkHeldIsotropicWaveletTest.cxx
+++ b/test/itkHeldIsotropicWaveletTest.cxx
@@ -56,7 +56,7 @@ itkHeldIsotropicWaveletTest(int, char *[])
 
   auto wavelet2Dfloat = Wavelet2DFloat::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(wavelet2Dfloat, HeldIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(wavelet2Dfloat, HeldIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   Point2D point2D;
   point2D[0] = 0.2;
@@ -75,7 +75,7 @@ itkHeldIsotropicWaveletTest(int, char *[])
   for (unsigned int p = 0; p < maxPolynomialOrder + 1; ++p)
   {
     wavelet2Dfloat->SetPolynomialOrder(p);
-    TEST_SET_GET_VALUE(p, wavelet2Dfloat->GetPolynomialOrder());
+    ITK_TEST_SET_GET_VALUE(p, wavelet2Dfloat->GetPolynomialOrder());
     Wavelet2DFloat::FunctionValueType value = wavelet2Dfloat->EvaluateMagnitude(freq2D);
     std::cout << "Order: " << p << "; Evaluate: " << value << std::endl;
   }
@@ -84,9 +84,9 @@ itkHeldIsotropicWaveletTest(int, char *[])
   // Test exception cases
   unsigned int polynomialOrder = 6;
   wavelet2Dfloat->SetPolynomialOrder(polynomialOrder);
-  TEST_SET_GET_VALUE(polynomialOrder, wavelet2Dfloat->GetPolynomialOrder());
+  ITK_TEST_SET_GET_VALUE(polynomialOrder, wavelet2Dfloat->GetPolynomialOrder());
 
-  TRY_EXPECT_EXCEPTION(wavelet2Dfloat->EvaluateMagnitude(freq2D));
+  ITK_TRY_EXPECT_EXCEPTION(wavelet2Dfloat->EvaluateMagnitude(freq2D));
 
 
   if (testPassed)

--- a/test/itkMonogenicSignalFrequencyImageFilterTest.cxx
+++ b/test/itkMonogenicSignalFrequencyImageFilterTest.cxx
@@ -57,7 +57,7 @@ itkMonogenicSignalFrequencyImageFilterTest(int argc, char * argv[])
   using ReaderType = itk::ImageFileReader<ImageType>;
   auto reader = ReaderType::New();
   reader->SetFileName(inputImage);
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
   // Perform FFT on input image.
   using FFTFilterType = itk::ForwardFFTImageFilter<ImageType>;
@@ -69,10 +69,10 @@ itkMonogenicSignalFrequencyImageFilterTest(int argc, char * argv[])
   using MonogenicSignalFilterType = itk::MonogenicSignalFrequencyImageFilter<ComplexImageType>;
   auto monoFilter = MonogenicSignalFilterType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(monoFilter, MonogenicSignalFrequencyImageFilter, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(monoFilter, MonogenicSignalFrequencyImageFilter, ImageToImageFilter);
 
   monoFilter->SetInput(fftFilter->GetOutput());
-  TRY_EXPECT_NO_EXCEPTION(monoFilter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(monoFilter->Update());
 
   unsigned int expectedNumberOfComponentsPerPixel = monoFilter->GetOutput()->GetNumberOfComponentsPerPixel();
   unsigned int computedNumberOfComponentsPerPixel = Dimension + 1;

--- a/test/itkPhaseAnalysisSoftThresholdImageFilterTest.cxx
+++ b/test/itkPhaseAnalysisSoftThresholdImageFilterTest.cxx
@@ -67,7 +67,7 @@ itkPhaseAnalysisSoftThresholdImageFilterTest(int argc, char * argv[])
 
   reader->SetFileName(inputImage);
 
-  TRY_EXPECT_NO_EXCEPTION(reader->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(reader->Update());
 
   // Perform FFT on input image.
   using FFTForwardFilterType = itk::ForwardFFTImageFilter<ImageType>;
@@ -75,7 +75,7 @@ itkPhaseAnalysisSoftThresholdImageFilterTest(int argc, char * argv[])
 
   fftForwardFilter->SetInput(reader->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(fftForwardFilter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(fftForwardFilter->Update());
 
   using ComplexImageType = FFTForwardFilterType::OutputImageType;
 
@@ -85,7 +85,7 @@ itkPhaseAnalysisSoftThresholdImageFilterTest(int argc, char * argv[])
 
   monoFilter->SetInput(fftForwardFilter->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(monoFilter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(monoFilter->Update());
 
   using VectorMonoOutputType = MonogenicSignalFrequencyFilterType::OutputImageType;
 
@@ -94,25 +94,25 @@ itkPhaseAnalysisSoftThresholdImageFilterTest(int argc, char * argv[])
 
   vecInverseFFT->SetInput(monoFilter->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(vecInverseFFT->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(vecInverseFFT->Update());
 
   // Input to the PhaseAnalysisSoftThreshold
   using PhaseAnalysisSoftThresholdFilterType =
     itk::PhaseAnalysisSoftThresholdImageFilter<VectorInverseFFTType::OutputImageType>;
   auto phaseAnalyzer = PhaseAnalysisSoftThresholdFilterType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(phaseAnalyzer, PhaseAnalysisSoftThresholdImageFilter, PhaseAnalysisImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(phaseAnalyzer, PhaseAnalysisSoftThresholdImageFilter, PhaseAnalysisImageFilter);
 
   auto applySoftThreshold = static_cast<bool>(std::stoi(argv[3]));
-  TEST_SET_GET_BOOLEAN(phaseAnalyzer, ApplySoftThreshold, applySoftThreshold);
+  ITK_TEST_SET_GET_BOOLEAN(phaseAnalyzer, ApplySoftThreshold, applySoftThreshold);
 
   auto numOfSigmas = static_cast<PhaseAnalysisSoftThresholdFilterType::OutputImagePixelType>(std::stod(argv[4]));
   phaseAnalyzer->SetNumOfSigmas(numOfSigmas);
-  TEST_SET_GET_VALUE(numOfSigmas, phaseAnalyzer->GetNumOfSigmas());
+  ITK_TEST_SET_GET_VALUE(numOfSigmas, phaseAnalyzer->GetNumOfSigmas());
 
   phaseAnalyzer->SetInput(vecInverseFFT->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(phaseAnalyzer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(phaseAnalyzer->Update());
 
 
   // Regression tests

--- a/test/itkRieszFrequencyFilterBankGeneratorTest.cxx
+++ b/test/itkRieszFrequencyFilterBankGeneratorTest.cxx
@@ -68,19 +68,19 @@ itkRieszFrequencyFilterBankGeneratorTest(int argc, char * argv[])
   using RieszFilterBankType = itk::RieszFrequencyFilterBankGenerator<ComplexImageType>;
   auto filterBank = RieszFilterBankType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(filterBank, RieszFrequencyFilterBankGenerator, GenerateImageSource);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(filterBank, RieszFrequencyFilterBankGenerator, GenerateImageSource);
 
   filterBank->SetSize(fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize());
 
   // Test exception cases
   unsigned int inputOrder = 0;
-  TRY_EXPECT_EXCEPTION(filterBank->SetOrder(inputOrder));
+  ITK_TRY_EXPECT_EXCEPTION(filterBank->SetOrder(inputOrder));
 
   inputOrder = std::stoi(argv[3]);
   filterBank->SetOrder(inputOrder);
-  TEST_SET_GET_VALUE(inputOrder, filterBank->GetOrder());
+  ITK_TEST_SET_GET_VALUE(inputOrder, filterBank->GetOrder());
 
-  TRY_EXPECT_NO_EXCEPTION(filterBank->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(filterBank->Update());
 
   // Get iterator to Indices of RieszFunction.
   using IndicesType = RieszFilterBankType::RieszFunctionType::SetType;

--- a/test/itkRieszWaveletPhaseAnalysisTest.cxx
+++ b/test/itkRieszWaveletPhaseAnalysisTest.cxx
@@ -213,7 +213,7 @@ runRieszWaveletPhaseAnalysisTest(const std::string &  inputImage,
   writer->SetFileName(outputFile);
   writer->SetInput(caster->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
   //
   return EXIT_SUCCESS;
 }
@@ -273,17 +273,17 @@ itkRieszWaveletPhaseAnalysisTest(int argc, char * argv[])
   using ShannonIsotropicWaveletType = itk::ShannonIsotropicWavelet<PixelType, ImageDimension, PointType>;
 
   auto heldIsotropicWavelet = HeldIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(heldIsotropicWavelet, HeldIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(heldIsotropicWavelet, HeldIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto vowIsotropicWavelet = VowIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(vowIsotropicWavelet, VowIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(vowIsotropicWavelet, VowIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto simoncellidIsotropicWavelet = SimoncelliIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     simoncellidIsotropicWavelet, SimoncelliIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto shannonIsotropicWavelet = ShannonIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(shannonIsotropicWavelet, ShannonIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(shannonIsotropicWavelet, ShannonIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   using HeldWavelet = itk::HeldIsotropicWavelet<>;
   using VowWavelet = itk::VowIsotropicWavelet<>;
@@ -298,42 +298,42 @@ itkRieszWaveletPhaseAnalysisTest(int argc, char * argv[])
   using HeldForwardWaveletType =
     itk::WaveletFrequencyForward<ComplexImageType, ComplexImageType, HeldWaveletFilterBankType>;
   auto heldForwardWavelet = HeldForwardWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(heldForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(heldForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
 
   using HeldInverseWaveletType =
     itk::WaveletFrequencyInverse<ComplexImageType, ComplexImageType, HeldWaveletFilterBankType>;
   auto heldInverseWavelet = HeldInverseWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(heldInverseWavelet, WaveletFrequencyInverse, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(heldInverseWavelet, WaveletFrequencyInverse, ImageToImageFilter);
 
   using VowForwardWaveletType =
     itk::WaveletFrequencyForward<ComplexImageType, ComplexImageType, VowWaveletFilterBankType>;
   auto vowForwardWavelet = VowForwardWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(vowForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(vowForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
 
   using VowInverseWaveletType =
     itk::WaveletFrequencyInverse<ComplexImageType, ComplexImageType, VowWaveletFilterBankType>;
   auto vowInverseWavelet = VowInverseWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(vowInverseWavelet, WaveletFrequencyInverse, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(vowInverseWavelet, WaveletFrequencyInverse, ImageToImageFilter);
 
   using SimoncelliForwardWaveletType =
     itk::WaveletFrequencyForward<ComplexImageType, ComplexImageType, SimoncelliWaveletFilterBankType>;
   auto simoncelliForwardWavelet = SimoncelliForwardWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(simoncelliForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(simoncelliForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
 
   using SimoncelliInverseWaveletType =
     itk::WaveletFrequencyInverse<ComplexImageType, ComplexImageType, SimoncelliWaveletFilterBankType>;
   auto simoncelliInverseWavelet = SimoncelliInverseWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(simoncelliInverseWavelet, WaveletFrequencyInverse, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(simoncelliInverseWavelet, WaveletFrequencyInverse, ImageToImageFilter);
 
   using ShannonForwardWaveletType =
     itk::WaveletFrequencyForward<ComplexImageType, ComplexImageType, ShannonWaveletFilterBankType>;
   auto shannonForwardWavelet = ShannonForwardWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(shannonForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(shannonForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
 
   using ShannonInverseWaveletType =
     itk::WaveletFrequencyInverse<ComplexImageType, ComplexImageType, ShannonWaveletFilterBankType>;
   auto shannonInverseWavelet = ShannonInverseWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(shannonInverseWavelet, WaveletFrequencyInverse, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(shannonInverseWavelet, WaveletFrequencyInverse, ImageToImageFilter);
 
   if (dimension == 2)
   {

--- a/test/itkShrinkDecimateImageFilterTest.cxx
+++ b/test/itkShrinkDecimateImageFilterTest.cxx
@@ -71,17 +71,17 @@ runShrinkDecimateImageFilterTest()
     {
       decimator->SetShrinkFactor(i, shrinkFactors[i]);
     }
-    TEST_SET_GET_VALUE(shrinkFactors, decimator->GetShrinkFactors());
+    ITK_TEST_SET_GET_VALUE(shrinkFactors, decimator->GetShrinkFactors());
 
     // Update with 2,2 shrink factor
     shrinkFactor = 2;
     shrinkFactors.Fill(shrinkFactor);
     decimator->SetShrinkFactors(shrinkFactors);
-    TEST_SET_GET_VALUE(shrinkFactors, decimator->GetShrinkFactors());
+    ITK_TEST_SET_GET_VALUE(shrinkFactors, decimator->GetShrinkFactors());
 
     decimator->SetInput(input);
 
-    TRY_EXPECT_NO_EXCEPTION(decimator->Update());
+    ITK_TRY_EXPECT_NO_EXCEPTION(decimator->Update());
 
     // Check values
     itk::ImageRegionConstIteratorWithIndex<ImageType> outIt(decimator->GetOutput(),
@@ -136,7 +136,7 @@ itkShrinkDecimateImageFilterTest(int argc, char * argv[])
   using ShrinkDecimateImageFilterType = itk::ShrinkDecimateImageFilter<ImageType, ImageType>;
   auto decimator = ShrinkDecimateImageFilterType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS(decimator, ShrinkDecimateImageFilter, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(decimator, ShrinkDecimateImageFilter, ImageToImageFilter);
 
   unsigned int dimension = 3;
   if (argc == 2)

--- a/test/itkStructureTensorTest.cxx
+++ b/test/itkStructureTensorTest.cxx
@@ -110,13 +110,13 @@ runStructureTensorTest()
   // WindowRadius
   unsigned int nonDefaultGaussianRadius = 3;
   tensor->SetGaussianWindowRadius(nonDefaultGaussianRadius);
-  TEST_SET_GET_VALUE(nonDefaultGaussianRadius, tensor->GetGaussianWindowRadius());
+  ITK_TEST_SET_GET_VALUE(nonDefaultGaussianRadius, tensor->GetGaussianWindowRadius());
   tensor->SetGaussianWindowRadius(2); // Restore default.
 
   // WindowSigma
   typename StructureTensorType::FloatType nonDefaultGaussianSigma = 2.0;
   tensor->SetGaussianWindowSigma(nonDefaultGaussianSigma);
-  TEST_SET_GET_VALUE(nonDefaultGaussianSigma, tensor->GetGaussianWindowSigma());
+  ITK_TEST_SET_GET_VALUE(nonDefaultGaussianSigma, tensor->GetGaussianWindowSigma());
   tensor->SetGaussianWindowSigma(1.0); // Restore default.
   // Use a external, new GaussianSource:
   // The gaussian source is modified in BeforeThreadedGenerateData() only if

--- a/test/itkVowIsotropicWaveletTest.cxx
+++ b/test/itkVowIsotropicWaveletTest.cxx
@@ -70,7 +70,7 @@ itkVowIsotropicWaveletTest(int, char *[])
   // Specific methods for this type:
   Wavelet2DFloat::FunctionValueType differentKappa = 0.750001;
   wavelet2Dfloat->SetKappa(differentKappa);
-  TEST_SET_GET_VALUE(differentKappa, wavelet2Dfloat->GetKappa());
+  ITK_TEST_SET_GET_VALUE(differentKappa, wavelet2Dfloat->GetKappa());
 
   if (testPassed)
   {

--- a/test/itkWaveletCoeffsPhaseAnalyzisImageFilterTest.cxx
+++ b/test/itkWaveletCoeffsPhaseAnalyzisImageFilterTest.cxx
@@ -60,7 +60,7 @@ runWaveletCoeffsPhaseAnalyzisImageFilterTest(const std::string &  inputImage,
   waveletCoeffsPhaseAnalyzisImageFilter->SetApplySoftThreshold(applySoftThreshold);
   waveletCoeffsPhaseAnalyzisImageFilter->SetThresholdNumOfSigmas(thresholdNumOfSigmas);
 
-  TRY_EXPECT_NO_EXCEPTION(waveletCoeffsPhaseAnalyzisImageFilter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(waveletCoeffsPhaseAnalyzisImageFilter->Update());
 
   // Write output image
   using WriterType = itk::ImageFileWriter<ImageType>;
@@ -74,7 +74,7 @@ runWaveletCoeffsPhaseAnalyzisImageFilterTest(const std::string &  inputImage,
   writer->SetFileName(outputFile);
   writer->UseCompressionOn();
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   return EXIT_SUCCESS;
 }
@@ -139,7 +139,7 @@ itkWaveletCoeffsPhaseAnalyzisImageFilterTest(int argc, char * argv[])
         itk::WaveletCoeffsPhaseAnalyzisImageFilter<ImageType, WaveletType>;
 
       auto waveletCoeffsPhaseAnalyzisImageFilter = WaveletCoeffsPhaseAnalyzisImageFilterType::New();
-      EXERCISE_BASIC_OBJECT_METHODS(
+      ITK_EXERCISE_BASIC_OBJECT_METHODS(
         waveletCoeffsPhaseAnalyzisImageFilter, WaveletCoeffsPhaseAnalyzisImageFilter, ImageToImageFilter);
 
       return runWaveletCoeffsPhaseAnalyzisImageFilterTest<3, WaveletType>(
@@ -157,7 +157,7 @@ itkWaveletCoeffsPhaseAnalyzisImageFilterTest(int argc, char * argv[])
         itk::WaveletCoeffsPhaseAnalyzisImageFilter<ImageType, WaveletType>;
 
       auto waveletCoeffsPhaseAnalyzisImageFilter = WaveletCoeffsPhaseAnalyzisImageFilterType::New();
-      EXERCISE_BASIC_OBJECT_METHODS(
+      ITK_EXERCISE_BASIC_OBJECT_METHODS(
         waveletCoeffsPhaseAnalyzisImageFilter, WaveletCoeffsPhaseAnalyzisImageFilter, ImageToImageFilter);
 
       return runWaveletCoeffsPhaseAnalyzisImageFilterTest<3, WaveletType>(
@@ -175,7 +175,7 @@ itkWaveletCoeffsPhaseAnalyzisImageFilterTest(int argc, char * argv[])
         itk::WaveletCoeffsPhaseAnalyzisImageFilter<ImageType, WaveletType>;
 
       auto waveletCoeffsPhaseAnalyzisImageFilter = WaveletCoeffsPhaseAnalyzisImageFilterType::New();
-      EXERCISE_BASIC_OBJECT_METHODS(
+      ITK_EXERCISE_BASIC_OBJECT_METHODS(
         waveletCoeffsPhaseAnalyzisImageFilter, WaveletCoeffsPhaseAnalyzisImageFilter, ImageToImageFilter);
 
       return runWaveletCoeffsPhaseAnalyzisImageFilterTest<3, WaveletType>(
@@ -193,7 +193,7 @@ itkWaveletCoeffsPhaseAnalyzisImageFilterTest(int argc, char * argv[])
         itk::WaveletCoeffsPhaseAnalyzisImageFilter<ImageType, WaveletType>;
 
       auto waveletCoeffsPhaseAnalyzisImageFilter = WaveletCoeffsPhaseAnalyzisImageFilterType::New();
-      EXERCISE_BASIC_OBJECT_METHODS(
+      ITK_EXERCISE_BASIC_OBJECT_METHODS(
         waveletCoeffsPhaseAnalyzisImageFilter, WaveletCoeffsPhaseAnalyzisImageFilter, ImageToImageFilter);
 
       return runWaveletCoeffsPhaseAnalyzisImageFilterTest<3, WaveletType>(

--- a/test/itkWaveletCoeffsSpatialDomainImageFilterTest.cxx
+++ b/test/itkWaveletCoeffsSpatialDomainImageFilterTest.cxx
@@ -55,7 +55,7 @@ runWaveletCoeffsSpatialDomainImageFilterTest(const std::string &  inputImage,
   waveletCoeffsSpatialDomainImageFilter->SetLevels(inputLevels);
   waveletCoeffsSpatialDomainImageFilter->SetHighPassSubBands(inputBands);
 
-  TRY_EXPECT_NO_EXCEPTION(waveletCoeffsSpatialDomainImageFilter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(waveletCoeffsSpatialDomainImageFilter->Update());
 
   itk::NumberToString<unsigned int> n2s;
   using WriterType = itk::ImageFileWriter<ImageType>;
@@ -75,7 +75,7 @@ runWaveletCoeffsSpatialDomainImageFilterTest(const std::string &  inputImage,
 
     try
     {
-      TRY_EXPECT_NO_EXCEPTION(writer->Update());
+      ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
     }
     catch (itk::ExceptionObject & e)
     {
@@ -126,7 +126,7 @@ itkWaveletCoeffsSpatialDomainImageFilterTest(int argc, char * argv[])
         itk::WaveletCoeffsSpatialDomainImageFilter<ImageType, WaveletType>;
 
       auto waveletCoeffsSpatialDomainImageFilter = WaveletCoeffsSpatialDomainImageFilterType::New();
-      EXERCISE_BASIC_OBJECT_METHODS(
+      ITK_EXERCISE_BASIC_OBJECT_METHODS(
         waveletCoeffsSpatialDomainImageFilter, WaveletCoeffsSpatialDomainImageFilter, ImageToImageFilter);
 
       return runWaveletCoeffsSpatialDomainImageFilterTest<3, WaveletType>(
@@ -144,7 +144,7 @@ itkWaveletCoeffsSpatialDomainImageFilterTest(int argc, char * argv[])
         itk::WaveletCoeffsSpatialDomainImageFilter<ImageType, WaveletType>;
 
       auto waveletCoeffsSpatialDomainImageFilter = WaveletCoeffsSpatialDomainImageFilterType::New();
-      EXERCISE_BASIC_OBJECT_METHODS(
+      ITK_EXERCISE_BASIC_OBJECT_METHODS(
         waveletCoeffsSpatialDomainImageFilter, WaveletCoeffsSpatialDomainImageFilter, ImageToImageFilter);
 
       return runWaveletCoeffsSpatialDomainImageFilterTest<3, WaveletType>(
@@ -162,7 +162,7 @@ itkWaveletCoeffsSpatialDomainImageFilterTest(int argc, char * argv[])
         itk::WaveletCoeffsSpatialDomainImageFilter<ImageType, WaveletType>;
 
       auto waveletCoeffsSpatialDomainImageFilter = WaveletCoeffsSpatialDomainImageFilterType::New();
-      EXERCISE_BASIC_OBJECT_METHODS(
+      ITK_EXERCISE_BASIC_OBJECT_METHODS(
         waveletCoeffsSpatialDomainImageFilter, WaveletCoeffsSpatialDomainImageFilter, ImageToImageFilter);
 
       return runWaveletCoeffsSpatialDomainImageFilterTest<3, WaveletType>(
@@ -180,7 +180,7 @@ itkWaveletCoeffsSpatialDomainImageFilterTest(int argc, char * argv[])
         itk::WaveletCoeffsSpatialDomainImageFilter<ImageType, WaveletType>;
 
       auto waveletCoeffsSpatialDomainImageFilter = WaveletCoeffsSpatialDomainImageFilterType::New();
-      EXERCISE_BASIC_OBJECT_METHODS(
+      ITK_EXERCISE_BASIC_OBJECT_METHODS(
         waveletCoeffsSpatialDomainImageFilter, WaveletCoeffsSpatialDomainImageFilter, ImageToImageFilter);
 
       return runWaveletCoeffsSpatialDomainImageFilterTest<3, WaveletType>(

--- a/test/itkWaveletFrequencyFilterBankGeneratorDownsampleTest.cxx
+++ b/test/itkWaveletFrequencyFilterBankGeneratorDownsampleTest.cxx
@@ -147,17 +147,17 @@ itkWaveletFrequencyFilterBankGeneratorDownsampleTest(int argc, char * argv[])
   using ShannonIsotropicWaveletType = itk::ShannonIsotropicWavelet<PixelType, ImageDimension, PointType>;
 
   auto heldIsotropicWavelet = HeldIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(heldIsotropicWavelet, HeldIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(heldIsotropicWavelet, HeldIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto vowIsotropicWavelet = VowIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(vowIsotropicWavelet, VowIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(vowIsotropicWavelet, VowIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto simoncellidIsotropicWavelet = SimoncelliIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     simoncellidIsotropicWavelet, SimoncelliIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto shannonIsotropicWavelet = ShannonIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(shannonIsotropicWavelet, ShannonIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(shannonIsotropicWavelet, ShannonIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   using HeldWavelet = itk::HeldIsotropicWavelet<>;
   using VowWavelet = itk::VowIsotropicWavelet<>;
@@ -170,19 +170,19 @@ itkWaveletFrequencyFilterBankGeneratorDownsampleTest(int argc, char * argv[])
   using ShannonWaveletFilterBankType = itk::WaveletFrequencyFilterBankGenerator<ComplexImageType, ShannonWavelet>;
 
   auto heldWaveletFilterBankGenerator = HeldWaveletFilterBankType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     heldWaveletFilterBankGenerator, WaveletFrequencyFilterBankGenerator, GenerateImageSource);
 
   auto vowWaveletFilterBankGenerator = VowWaveletFilterBankType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     vowWaveletFilterBankGenerator, WaveletFrequencyFilterBankGenerator, GenerateImageSource);
 
   auto simoncelliWaveletFilterBankGenerator = SimoncelliWaveletFilterBankType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     simoncelliWaveletFilterBankGenerator, WaveletFrequencyFilterBankGenerator, GenerateImageSource);
 
   auto shannonWaveletFilterBankGenerator = ShannonWaveletFilterBankType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     shannonWaveletFilterBankGenerator, WaveletFrequencyFilterBankGenerator, GenerateImageSource);
 
   if (dimension == 2)

--- a/test/itkWaveletFrequencyFilterBankGeneratorTest.cxx
+++ b/test/itkWaveletFrequencyFilterBankGeneratorTest.cxx
@@ -73,8 +73,8 @@ runWaveletFrequencyFilterBankGeneratorTest(const std::string &  inputImage,
   forwardFilterBank->SetSize(fftFilter->GetOutput()->GetLargestPossibleRegion().GetSize());
 
   // Test Get/Set
-  TEST_SET_GET_VALUE(highSubBands, forwardFilterBank->GetHighPassSubBands());
-  TEST_SET_GET_BOOLEAN(forwardFilterBank, InverseBank, false);
+  ITK_TEST_SET_GET_VALUE(highSubBands, forwardFilterBank->GetHighPassSubBands());
+  ITK_TEST_SET_GET_BOOLEAN(forwardFilterBank, InverseBank, false);
   auto waveletInstance = forwardFilterBank->GetModifiableWaveletFunction();
   waveletInstance->Print(std::cout);
 
@@ -106,7 +106,7 @@ runWaveletFrequencyFilterBankGeneratorTest(const std::string &  inputImage,
   writer->SetFileName(outputImage);
   writer->SetInput(complexToRealFilter->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
   // Inverse FFT Transform
   using InverseFFTFilterType = itk::InverseFFTImageFilter<ComplexImageType, ImageType>;
@@ -206,17 +206,17 @@ itkWaveletFrequencyFilterBankGeneratorTest(int argc, char * argv[])
   using ShannonIsotropicWaveletType = itk::ShannonIsotropicWavelet<PixelType, ImageDimension, PointType>;
 
   auto heldIsotropicWavelet = HeldIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(heldIsotropicWavelet, HeldIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(heldIsotropicWavelet, HeldIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto vowIsotropicWavelet = VowIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(vowIsotropicWavelet, VowIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(vowIsotropicWavelet, VowIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto simoncellidIsotropicWavelet = SimoncelliIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     simoncellidIsotropicWavelet, SimoncelliIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto shannonIsotropicWavelet = ShannonIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(shannonIsotropicWavelet, ShannonIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(shannonIsotropicWavelet, ShannonIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   using HeldWavelet = itk::HeldIsotropicWavelet<>;
   using VowWavelet = itk::VowIsotropicWavelet<>;
@@ -229,19 +229,19 @@ itkWaveletFrequencyFilterBankGeneratorTest(int argc, char * argv[])
   using ShannonWaveletFilterBankType = itk::WaveletFrequencyFilterBankGenerator<ComplexImageType, ShannonWavelet>;
 
   auto heldWaveletFilterBankGenerator = HeldWaveletFilterBankType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     heldWaveletFilterBankGenerator, WaveletFrequencyFilterBankGenerator, GenerateImageSource);
 
   auto vowWaveletFilterBankGenerator = VowWaveletFilterBankType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     vowWaveletFilterBankGenerator, WaveletFrequencyFilterBankGenerator, GenerateImageSource);
 
   auto simoncelliWaveletFilterBankGenerator = SimoncelliWaveletFilterBankType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     simoncelliWaveletFilterBankGenerator, WaveletFrequencyFilterBankGenerator, GenerateImageSource);
 
   auto shannonWaveletFilterBankGenerator = ShannonWaveletFilterBankType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     shannonWaveletFilterBankGenerator, WaveletFrequencyFilterBankGenerator, GenerateImageSource);
 
   if (dimension == 2)

--- a/test/itkWaveletFrequencyForwardTest.cxx
+++ b/test/itkWaveletFrequencyForwardTest.cxx
@@ -217,7 +217,7 @@ runWaveletFrequencyForwardTest(const std::string &  inputImage,
 
       writer->SetFileName(AppendToFilename(outputImage, n2s(nOutput)));
       writer->SetInput(inverseFFT->GetOutput());
-      TRY_EXPECT_NO_EXCEPTION(writer->Update());
+      ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
     }
   }
 
@@ -267,17 +267,17 @@ itkWaveletFrequencyForwardTest(int argc, char * argv[])
   using ShannonIsotropicWaveletType = itk::ShannonIsotropicWavelet<PixelType, ImageDimension, PointType>;
 
   auto heldIsotropicWavelet = HeldIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(heldIsotropicWavelet, HeldIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(heldIsotropicWavelet, HeldIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto vowIsotropicWavelet = VowIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(vowIsotropicWavelet, VowIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(vowIsotropicWavelet, VowIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto simoncellidIsotropicWavelet = SimoncelliIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     simoncellidIsotropicWavelet, SimoncelliIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto shannonIsotropicWavelet = ShannonIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(shannonIsotropicWavelet, ShannonIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(shannonIsotropicWavelet, ShannonIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   using HeldWavelet = itk::HeldIsotropicWavelet<>;
   using VowWavelet = itk::VowIsotropicWavelet<>;
@@ -292,22 +292,22 @@ itkWaveletFrequencyForwardTest(int argc, char * argv[])
   using HeldForwardWaveletType =
     itk::WaveletFrequencyForward<ComplexImageType, ComplexImageType, HeldWaveletFilterBankType>;
   auto heldForwardWavelet = HeldForwardWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(heldForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(heldForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
 
   using VowForwardWaveletType =
     itk::WaveletFrequencyForward<ComplexImageType, ComplexImageType, VowWaveletFilterBankType>;
   auto vowForwardWavelet = VowForwardWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(vowForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(vowForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
 
   using SimoncelliForwardWaveletType =
     itk::WaveletFrequencyForward<ComplexImageType, ComplexImageType, SimoncelliWaveletFilterBankType>;
   auto simoncelliForwardWavelet = SimoncelliForwardWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(simoncelliForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(simoncelliForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
 
   using ShannonForwardWaveletType =
     itk::WaveletFrequencyForward<ComplexImageType, ComplexImageType, ShannonWaveletFilterBankType>;
   auto shannonForwardWavelet = ShannonForwardWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(shannonForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(shannonForwardWavelet, WaveletFrequencyForward, ImageToImageFilter);
 
   if (dimension == 2)
   {

--- a/test/itkWaveletFrequencyForwardUndecimatedTest.cxx
+++ b/test/itkWaveletFrequencyForwardUndecimatedTest.cxx
@@ -208,7 +208,7 @@ runWaveletFrequencyForwardUndecimatedTest(const std::string &  inputImage,
 
     writer->SetFileName(AppendToFilenameUndecimated(outputImage, n2s(nOutput)));
     writer->SetInput(inverseFFT->GetOutput());
-    TRY_EXPECT_NO_EXCEPTION(writer->Update());
+    ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
   }
 
   if (testPassed)
@@ -257,17 +257,17 @@ itkWaveletFrequencyForwardUndecimatedTest(int argc, char * argv[])
   using ShannonIsotropicWaveletType = itk::ShannonIsotropicWavelet<PixelType, ImageDimension, PointType>;
 
   auto heldIsotropicWavelet = HeldIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(heldIsotropicWavelet, HeldIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(heldIsotropicWavelet, HeldIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto vowIsotropicWavelet = VowIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(vowIsotropicWavelet, VowIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(vowIsotropicWavelet, VowIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto simoncellidIsotropicWavelet = SimoncelliIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(
     simoncellidIsotropicWavelet, SimoncelliIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   auto shannonIsotropicWavelet = ShannonIsotropicWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(shannonIsotropicWavelet, ShannonIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(shannonIsotropicWavelet, ShannonIsotropicWavelet, IsotropicWaveletFrequencyFunction);
 
   using HeldWavelet = itk::HeldIsotropicWavelet<>;
   using VowWavelet = itk::VowIsotropicWavelet<>;
@@ -282,22 +282,22 @@ itkWaveletFrequencyForwardUndecimatedTest(int argc, char * argv[])
   using HeldForwardWaveletType =
     itk::WaveletFrequencyForwardUndecimated<ComplexImageType, ComplexImageType, HeldWaveletFilterBankType>;
   auto heldForwardWavelet = HeldForwardWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(heldForwardWavelet, WaveletFrequencyForwardUndecimated, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(heldForwardWavelet, WaveletFrequencyForwardUndecimated, ImageToImageFilter);
 
   using VowForwardWaveletType =
     itk::WaveletFrequencyForwardUndecimated<ComplexImageType, ComplexImageType, VowWaveletFilterBankType>;
   auto vowForwardWavelet = VowForwardWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(vowForwardWavelet, WaveletFrequencyForwardUndecimated, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(vowForwardWavelet, WaveletFrequencyForwardUndecimated, ImageToImageFilter);
 
   using SimoncelliForwardWaveletType =
     itk::WaveletFrequencyForwardUndecimated<ComplexImageType, ComplexImageType, SimoncelliWaveletFilterBankType>;
   auto simoncelliForwardWavelet = SimoncelliForwardWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(simoncelliForwardWavelet, WaveletFrequencyForwardUndecimated, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(simoncelliForwardWavelet, WaveletFrequencyForwardUndecimated, ImageToImageFilter);
 
   using ShannonForwardWaveletType =
     itk::WaveletFrequencyForwardUndecimated<ComplexImageType, ComplexImageType, ShannonWaveletFilterBankType>;
   auto shannonForwardWavelet = ShannonForwardWaveletType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(shannonForwardWavelet, WaveletFrequencyForwardUndecimated, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(shannonForwardWavelet, WaveletFrequencyForwardUndecimated, ImageToImageFilter);
 
   if (dimension == 2)
   {

--- a/test/itkWaveletFrequencyInverseTest.cxx
+++ b/test/itkWaveletFrequencyInverseTest.cxx
@@ -149,7 +149,7 @@ runWaveletFrequencyInverseTest(const std::string &  inputImage,
   writer->SetFileName(outputImage);
   writer->SetInput(changeInfo->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 #ifdef ITK_VISUALIZE_TESTS
   itk::ViewImage<ImageType>::View(reader->GetOutput(), "Original");

--- a/test/itkWaveletFrequencyInverseUndecimatedTest.cxx
+++ b/test/itkWaveletFrequencyInverseUndecimatedTest.cxx
@@ -141,7 +141,7 @@ runWaveletFrequencyInverseUndecimatedTest(const std::string &  inputImage,
   writer->SetFileName(outputImage);
   writer->SetInput(inverseFFT->GetOutput());
 
-  TRY_EXPECT_NO_EXCEPTION(writer->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(writer->Update());
 
 #ifdef ITK_VISUALIZE_TESTS
   itk::ViewImage<ImageType>::View(reader->GetOutput(), "Original");

--- a/test/itkWaveletUtilitiesTest.cxx
+++ b/test/itkWaveletUtilitiesTest.cxx
@@ -188,7 +188,7 @@ itkWaveletUtilitiesTest(int, char *[])
     unsigned int linearIndex = 4;
     unsigned int levels = 1;
     unsigned int bands = 1;
-    TRY_EXPECT_EXCEPTION(itk::utils::IndexToLevelBandSteerablePyramid(linearIndex, levels, bands));
+    ITK_TRY_EXPECT_EXCEPTION(itk::utils::IndexToLevelBandSteerablePyramid(linearIndex, levels, bands));
   }
   {
     unsigned int linearIndex = 0;
@@ -239,7 +239,7 @@ itkWaveletUtilitiesTest(int, char *[])
     unsigned int linearIndex = 5;
     unsigned int levels = 2;
     unsigned int bands = 2;
-    TRY_EXPECT_EXCEPTION(itk::utils::IndexToLevelBandSteerablePyramid(linearIndex, levels, bands));
+    ITK_TRY_EXPECT_EXCEPTION(itk::utils::IndexToLevelBandSteerablePyramid(linearIndex, levels, bands));
   }
 
   if (!testOutputIndexToLevelBandPassed)

--- a/test/itkZeroDCImageFilterTest.cxx
+++ b/test/itkZeroDCImageFilterTest.cxx
@@ -44,13 +44,13 @@ runZeroDCImageFilterTest(const std::string & inputImage)
   using ZeroDCFilterType = itk::ZeroDCImageFilter<ImageType>;
   auto zeroDCFilter = ZeroDCFilterType::New();
   zeroDCFilter->SetInput(reader->GetOutput());
-  TRY_EXPECT_NO_EXCEPTION(zeroDCFilter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(zeroDCFilter->Update());
 
   // Perform FFT on zeroDC image and check freq bin 0 has zero value.
   using FFTForwardFilterType = itk::ForwardFFTImageFilter<ImageType>;
   auto fftForwardFilter = FFTForwardFilterType::New();
   fftForwardFilter->SetInput(zeroDCFilter->GetOutput());
-  TRY_EXPECT_NO_EXCEPTION(fftForwardFilter->Update());
+  ITK_TRY_EXPECT_NO_EXCEPTION(fftForwardFilter->Update());
 
   using ComplexImageType = typename FFTForwardFilterType::OutputImageType;
   typename ComplexImageType::IndexType zeroIndex;
@@ -106,7 +106,7 @@ itkZeroDCImageFilterTest(int argc, char * argv[])
   using ZeroDCFilterType = itk::ZeroDCImageFilter<ImageType>;
 
   auto zeroDCFilter = ZeroDCFilterType::New();
-  EXERCISE_BASIC_OBJECT_METHODS(zeroDCFilter, ZeroDCImageFilter, ImageToImageFilter);
+  ITK_EXERCISE_BASIC_OBJECT_METHODS(zeroDCFilter, ZeroDCImageFilter, ImageToImageFilter);
 
   if (dimension == 2)
   {


### PR DESCRIPTION
 This PR fixes changes made in #2053. Essentially, ITK_DISALLOW_COPY_AND_ASSIGN has been changed to ITK_DISALLOW_COPY_AND_MOVE to more accurately convey the actions taking place. ITK_DISALLOW_COPY_AND_ASSIGN will only be used if ITK_FUTURE_LEGACY_REMOVE=OFF.

In addition, this will add `;` to the end of several macros.

Lastly, several testing macros had their naming definitions changed to have an `ITK_` in front of the definition.