### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/itkExpandWithZerosImageFilter.h
+++ b/include/itkExpandWithZerosImageFilter.h
@@ -75,7 +75,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ExpandWithZerosImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ExpandWithZerosImageFilter);
 
   /** Typedef to describe the output image region type. */
   using OutputImageRegionType = typename TOutputImage::RegionType;

--- a/include/itkFrequencyExpandImageFilter.h
+++ b/include/itkFrequencyExpandImageFilter.h
@@ -114,7 +114,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FrequencyExpandImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(FrequencyExpandImageFilter);
 
   /** Typedef to describe the output image region type. */
   using ImageRegionType = typename TImageType::RegionType;

--- a/include/itkFrequencyExpandViaInverseFFTImageFilter.h
+++ b/include/itkFrequencyExpandViaInverseFFTImageFilter.h
@@ -62,7 +62,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FrequencyExpandViaInverseFFTImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(FrequencyExpandViaInverseFFTImageFilter);
 
   /** ImageDimension enumeration. */
   static constexpr unsigned int ImageDimension = TImageType::ImageDimension;

--- a/include/itkFrequencyFunction.h
+++ b/include/itkFrequencyFunction.h
@@ -44,7 +44,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FrequencyFunction, SpatialFunction);
+  itkOverrideGetNameOfClassMacro(FrequencyFunction);
 
   /** Input type for the function. */
   using InputType = typename Superclass::InputType;

--- a/include/itkFrequencyShrinkImageFilter.h
+++ b/include/itkFrequencyShrinkImageFilter.h
@@ -88,7 +88,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FrequencyShrinkImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(FrequencyShrinkImageFilter);
 
   /** Typedef to images */
   using ImageType = TImageType;

--- a/include/itkFrequencyShrinkViaInverseFFTImageFilter.h
+++ b/include/itkFrequencyShrinkViaInverseFFTImageFilter.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FrequencyShrinkViaInverseFFTImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(FrequencyShrinkViaInverseFFTImageFilter);
 
   /** Typedef to images */
   using ImageType = TImageType;

