### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkExpandWithZerosImageFilter.hxx
+++ b/include/itkExpandWithZerosImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkExpandWithZerosImageFilter_hxx
 #define itkExpandWithZerosImageFilter_hxx
 
-#include "itkExpandWithZerosImageFilter.h"
 #include "itkImageScanlineIterator.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkObjectFactory.h"

--- a/include/itkFrequencyExpandImageFilter.hxx
+++ b/include/itkFrequencyExpandImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkFrequencyExpandImageFilter_hxx
 #define itkFrequencyExpandImageFilter_hxx
 
-#include <itkFrequencyExpandImageFilter.h>
 #include <itkProgressReporter.h>
 #include "itkInd2Sub.h"
 #include <itkPasteImageFilter.h>

--- a/include/itkFrequencyExpandViaInverseFFTImageFilter.hxx
+++ b/include/itkFrequencyExpandViaInverseFFTImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkFrequencyExpandViaInverseFFTImageFilter_hxx
 #define itkFrequencyExpandViaInverseFFTImageFilter_hxx
 
-#include "itkFrequencyExpandViaInverseFFTImageFilter.h"
 
 namespace itk
 {

--- a/include/itkFrequencyShrinkImageFilter.hxx
+++ b/include/itkFrequencyShrinkImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkFrequencyShrinkImageFilter_hxx
 #define itkFrequencyShrinkImageFilter_hxx
 
-#include <itkFrequencyShrinkImageFilter.h>
 #include <itkProgressReporter.h>
 #include <numeric>
 #include <functional>

--- a/include/itkFrequencyShrinkViaInverseFFTImageFilter.hxx
+++ b/include/itkFrequencyShrinkViaInverseFFTImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkFrequencyShrinkViaInverseFFTImageFilter_hxx
 #define itkFrequencyShrinkViaInverseFFTImageFilter_hxx
 
-#include <itkFrequencyShrinkViaInverseFFTImageFilter.h>
 
 namespace itk
 {

--- a/include/itkHeldIsotropicWavelet.hxx
+++ b/include/itkHeldIsotropicWavelet.hxx
@@ -20,7 +20,6 @@
 
 #include <cmath>
 #include <itkMath.h>
-#include <itkHeldIsotropicWavelet.h>
 
 namespace itk
 {

--- a/include/itkIsotropicWaveletFrequencyFunction.hxx
+++ b/include/itkIsotropicWaveletFrequencyFunction.hxx
@@ -18,7 +18,6 @@
 #ifndef itkIsotropicWaveletFrequencyFunction_hxx
 #define itkIsotropicWaveletFrequencyFunction_hxx
 
-#include "itkIsotropicWaveletFrequencyFunction.h"
 #include <cmath>
 #include <itkMath.h>
 

--- a/include/itkMonogenicSignalFrequencyImageFilter.hxx
+++ b/include/itkMonogenicSignalFrequencyImageFilter.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkMonogenicSignalFrequencyImageFilter_hxx
 #define itkMonogenicSignalFrequencyImageFilter_hxx
-#include "itkMonogenicSignalFrequencyImageFilter.h"
 #include "itkImageRegionIterator.h"
 namespace itk
 {

--- a/include/itkPhaseAnalysisImageFilter.hxx
+++ b/include/itkPhaseAnalysisImageFilter.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkPhaseAnalysisImageFilter_hxx
 #define itkPhaseAnalysisImageFilter_hxx
-#include "itkPhaseAnalysisImageFilter.h"
 
 namespace itk
 {

--- a/include/itkPhaseAnalysisSoftThresholdImageFilter.hxx
+++ b/include/itkPhaseAnalysisSoftThresholdImageFilter.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkPhaseAnalysisSoftThresholdImageFilter_hxx
 #define itkPhaseAnalysisSoftThresholdImageFilter_hxx
-#include "itkPhaseAnalysisSoftThresholdImageFilter.h"
 #include "itkImageScanlineConstIterator.h"
 #include "itkImageScanlineIterator.h"
 

--- a/include/itkRieszFrequencyFilterBankGenerator.hxx
+++ b/include/itkRieszFrequencyFilterBankGenerator.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkRieszFrequencyFilterBankGenerator_hxx
 #define itkRieszFrequencyFilterBankGenerator_hxx
-#include "itkRieszFrequencyFilterBankGenerator.h"
 #include "itkNumericTraits.h"
 
 namespace itk

--- a/include/itkRieszFrequencyFunction.hxx
+++ b/include/itkRieszFrequencyFunction.hxx
@@ -20,8 +20,6 @@
 
 #include <cmath>
 #include <itkMath.h>
-#include "itkRieszFrequencyFunction.h"
-#include "itkRieszFrequencyFunction.h"
 #include <algorithm>
 
 namespace itk

--- a/include/itkRieszRotationMatrix.hxx
+++ b/include/itkRieszRotationMatrix.hxx
@@ -18,7 +18,6 @@
 #ifndef itkRieszRotationMatrix_hxx
 #define itkRieszRotationMatrix_hxx
 
-#include "itkRieszRotationMatrix.h"
 #include "itkNumericTraits.h"
 #include "itkMultiplyImageFilter.h"
 #include "itkAddImageFilter.h"

--- a/include/itkShannonIsotropicWavelet.hxx
+++ b/include/itkShannonIsotropicWavelet.hxx
@@ -20,7 +20,6 @@
 
 #include <cmath>
 #include <itkMath.h>
-#include <itkShannonIsotropicWavelet.h>
 
 namespace itk
 {

--- a/include/itkShrinkDecimateImageFilter.hxx
+++ b/include/itkShrinkDecimateImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkShrinkDecimateImageFilter_hxx
 #define itkShrinkDecimateImageFilter_hxx
 
-#include "itkShrinkDecimateImageFilter.h"
 #include "itkImageScanlineIterator.h"
 #include <numeric>
 #include <functional>

--- a/include/itkSimoncelliIsotropicWavelet.hxx
+++ b/include/itkSimoncelliIsotropicWavelet.hxx
@@ -20,7 +20,6 @@
 
 #include <cmath>
 #include <itkMath.h>
-#include <itkSimoncelliIsotropicWavelet.h>
 
 namespace itk
 {

--- a/include/itkStructureTensorImageFilter.hxx
+++ b/include/itkStructureTensorImageFilter.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkStructureTensorImageFilter_hxx
 #define itkStructureTensorImageFilter_hxx
-#include "itkStructureTensorImageFilter.h"
 #include "itkImageScanlineConstIterator.h"
 #include "itkImageScanlineIterator.h"
 #include <itkMultiplyImageFilter.h>

--- a/include/itkVectorInverseFFTImageFilter.hxx
+++ b/include/itkVectorInverseFFTImageFilter.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkVectorInverseFFTImageFilter_hxx
 #define itkVectorInverseFFTImageFilter_hxx
-#include "itkVectorInverseFFTImageFilter.h"
 #include <itkVectorIndexSelectionCastImageFilter.h>
 #include <itkComposeImageFilter.h>
 #include <itkProgressAccumulator.h>

--- a/include/itkVowIsotropicWavelet.hxx
+++ b/include/itkVowIsotropicWavelet.hxx
@@ -20,7 +20,6 @@
 
 #include <cmath>
 #include <itkMath.h>
-#include <itkVowIsotropicWavelet.h>
 
 namespace itk
 {

--- a/include/itkWaveletCoeffsPhaseAnalyzisImageFilter.hxx
+++ b/include/itkWaveletCoeffsPhaseAnalyzisImageFilter.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkWaveletCoeffsPhaseAnalyzisImageFilter_hxx
 #define itkWaveletCoeffsPhaseAnalyzisImageFilter_hxx
-#include "itkWaveletCoeffsPhaseAnalyzisImageFilter.h"
 #include "itkForwardFFTImageFilter.h"
 #include "itkInverseFFTImageFilter.h"
 #include "itkFFTPadImageFilter.h"

--- a/include/itkWaveletCoeffsSpatialDomainImageFilter.hxx
+++ b/include/itkWaveletCoeffsSpatialDomainImageFilter.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkWaveletCoeffsSpatialDomainImageFilter_hxx
 #define itkWaveletCoeffsSpatialDomainImageFilter_hxx
-#include "itkWaveletCoeffsSpatialDomainImageFilter.h"
 #include "itkForwardFFTImageFilter.h"
 #include "itkInverseFFTImageFilter.h"
 #include "itkFFTPadImageFilter.h"

--- a/include/itkWaveletFrequencyFilterBankGenerator.hxx
+++ b/include/itkWaveletFrequencyFilterBankGenerator.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkWaveletFrequencyFilterBankGenerator_hxx
 #define itkWaveletFrequencyFilterBankGenerator_hxx
-#include "itkWaveletFrequencyFilterBankGenerator.h"
 #include "itkNumericTraits.h"
 
 namespace itk

--- a/include/itkWaveletFrequencyForward.hxx
+++ b/include/itkWaveletFrequencyForward.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkWaveletFrequencyForward_hxx
 #define itkWaveletFrequencyForward_hxx
-#include <itkWaveletFrequencyForward.h>
 #include <itkCastImageFilter.h>
 #include <itkImage.h>
 #include <algorithm>

--- a/include/itkWaveletFrequencyForwardUndecimated.hxx
+++ b/include/itkWaveletFrequencyForwardUndecimated.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkWaveletFrequencyForwardUndecimated_hxx
 #define itkWaveletFrequencyForwardUndecimated_hxx
-#include <itkWaveletFrequencyForwardUndecimated.h>
 #include <itkCastImageFilter.h>
 #include <itkImage.h>
 #include <algorithm>

--- a/include/itkWaveletFrequencyInverse.hxx
+++ b/include/itkWaveletFrequencyInverse.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkWaveletFrequencyInverse_hxx
 #define itkWaveletFrequencyInverse_hxx
-#include <itkWaveletFrequencyInverse.h>
 #include <itkCastImageFilter.h>
 #include <itkImage.h>
 #include <algorithm>

--- a/include/itkWaveletFrequencyInverseUndecimated.hxx
+++ b/include/itkWaveletFrequencyInverseUndecimated.hxx
@@ -17,7 +17,6 @@
  *=========================================================================*/
 #ifndef itkWaveletFrequencyInverseUndecimated_hxx
 #define itkWaveletFrequencyInverseUndecimated_hxx
-#include <itkWaveletFrequencyInverseUndecimated.h>
 #include <itkCastImageFilter.h>
 #include <itkImage.h>
 #include <algorithm>

--- a/include/itkZeroDCImageFilter.hxx
+++ b/include/itkZeroDCImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkZeroDCImageFilter_hxx
 #define itkZeroDCImageFilter_hxx
 
-#include "itkZeroDCImageFilter.h"
 #include <itkSubtractImageFilter.h>
 #include <itkStatisticsImageFilter.h>
 #include "itkProgressAccumulator.h"


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

