### PR TITLE
COMP: Update RemoteModulePackageAction and Python 3.10+

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -16,5 +16,6 @@ jobs:
 
   python-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
+    with:
     secrets:
       pypi_password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -12,9 +12,9 @@ on:
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.3
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.3
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
     secrets:
       pypi_password: ${{ secrets.pypi_password }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "itk-isotropicwavelets"
-version = "0.7.1"
+version = "0.7.2"
 description = "Steerable Wavelet Pyramid with Isotropic Wavelets and Riesz Functions"
 readme = "README.rst"
 license = {file = "LICENSE"}
@@ -38,7 +38,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "itk == 5.4.*",
 ]
@@ -51,7 +51,7 @@ Homepage = "https://github.com/InsightSoftwareConsortium/ITKIsotropicWavelets"
 # The versions of CMake to allow. If CMake is not present on the system or does
 # not pass this specifier, it will be downloaded via PyPI if possible. An empty
 # string will disable this check.
-cmake.version = ">=3.16.3"
+cmake.version = ">=3.22.1"
 
 # A list of args to pass to CMake when configuring the project. Setting this in
 # config or envvar will override toml. See also ``cmake.define``.

--- a/wrapping/itkStructureTensorImageFilter.wrap
+++ b/wrapping/itkStructureTensorImageFilter.wrap
@@ -2,19 +2,15 @@ itk_wrap_include("itkVariableSizeMatrix.h")
 
 itk_wrap_class("itk::Image" POINTER)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
-    foreach(t ${WRAP_ITK_REAL})
-      itk_wrap_template("VSM${ITKM_I${t}}${d}"
-        "itk::VariableSizeMatrix< ${ITKT_D} >, ${d}")
-    endforeach()
+    itk_wrap_template("VSM${d}"
+      "itk::VariableSizeMatrix< ${ITKT_D} >, ${d}")
   endforeach()
 itk_end_wrap_class()
 
 itk_wrap_class("itk::ImageSource" POINTER)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
-    foreach(t ${WRAP_ITK_REAL})
-      itk_wrap_template("VSM${ITKM_I${ITKM_${t}}}${d}"
-        "itk::Image<itk::VariableSizeMatrix< ${ITKT_D} >, ${d} >")
-    endforeach()
+    itk_wrap_template("IVSM${d}"
+      "itk::Image<itk::VariableSizeMatrix< ${ITKT_D} >, ${d} >")
   endforeach()
 itk_end_wrap_class()
 
@@ -29,7 +25,7 @@ itk_end_wrap_class()
 itk_wrap_class("itk::ImageToImageFilter" POINTER)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     foreach(t ${WRAP_ITK_REAL})
-      itk_wrap_template("${ITKM_I${t}${d}}VSM${ITKM_I${ITKM_${t}}}${d}"
+      itk_wrap_template("${ITKM_I${t}${d}}IVSM${d}"
         "${ITKT_I${t}${d}}, itk::Image<itk::VariableSizeMatrix< ${ITKT_D} >, ${d} >")
     endforeach()
   endforeach()
@@ -38,9 +34,8 @@ itk_end_wrap_class()
 itk_wrap_class("itk::StructureTensorImageFilter" POINTER)
   foreach(d ${ITK_WRAP_IMAGE_DIMS})
     foreach(t ${WRAP_ITK_REAL})
-      itk_wrap_template("${ITKM_I${t}${d}}VSM${ITKM_I${ITKM_${t}}}${d}"
+      itk_wrap_template("${ITKM_I${t}${d}}IVSM${d}"
         "${ITKT_I${t}${d}}, itk::Image<itk::VariableSizeMatrix< ${ITKT_D} >, ${d} >")
     endforeach()
   endforeach()
 itk_end_wrap_class()
-


### PR DESCRIPTION
- Update github actions to v5.4.5 and package management for python 3.10
- Fix duplicate SWIG template instantiation in StructureTensor wrapping that caused Python wheel builds to fail