--- a/include/itkHeldIsotropicWavelet.h
+++ b/include/itkHeldIsotropicWavelet.h
@@ -57,7 +57,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(HeldIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  itkOverrideGetNameOfClassMacro(HeldIsotropicWavelet);
 
   /** Input type for the function. */
   using InputType = typename Superclass::InputType;

--- a/include/itkIsotropicFrequencyFunction.h
+++ b/include/itkIsotropicFrequencyFunction.h
@@ -48,7 +48,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(IsotropicFrequencyFunction, FrequencyFunction);
+  itkOverrideGetNameOfClassMacro(IsotropicFrequencyFunction);
 
   /** Input type for the function. */
   using InputType = typename Superclass::InputType;

--- a/include/itkIsotropicWaveletFrequencyFunction.h
+++ b/include/itkIsotropicWaveletFrequencyFunction.h
@@ -66,7 +66,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(IsotropicWaveletFrequencyFunction, IsotropicFrequencyFunction);
+  itkOverrideGetNameOfClassMacro(IsotropicWaveletFrequencyFunction);
 
   /** Input type for the function. */
   using InputType = typename Superclass::InputType;

--- a/include/itkMonogenicSignalFrequencyImageFilter.h
+++ b/include/itkMonogenicSignalFrequencyImageFilter.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(MonogenicSignalFrequencyImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(MonogenicSignalFrequencyImageFilter);
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /// This ensure that InputPixelType is complex<float||double>

--- a/include/itkPhaseAnalysisImageFilter.h
+++ b/include/itkPhaseAnalysisImageFilter.h
@@ -80,7 +80,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(PhaseAnalysisImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(PhaseAnalysisImageFilter);
 
   /** Some convenient type alias. */
   using InputImageType = typename Superclass::InputImageType;

--- a/include/itkPhaseAnalysisSoftThresholdImageFilter.h
+++ b/include/itkPhaseAnalysisSoftThresholdImageFilter.h
@@ -58,7 +58,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(PhaseAnalysisSoftThresholdImageFilter, PhaseAnalysisImageFilter);
+  itkOverrideGetNameOfClassMacro(PhaseAnalysisSoftThresholdImageFilter);
 
   /** Some convenient type alias. */
   using InputImageType = typename Superclass::InputImageType;

--- a/include/itkRieszFrequencyFilterBankGenerator.h
+++ b/include/itkRieszFrequencyFilterBankGenerator.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Creation through object factory macro */
-  itkTypeMacro(RieszFrequencyFilterBankGenerator, GenerateImageSourceFilter);
+  itkOverrideGetNameOfClassMacro(RieszFrequencyFilterBankGenerator);
 
   /** Inherit types from Superclass. */
   using OutputImageType = typename Superclass::OutputImageType;

--- a/include/itkRieszFrequencyFunction.h
+++ b/include/itkRieszFrequencyFunction.h
@@ -51,7 +51,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(RieszFrequencyFunction, FrequencyFunction);
+  itkOverrideGetNameOfClassMacro(RieszFrequencyFunction);
 
   /** Input type for the function. */
   using InputType = typename Superclass::InputType;

--- a/include/itkShannonIsotropicWavelet.h
+++ b/include/itkShannonIsotropicWavelet.h
@@ -59,7 +59,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ShannonIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  itkOverrideGetNameOfClassMacro(ShannonIsotropicWavelet);
 
   /** Input type for the function. */
   using InputType = typename Superclass::InputType;

--- a/include/itkShrinkDecimateImageFilter.h
+++ b/include/itkShrinkDecimateImageFilter.h
@@ -55,7 +55,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ShrinkDecimateImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ShrinkDecimateImageFilter);
 
   /** Typedef to images */
   using OutputImageType = TOutputImage;

--- a/include/itkSimoncelliIsotropicWavelet.h
+++ b/include/itkSimoncelliIsotropicWavelet.h
@@ -64,7 +64,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SimoncelliIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  itkOverrideGetNameOfClassMacro(SimoncelliIsotropicWavelet);
 
   /** Input type for the function. */
   using InputType = typename Superclass::InputType;

--- a/include/itkStructureTensorImageFilter.h
+++ b/include/itkStructureTensorImageFilter.h
@@ -99,7 +99,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(StructureTensorImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(StructureTensorImageFilter);
 
   /** Some convenient type alias. */
   using InputImageType = typename Superclass::InputImageType;

--- a/include/itkVectorInverseFFTImageFilter.h
+++ b/include/itkVectorInverseFFTImageFilter.h
@@ -62,7 +62,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VectorInverseFFTImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(VectorInverseFFTImageFilter);
 
   /** ImageDimension enumeration. */
   static constexpr unsigned int ImageDimension = InputImageType::ImageDimension;

--- a/include/itkVowIsotropicWavelet.h
+++ b/include/itkVowIsotropicWavelet.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VowIsotropicWavelet, IsotropicWaveletFrequencyFunction);
+  itkOverrideGetNameOfClassMacro(VowIsotropicWavelet);
 
   /** Input type for the function. */
   using InputType = typename Superclass::InputType;

--- a/include/itkWaveletCoeffsPhaseAnalyzisImageFilter.h
+++ b/include/itkWaveletCoeffsPhaseAnalyzisImageFilter.h
@@ -77,7 +77,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(WaveletCoeffsPhaseAnalyzisImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(WaveletCoeffsPhaseAnalyzisImageFilter);
 
   /** Flag to store the number of levels, highpasssubbands, output index, applysoftthreshold,
   thresholdnumofsigmas.**/

--- a/include/itkWaveletCoeffsSpatialDomainImageFilter.h
+++ b/include/itkWaveletCoeffsSpatialDomainImageFilter.h
@@ -70,7 +70,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(WaveletCoeffsSpatialDomainImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(WaveletCoeffsSpatialDomainImageFilter);
 
   using ImageType = TImageType;
   using IntType = unsigned int;

--- a/include/itkWaveletFrequencyFilterBankGenerator.h
+++ b/include/itkWaveletFrequencyFilterBankGenerator.h
@@ -65,7 +65,7 @@ public:
   itkNewMacro(Self);
 
   /** Creation through object factory macro */
-  itkTypeMacro(WaveletFrequencyFilterBankGenerator, GenerateImageSourceFilter);
+  itkOverrideGetNameOfClassMacro(WaveletFrequencyFilterBankGenerator);
 
   /** Inherit types from Superclass. */
   using OutputImageType = typename Superclass::OutputImageType;

--- a/include/itkWaveletFrequencyForward.h
+++ b/include/itkWaveletFrequencyForward.h
@@ -87,7 +87,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(WaveletFrequencyForward, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(WaveletFrequencyForward);
   virtual void
   SetLevels(unsigned int n);
 

--- a/include/itkWaveletFrequencyForwardUndecimated.h
+++ b/include/itkWaveletFrequencyForwardUndecimated.h
@@ -79,7 +79,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(WaveletFrequencyForwardUndecimated, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(WaveletFrequencyForwardUndecimated);
   virtual void
   SetLevels(unsigned int n);
 

--- a/include/itkWaveletFrequencyInverse.h
+++ b/include/itkWaveletFrequencyInverse.h
@@ -75,7 +75,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(WaveletFrequencyInverse, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(WaveletFrequencyInverse);
 
   /** Number of levels/scales. Maximum depends on size of image */
   void

--- a/include/itkWaveletFrequencyInverseUndecimated.h
+++ b/include/itkWaveletFrequencyInverseUndecimated.h
@@ -67,7 +67,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(WaveletFrequencyInverseUndecimated, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(WaveletFrequencyInverseUndecimated);
 
   /** Number of levels/scales. Maximum depends on size of image */
   void

--- a/include/itkZeroDCImageFilter.h
+++ b/include/itkZeroDCImageFilter.h
@@ -53,7 +53,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ZeroDCImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ZeroDCImageFilter);
 
   /** Typedef to describe the output image region type. */
   using ImageRegionType = typename TImageType::RegionType;


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
